### PR TITLE
Question answering using embeddings

### DIFF
--- a/examples/Question_answering_using_embeddings.ipynb
+++ b/examples/Question_answering_using_embeddings.ipynb
@@ -1,0 +1,775 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 167,
+   "id": "9e3839a6-9146-4f60-b74b-19abbc24278d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import openai\n",
+    "import numpy as np\n",
+    "from tqdm.notebook import tqdm\n",
+    "import pickle\n",
+    "from transformers import GPT2TokenizerFast\n",
+    "\n",
+    "ENGINE_NAME = \"curie\"\n",
+    "\n",
+    "DOC_EMBEDDING_MODEL = f\"text-search-{ENGINE_NAME}-doc-001\"\n",
+    "QUERY_EMBEDDING_MODEL = f\"text-search-{MODEL_NAME}-query-001\"\n",
+    "\n",
+    "COMPLETIONS_MODEL = \"text-davinci-002\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9312f62f-e208-4030-a648-71ad97aee74f",
+   "metadata": {},
+   "source": [
+    "# Question Answering\n",
+    "\n",
+    "Many use cases require GPT to respond to user questions with insightful answers. For example, a customer support chatbot may need to provide answers to common questions. The GPT models have picked up a lot of general knowledge in training, but we often need to ingest and use a body of more specific information.\n",
+    "\n",
+    "In this notebook we will demonstrate a method for augmenting GPT with a large body of additional contextual information by using embeddings search and retrieval. We'll be using a dataset of Wikipedia articles about the 2020 Summer Olympic Games. Please see [this notebook](examples/fine-tuned_qa/olympics-1-collect-data.ipynb) to follow the data gathering process.\n",
+    "\n",
+    "GPT-3 isn't an expert on the Olympics by default:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 176,
+   "id": "a167516c-7c19-4bda-afa5-031aa0ae13bb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"The 2020 Summer Olympics men's high jump was won by Mariusz Przybylski of Poland.\""
+      ]
+     },
+     "execution_count": 176,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prompt = \"Who won the 2020 Summer Olympics men's high jump?\"\n",
+    "\n",
+    "openai.Completion.create(\n",
+    "    prompt=prompt,\n",
+    "    temperature=0,\n",
+    "    max_tokens=300,\n",
+    "    top_p=1,\n",
+    "    frequency_penalty=0,\n",
+    "    presence_penalty=0,\n",
+    "    engine=COMPLETIONS_MODEL\n",
+    ")[\"choices\"][0][\"text\"].strip(\"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47204cce-a7d5-4c81-ab6e-53323026e08c",
+   "metadata": {},
+   "source": [
+    "Mariusz Przybylski is a professional footballer from Poland, and not much of a high jumper! Evidently GPT-3 needs some assistance here. (In fact we'd ideally like the model to be more conservative and say \"I don't know\" rather than making a guess - see [this guide](examples/fine-tuned_qa) for an exploration of that topic.)\n",
+    "\n",
+    "When the total required context is short, we can include it in the prompt directly. In this case, we can use this information taken from Wikipedia:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 179,
+   "id": "fceaf665-2602-4788-bc44-9eb256a6f955",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Gianmarco Tamberi and Mutaz Essa Barshim won the 2020 Summer Olympics men's high jump.\""
+      ]
+     },
+     "execution_count": 179,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prompt = \"\"\"\n",
+    "The men's high jump event at the 2020 Summer Olympics took place between 30 July and 1 August 2021 at the Olympic Stadium.\n",
+    "33 athletes from 24 nations competed; the total possible number depended on how many nations would use universality places \n",
+    "to enter athletes in addition to the 32 qualifying through mark or ranking (no universality places were used in 2021).\n",
+    "Italian athlete Gianmarco Tamberi along with Qatari athlete Mutaz Essa Barshim emerged as joint winners of the event following\n",
+    "a tie between both of them as they cleared 2.37m. Both Tamberi and Barshim agreed to share the gold medal in a rare instance\n",
+    "where the athletes of different nations had agreed to share the same medal in the history of Olympics. \n",
+    "Barshim in particular was heard to ask a competition official \"Can we have two golds?\" in response to being offered a \n",
+    "'jump off'. Maksim Nedasekau of Belarus took bronze. The medals were the first ever in the men's high jump for Italy and \n",
+    "Belarus, the first gold in the men's high jump for Italy and Qatar, and the third consecutive medal in the men's high jump\n",
+    "for Qatar (all by Barshim). Barshim became only the second man to earn three medals in high jump, joining Patrik Sjöberg\n",
+    "of Sweden (1984 to 1992).\n",
+    "\n",
+    "Who won the 2020 Summer Olympics men's high jump?\"\"\"\n",
+    "\n",
+    "openai.Completion.create(\n",
+    "    prompt=prompt,\n",
+    "    temperature=0,\n",
+    "    max_tokens=300,\n",
+    "    top_p=1,\n",
+    "    frequency_penalty=0,\n",
+    "    presence_penalty=0,\n",
+    "    engine=COMPLETIONS_MODEL\n",
+    ")[\"choices\"][0][\"text\"].strip(\"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee85ee77-d8d2-4788-b57e-0785f2d7e2e3",
+   "metadata": {},
+   "source": [
+    "But this technique only works when the dataset of extra content that the model may need to know is small enough to fit in a single prompt. What do we do when we need the model to choose relevant contextual information from within a large body of information?\n",
+    "\n",
+    "**In this notebook we demonstrate a method for augmenting GPT with a large body of additional contextual information by using embeddings search and retrieval.** This method answers queries in two steps: first it retrieves the information relevant to the query, then it writes an answer tailored to the question based on the retrieved information. The first step uses the Embedding API, the second step uses the Completion API.\n",
+    " \n",
+    "The steps are:\n",
+    "* Preprocess the contextual information by splitting it into chunks and create an embedding vector for each chunk.\n",
+    "* On receiving a query, embed the query in the same vector space as the context chunks and find the context embeddings which are most similar to the query.\n",
+    "* Prepend the most relevant context embeddings to the query prompt.\n",
+    "* Submit the question along with the most relevant context to GPT, and receive an answer which makes use of the provided contextual information."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c9bfea5-a028-4191-b9f1-f210d76ec4e3",
+   "metadata": {},
+   "source": [
+    "# 1) Preprocess the contextual information\n",
+    "\n",
+    "We preprocess the contextual information by creating an embedding vector for each chunk of context in the knowledge base. An embedding is a vector of numbers that helps us understand how similar or different things are. The closer two embeddings are to each other, the more similar the things are that they represent.\n",
+    "\n",
+    "This indexing stage can be executed offline and only runs once to precompute the indexes for the dataset so that each piece of content can be retrieved later. Since this is a small example, we will store and search the embeddings locally. If you have a larger dataset, consider using a vector search engine like Pinecone or Weaviate to power the search.\n",
+    "\n",
+    "For the purposes of this tutorial we chose to use Curie embeddings, which are at a very good price and performance point. Since we will be using these embeddings for retrieval, we’ll use the search embeddings. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "cc9c8d69-e234-48b4-87e3-935970e1523a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3980 rows in the data.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>content</th>\n",
+       "      <th>tokens</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>title</th>\n",
+       "      <th>heading</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>United States at the 2020 Summer Olympics</th>\n",
+       "      <th>Diving</th>\n",
+       "      <td>U.S. divers qualified for the following indivi...</td>\n",
+       "      <td>89</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Austria at the 2020 Summer Olympics</th>\n",
+       "      <th>Summary</th>\n",
+       "      <td>Austria competed at the 2020 Summer Olympics i...</td>\n",
+       "      <td>115</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2020 Women's Rugby Sevens Final Olympic Qualification Tournament</th>\n",
+       "      <th>Knockout stage</th>\n",
+       "      <td>With two Olympic places available, the top eig...</td>\n",
+       "      <td>49</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Italy at the 2020 Summer Olympics</th>\n",
+       "      <th>Karate</th>\n",
+       "      <td>Italy entered five karateka into the inaugural...</td>\n",
+       "      <td>148</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2020 United States Olympic Team Trials (wrestling)</th>\n",
+       "      <th>Summary</th>\n",
+       "      <td>The 2020 United States Olympic Team Trials for...</td>\n",
+       "      <td>119</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                                                             content  \\\n",
+       "title                                              heading                                                             \n",
+       "United States at the 2020 Summer Olympics          Diving          U.S. divers qualified for the following indivi...   \n",
+       "Austria at the 2020 Summer Olympics                Summary         Austria competed at the 2020 Summer Olympics i...   \n",
+       "2020 Women's Rugby Sevens Final Olympic Qualifi... Knockout stage  With two Olympic places available, the top eig...   \n",
+       "Italy at the 2020 Summer Olympics                  Karate          Italy entered five karateka into the inaugural...   \n",
+       "2020 United States Olympic Team Trials (wrestling) Summary         The 2020 United States Olympic Team Trials for...   \n",
+       "\n",
+       "                                                                   tokens  \n",
+       "title                                              heading                 \n",
+       "United States at the 2020 Summer Olympics          Diving              89  \n",
+       "Austria at the 2020 Summer Olympics                Summary            115  \n",
+       "2020 Women's Rugby Sevens Final Olympic Qualifi... Knockout stage      49  \n",
+       "Italy at the 2020 Summer Olympics                  Karate             148  \n",
+       "2020 United States Olympic Team Trials (wrestling) Summary            119  "
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Load the dataset, obtained from this notebook <LINK>.\n",
+    "# This dataset has already been split into sections, one row for each section of the Wikipedia page.\n",
+    "\n",
+    "df = pd.read_csv('olympics_sections.csv')\n",
+    "df = df.set_index([\"title\", \"heading\"])\n",
+    "print(f\"{len(df)} rows in the data.\")\n",
+    "df.sample(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 215,
+   "id": "ba475f30-ef7f-431c-b60d-d5970b62ad09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_embedding(text: str, engine: str) -> np.array:\n",
+    "    result = openai.Engine(engine).embeddings(input=text)\n",
+    "    return np.array(result[\"data\"][0][\"embedding\"])\n",
+    "\n",
+    "def get_doc_embedding(text: str) -> np.array:\n",
+    "    return get_embedding(text, DOC_EMBEDDING_MODEL)\n",
+    "\n",
+    "def get_query_embedding(text: str) -> np.array:\n",
+    "    return get_embedding(text, QUERY_EMBEDDING_MODEL)\n",
+    "\n",
+    "def compute_doc_embeddings(df: pd.DataFrame) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Create an embedding for each document in the dataframe using the OpenAI Embeddings API.\n",
+    "    \n",
+    "    Return a dictionary that maps between each embedding vector and the index of the row that it corresponds to.\n",
+    "    \"\"\"\n",
+    "    return {\n",
+    "        idx: get_doc_embedding(r.content) for idx, r in tqdm(df.iterrows(), total=len(df))\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "ab50bfca-cb02-41c6-b338-4400abe1d86e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5d2192513f1349febdaef6ccb9ab1046",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/3980 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1min 46s, sys: 7.92 s, total: 1min 54s\n",
+      "Wall time: 11min 16s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "context_embeddings = compute_doc_embeddings(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 249,
+   "id": "a298f666-f31f-4356-a882-e2170524a637",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "147.552"
+      ]
+     },
+     "execution_count": 249,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "sys.getsizeof(context_embeddings) / 1000"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa32cf88-9edb-4dc6-b4cf-a16a8de7d304",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# 2) Find the most similar context embeddings to the question embedding\n",
+    "\n",
+    "At the time of question-answering, to answer the user's query we compute the embedding of the question and use it to find the most similar context chunks.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 210,
+   "id": "dcd680e9-f194-4180-b14f-fc357498eb92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def vector_similarity(x: np.array, y: np.array) -> float:\n",
+    "    return np.dot(x, y)\n",
+    "\n",
+    "def order_contexts_by_query_similarity(query: str, contexts: dict[(str, str), np.array]) -> list[(float, (str, str))]:\n",
+    "    \"\"\"\n",
+    "    Find the query embedding for the supplied query, and compare it against all of the pre-calculated context embeddings\n",
+    "    to find the most relevant contexts. \n",
+    "    \n",
+    "    Return the list of contexts, sorted by relevance in descending order.\n",
+    "    \"\"\"\n",
+    "    query_embedding = get_query_embedding(query)\n",
+    "    \n",
+    "    context_similarities = sorted([\n",
+    "        (vector_similarity(query_embedding, doc_embedding), doc_index) for doc_index, doc_embedding in contexts.items()\n",
+    "    ], reverse=True)\n",
+    "    \n",
+    "    return context_similarities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 211,
+   "id": "e3a27d73-f47f-480d-b336-079414f749cb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(0.4296262686167575,\n",
+       "  (\"Athletics at the 2020 Summer Olympics – Men's high jump\", 'Summary')),\n",
+       " (0.4067051275316437,\n",
+       "  (\"Athletics at the 2020 Summer Olympics – Women's high jump\", 'Summary')),\n",
+       " (0.4046927788902179,\n",
+       "  (\"Athletics at the 2020 Summer Olympics – Men's high jump\", 'Background')),\n",
+       " (0.40424431005550354,\n",
+       "  (\"Athletics at the 2020 Summer Olympics – Men's triple jump\", 'Summary')),\n",
+       " (0.4021923762547752,\n",
+       "  (\"Athletics at the 2020 Summer Olympics – Women's long jump\", 'Summary'))]"
+      ]
+     },
+     "execution_count": 211,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "order_contexts_by_query_similarity(\"Who won the men's high jump?\", context_embeddings)[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3cf71fae-abb1-46b2-a483-c1b2f1a915c2",
+   "metadata": {},
+   "source": [
+    "We can see that summaries information about the men's and women's high jump competitions are judged to be the most relevant contexts for this question, which is in line with what we would expect."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0efa0f6-4469-457a-89a4-a2f5736a01e0",
+   "metadata": {},
+   "source": [
+    "# 3) Add the most relevant contexts to the query prompt\n",
+    "\n",
+    "Once we've calculated the most relevant pieces of context, we construct a prompt by simply prepending them to the supplied query. It is helpful to use a query separator to help the model distinguish between separate pieces of text."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 214,
+   "id": "b763ace2-1946-48e0-8ff1-91ba335d47a0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Context separator contains 3 tokens'"
+      ]
+     },
+     "execution_count": 214,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "MAX_CONTEXT_LEN = 500\n",
+    "CONTEXT_SEPARATOR = \"\\n* \"\n",
+    "\n",
+    "tokenizer = GPT2TokenizerFast.from_pretrained(\"gpt2\")\n",
+    "context_separator_len = len(tokenizer.tokenize(CONTEXT_SEPARATOR))\n",
+    "\n",
+    "f\"Context separator contains {context_separator_len} tokens\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 160,
+   "id": "0c5c0509-eeb9-4552-a5d4-6ace04ef73dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def construct_prompt(question: str, contexts: dict, df: pd.DataFrame) -> str:\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    \"\"\"\n",
+    "    most_relevant_contexts = order_contexts_by_query_similarity(question, doc_embeddings)\n",
+    "    \n",
+    "    chosen_contexts = []\n",
+    "    chosen_contexts_indexes = []\n",
+    "    chosen_contexts_len = 0\n",
+    "     \n",
+    "    for _, context_index in most_relevant_contexts:\n",
+    "        # Add contexts until we run out of space.\n",
+    "        # In this version, we will not add the final context that overflows our limit; \n",
+    "        # you may wish to \"partially add\" that final context.\n",
+    "        \n",
+    "        context = df.loc[context_index]\n",
+    "        \n",
+    "        chosen_contexts_len += context.tokens + context_separator_len\n",
+    "        if chosen_contexts_len > MAX_CONTEXT_LEN:\n",
+    "            break\n",
+    "            \n",
+    "        chosen_contexts.append(CONTEXT_SEPARATOR + context.content)\n",
+    "        chosen_contexts_indexes.append(str(context_index))\n",
+    "        \n",
+    "    print(f\"Selected {len(chosen_contexts)} contexts:\")\n",
+    "    print(\"\\n\".join(chosen_contexts_indexes))\n",
+    "        \n",
+    "    return \"\".join(chosen_contexts) + \"\\n\\n\" + question + \"\\n\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 161,
+   "id": "f614045a-3917-4b28-9643-7e0c299ec1a7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Selected 3 contexts:\n",
+      "(\"Athletics at the 2020 Summer Olympics – Women's high jump\", 'Summary')\n",
+      "(\"Athletics at the 2020 Summer Olympics – Men's high jump\", 'Summary')\n",
+      "(\"Athletics at the 2020 Summer Olympics – Men's triple jump\", 'Summary')\n",
+      "===\n",
+      " \n",
+      "* The women's high jump event at the 2020 Summer Olympics took place on 5 and 7 August 2021 at the Japan National Stadium. Even though 32 athletes qualified through the qualification system for the Games, only 31 took part in the competition. This was the 22nd appearance of the event, having appeared at every Olympics since women's athletics was introduced in 1928.\n",
+      "* The men's high jump event at the 2020 Summer Olympics took place between 30 July and 1 August 2021 at the Olympic Stadium. 33 athletes from 24 nations competed; the total possible number depended on how many nations would use universality places to enter athletes in addition to the 32 qualifying through mark or ranking (no universality places were used in 2021). Italian athlete Gianmarco Tamberi along with Qatari athlete Mutaz Essa Barshim emerged as joint winners of the event following a tie between both of them as they cleared 2.37m. Both Tamberi and Barshim agreed to share the gold medal in a rare instance where the athletes of different nations had agreed to share the same medal in the history of Olympics. Barshim in particular was heard to ask a competition official \"Can we have two golds?\" in response to being offered a 'jump off'. Maksim Nedasekau of Belarus took bronze. The medals were the first ever in the men's high jump for Italy and Belarus, the first gold in the men's high jump for Italy and Qatar, and the third consecutive medal in the men's high jump for Qatar (all by Barshim). Barshim became only the second man to earn three medals in high jump, joining Patrik Sjöberg of Sweden (1984 to 1992).\n",
+      "* The men's triple jump event at the 2020 Summer Olympics took place between 3 and 5 August 2021 at the Japan National Stadium. Approximately 35 athletes were expected to compete; the exact number was dependent on how many nations use universality places to enter athletes in addition to the 32 qualifying through time or ranking (2 universality places were used in 2016). 32 athletes from 19 nations competed. Pedro Pichardo of Portugal won the gold medal, the nation's second victory in the men's triple jump (after Nelson Évora in 2008). China's Zhu Yaming took silver, while Hugues Fabrice Zango earned Burkina Faso's first Olympic medal in any event.\n",
+      "\n",
+      "Who won the 2020 Summer Olympics men's high jump?\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = construct_prompt(\n",
+    "    \"Who won the 2020 Summer Olympics men's high jump?\",\n",
+    "    doc_embeddings,\n",
+    "    df\n",
+    ")\n",
+    "\n",
+    "print(\"===\\n\", prompt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b022fd4-0a3c-4ae1-bed1-4c80e4f0fb56",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# 4) Submit the extended query to the Completions API.\n",
+    "\n",
+    "Now that we've retrieved the relevant context, we can finally use the Completions API to answer the user's query."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 233,
+   "id": "b0edfec7-9243-4573-92e0-253d31c771ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "COMPLETIONS_API_PARAMS = {\n",
+    "    \"temperature\": 0.0,\n",
+    "    \"max_tokens\": 300,\n",
+    "    \"top_p\": 1,\n",
+    "    \"frequency_penalty\": 0,\n",
+    "    \"presence_penalty\": 0,\n",
+    "    \"engine\": COMPLETIONS_MODEL,\n",
+    "    \"stop\": \"\\n\\n\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 234,
+   "id": "9c1c9a69-848e-4099-a90d-c8da36c153d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def answer_query_with_context(\n",
+    "    query: str,\n",
+    "    df: pd.DataFrame,\n",
+    "    context_embeddings: dict[(str, str), np.array]\n",
+    ") -> str:\n",
+    "    prompt = construct_prompt(\n",
+    "        query,\n",
+    "        context_embeddings,\n",
+    "        df\n",
+    "    )\n",
+    "\n",
+    "    response = openai.Completion.create(\n",
+    "                prompt=prompt,\n",
+    "                **COMPLETIONS_API_PARAMS\n",
+    "            )\n",
+    "\n",
+    "    return response[\"choices\"][0][\"text\"].strip(\"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 235,
+   "id": "c233e449-bf33-4c9e-b095-6a4dd278c8fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Selected 3 contexts:\n",
+      "(\"Athletics at the 2020 Summer Olympics – Women's high jump\", 'Summary')\n",
+      "(\"Athletics at the 2020 Summer Olympics – Men's high jump\", 'Summary')\n",
+      "(\"Athletics at the 2020 Summer Olympics – Men's triple jump\", 'Summary')\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\"Gianmarco Tamberi and Mutaz Essa Barshim both cleared 2.37m to win the gold medal in the men's high jump event at the 2020 Summer Olympics.\""
+      ]
+     },
+     "execution_count": 235,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "answer_query_with_context(\"Who won the 2020 Summer Olympics men's high jump?\", df, context_embeddings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b48d155-d2d4-447c-ab8e-5a5b4722b07c",
+   "metadata": {},
+   "source": [
+    "# More Examples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 242,
+   "id": "1127867b-2884-44bb-9439-0e8ae171c835",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Selected 1 contexts:\n",
+      "('2020 Summer Olympics', 'Postponement to 2021')\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'The 2020 Summer Olympics were originally postponed due to the COVID-19 pandemic. The outbreak of the pandemic began in China in December 2019, and spread to Japan in January 2020. The outbreak was declared a Public Health Emergency of International Concern by the World Health Organization on 30 January 2020. On 25 February 2020, the IOC announced that it would hold a meeting on the following day to discuss the outbreak and its potential impact on the Games.'"
+      ]
+     },
+     "execution_count": 242,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = \"Why was the 2020 Summer Olympics originally postponed?\"\n",
+    "answer_query_with_context(query, df, context_embeddings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 236,
+   "id": "720d9e0b-b189-4101-91ee-babf736199e6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Selected 1 contexts:\n",
+      "('2020 Summer Olympics medal table', 'Summary')\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'The United States won the most medals overall, with 113, and the most gold medals, with 39.'"
+      ]
+     },
+     "execution_count": 236,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = \"In the 2020 Summer Olympics, how many gold medals did the country which won the most medals win?\"\n",
+    "answer_query_with_context(query, df, context_embeddings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 238,
+   "id": "4e8e51cc-e4eb-4557-9e09-2929d4df5b7f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Selected 3 contexts:\n",
+      "(\"Athletics at the 2020 Summer Olympics – Men's shot put\", 'Summary')\n",
+      "(\"Athletics at the 2020 Summer Olympics – Men's shot put\", 'Background')\n",
+      "(\"Athletics at the 2020 Summer Olympics – Men's hammer throw\", 'Competition format')\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'The men’s shotput competition at the 2020 Summer Olympics was unusual because the same three competitors received the same medals in back-to-back editions of the same individual event. Americans Ryan Crouser and Joe Kovacs and New Zealander Tom Walsh repeated their gold, silver, and bronze (respectively) performances from the 2016 Summer Olympics. They became the 15th, 16th, and 17th men to earn multiple medals in the shot put; Crouser was the 4th to repeat as champion.'"
+      ]
+     },
+     "execution_count": 238,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = \"What was unusual about the men’s shotput competition?\"\n",
+    "answer_query_with_context(query, df, context_embeddings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 239,
+   "id": "37c83519-e3c6-4c44-8b4a-98cbb3a5f5ba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Selected 1 contexts:\n",
+      "('Italy at the 2020 Summer Olympics', 'Summary')\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'10'"
+      ]
+     },
+     "execution_count": 239,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = \"In the 2020 Summer Olympics, how many silver medals did Italy win?\"\n",
+    "answer_query_with_context(query, df, context_embeddings)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/Question_answering_using_embeddings.ipynb
+++ b/examples/Question_answering_using_embeddings.ipynb
@@ -191,7 +191,7 @@
    "id": "0c9bfea5-a028-4191-b9f1-f210d76ec4e3",
    "metadata": {},
    "source": [
-    "# 1) Preprocess the contextual information\n",
+    "# 1) Preprocess the document library\n",
     "\n",
     "We plan to use document embeddings to fetch the most relevant part of parts of our document library and insert them into the prompt that we provide to GPT-3. We therefore need to break up the document library into \"sections\" of context, which can be searched and retrieved separately. \n",
     "\n",
@@ -439,7 +439,7 @@
    "source": [
     "So we have split our document library into sections, and encoded them by creating embedding vectors that represent each chunk. Next we will use these embeddings to answer our users' questions.\n",
     "\n",
-    "# 2) Find the most similar context embeddings to the question embedding\n",
+    "# 2) Find the most similar document embeddings to the question embedding\n",
     "\n",
     "At the time of question-answering, to answer the user's query we compute the query embedding of the question and use it to find the most similar document sections. Since this is a small example, we store and search the embeddings locally. If you have a larger dataset, consider using a vector search engine like [Pinecone](https://www.pinecone.io/) or [Weaviate](https://github.com/semi-technologies/weaviate) to power the search."
    ]
@@ -547,7 +547,7 @@
    "id": "a0efa0f6-4469-457a-89a4-a2f5736a01e0",
    "metadata": {},
    "source": [
-    "# 3) Add the most relevant contexts to the query prompt\n",
+    "# 3) Add the most relevant document sections to the query prompt\n",
     "\n",
     "Once we've calculated the most relevant pieces of context, we construct a prompt by simply prepending them to the supplied query. It is helpful to use a query separator to help the model distinguish between separate pieces of text."
    ]

--- a/examples/Question_answering_using_embeddings.ipynb
+++ b/examples/Question_answering_using_embeddings.ipynb
@@ -1,8 +1,20 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "c4ca8276-e829-4cff-8905-47534e4b4d4e",
+   "metadata": {},
+   "source": [
+    "# Question Answering using Embeddings\n",
+    "\n",
+    "Many use cases require GPT-3 to respond to user questions with insightful answers. For example, a customer support chatbot may need to provide answers to common questions. The GPT models have picked up a lot of general knowledge in training, but we often need to ingest and use a large library of more specific information.\n",
+    "\n",
+    "In this notebook we will demonstrate a method for enabling GPT-3 able to answer questions using a library of text as a reference, by using document embeddings and retrieval. We'll be using a dataset of Wikipedia articles about the 2020 Summer Olympic Games. Please see [this notebook](examples/fine-tuned_qa/olympics-1-collect-data.ipynb) to follow the data gathering process."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 167,
+   "execution_count": 4,
    "id": "9e3839a6-9146-4f60-b74b-19abbc24278d",
    "metadata": {},
    "outputs": [],
@@ -10,14 +22,8 @@
     "import pandas as pd\n",
     "import openai\n",
     "import numpy as np\n",
-    "from tqdm.notebook import tqdm\n",
     "import pickle\n",
     "from transformers import GPT2TokenizerFast\n",
-    "\n",
-    "ENGINE_NAME = \"curie\"\n",
-    "\n",
-    "DOC_EMBEDDING_MODEL = f\"text-search-{ENGINE_NAME}-doc-001\"\n",
-    "QUERY_EMBEDDING_MODEL = f\"text-search-{MODEL_NAME}-query-001\"\n",
     "\n",
     "COMPLETIONS_MODEL = \"text-davinci-002\""
    ]
@@ -27,18 +33,12 @@
    "id": "9312f62f-e208-4030-a648-71ad97aee74f",
    "metadata": {},
    "source": [
-    "# Question Answering\n",
-    "\n",
-    "Many use cases require GPT to respond to user questions with insightful answers. For example, a customer support chatbot may need to provide answers to common questions. The GPT models have picked up a lot of general knowledge in training, but we often need to ingest and use a body of more specific information.\n",
-    "\n",
-    "In this notebook we will demonstrate a method for augmenting GPT with a large body of additional contextual information by using embeddings search and retrieval. We'll be using a dataset of Wikipedia articles about the 2020 Summer Olympic Games. Please see [this notebook](examples/fine-tuned_qa/olympics-1-collect-data.ipynb) to follow the data gathering process.\n",
-    "\n",
-    "GPT-3 isn't an expert on the Olympics by default:"
+    "By default, GPT-3 isn't an expert on the 2020 Olympics:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 176,
+   "execution_count": 5,
    "id": "a167516c-7c19-4bda-afa5-031aa0ae13bb",
    "metadata": {},
    "outputs": [
@@ -48,7 +48,7 @@
        "\"The 2020 Summer Olympics men's high jump was won by Mariusz Przybylski of Poland.\""
       ]
      },
-     "execution_count": 176,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -63,8 +63,8 @@
     "    top_p=1,\n",
     "    frequency_penalty=0,\n",
     "    presence_penalty=0,\n",
-    "    engine=COMPLETIONS_MODEL\n",
-    ")[\"choices\"][0][\"text\"].strip(\"\\n\")"
+    "    model=COMPLETIONS_MODEL\n",
+    ")[\"choices\"][0][\"text\"].strip(\" \\n\")"
    ]
   },
   {
@@ -72,14 +72,60 @@
    "id": "47204cce-a7d5-4c81-ab6e-53323026e08c",
    "metadata": {},
    "source": [
-    "Mariusz Przybylski is a professional footballer from Poland, and not much of a high jumper! Evidently GPT-3 needs some assistance here. (In fact we'd ideally like the model to be more conservative and say \"I don't know\" rather than making a guess - see [this guide](examples/fine-tuned_qa) for an exploration of that topic.)\n",
+    "Mariusz Przybylski is a professional footballer from Poland, and not much of a high jumper! Evidently GPT-3 needs some assistance here. \n",
     "\n",
-    "When the total required context is short, we can include it in the prompt directly. In this case, we can use this information taken from Wikipedia:"
+    "The first issue to tackle is that the model is hallucinating an answer rather than telling us \"I don't know\". This is bad because it makes it hard to trust the answer that the model gives us! \n",
+    "\n",
+    "# 0) Preventing hallucination with prompt engineering\n",
+    "\n",
+    "We can address this hallucination issue by being more explicit with our prompt:\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 179,
+   "execution_count": 6,
+   "id": "a5451371-17fe-4ef3-aa02-affcf4edb0e0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Sorry, I don't know.\""
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prompt = \"\"\"Answer the question as truthfully as possible, and if you're unsure of the answer, say \"Sorry, I don't know\".\n",
+    "\n",
+    "Q: Who won the 2020 Summer Olympics men's high jump?\n",
+    "A:\"\"\"\n",
+    "\n",
+    "openai.Completion.create(\n",
+    "    prompt=prompt,\n",
+    "    temperature=0,\n",
+    "    max_tokens=300,\n",
+    "    top_p=1,\n",
+    "    frequency_penalty=0,\n",
+    "    presence_penalty=0,\n",
+    "    model=COMPLETIONS_MODEL\n",
+    ")[\"choices\"][0][\"text\"].strip(\" \\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1af18d66-d47a-496d-ae5f-4c5d53caa434",
+   "metadata": {},
+   "source": [
+    "To help the model answer the question, we provide extra contextual information in the prompt. When the total required context is short, we can include it in the prompt directly. For example we can use this information taken from Wikipedia. We update the initial prompt to tell the model to explicitly make use of the provided text."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "id": "fceaf665-2602-4788-bc44-9eb256a6f955",
    "metadata": {},
    "outputs": [
@@ -89,13 +135,15 @@
        "\"Gianmarco Tamberi and Mutaz Essa Barshim won the 2020 Summer Olympics men's high jump.\""
       ]
      },
-     "execution_count": 179,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "prompt = \"\"\"\n",
+    "prompt = \"\"\"Answer the question as truthfully as possible using the provided text, and if the answer is not contained within the text below, say \"I don't know\"\n",
+    "\n",
+    "Context:\n",
     "The men's high jump event at the 2020 Summer Olympics took place between 30 July and 1 August 2021 at the Olympic Stadium.\n",
     "33 athletes from 24 nations competed; the total possible number depended on how many nations would use universality places \n",
     "to enter athletes in addition to the 32 qualifying through mark or ranking (no universality places were used in 2021).\n",
@@ -108,7 +156,8 @@
     "for Qatar (all by Barshim). Barshim became only the second man to earn three medals in high jump, joining Patrik Sjöberg\n",
     "of Sweden (1984 to 1992).\n",
     "\n",
-    "Who won the 2020 Summer Olympics men's high jump?\"\"\"\n",
+    "Q: Who won the 2020 Summer Olympics men's high jump?\n",
+    "A:\"\"\"\n",
     "\n",
     "openai.Completion.create(\n",
     "    prompt=prompt,\n",
@@ -117,8 +166,8 @@
     "    top_p=1,\n",
     "    frequency_penalty=0,\n",
     "    presence_penalty=0,\n",
-    "    engine=COMPLETIONS_MODEL\n",
-    ")[\"choices\"][0][\"text\"].strip(\"\\n\")"
+    "    model=COMPLETIONS_MODEL\n",
+    ")[\"choices\"][0][\"text\"].strip(\" \\n\")"
    ]
   },
   {
@@ -126,9 +175,9 @@
    "id": "ee85ee77-d8d2-4788-b57e-0785f2d7e2e3",
    "metadata": {},
    "source": [
-    "But this technique only works when the dataset of extra content that the model may need to know is small enough to fit in a single prompt. What do we do when we need the model to choose relevant contextual information from within a large body of information?\n",
+    "Adding extra information into the prompt only works when the dataset of extra content that the model may need to know is small enough to fit in a single prompt. What do we do when we need the model to choose relevant contextual information from within a large body of information?\n",
     "\n",
-    "**In this notebook we demonstrate a method for augmenting GPT with a large body of additional contextual information by using embeddings search and retrieval.** This method answers queries in two steps: first it retrieves the information relevant to the query, then it writes an answer tailored to the question based on the retrieved information. The first step uses the Embedding API, the second step uses the Completion API.\n",
+    "**In the remainder of this notebook, we will demonstrate a method for augmenting GPT-3 with a large body of additional contextual information by using document embeddings and retrieval.** This method answers queries in two steps: first it retrieves the information relevant to the query, then it writes an answer tailored to the question based on the retrieved information. The first step uses the [Embedding API](https://beta.openai.com/docs/guides/embeddings), the second step uses the [Completions API](https://beta.openai.com/docs/guides/completion/introduction).\n",
     " \n",
     "The steps are:\n",
     "* Preprocess the contextual information by splitting it into chunks and create an embedding vector for each chunk.\n",
@@ -144,16 +193,14 @@
    "source": [
     "# 1) Preprocess the contextual information\n",
     "\n",
-    "We preprocess the contextual information by creating an embedding vector for each chunk of context in the knowledge base. An embedding is a vector of numbers that helps us understand how similar or different things are. The closer two embeddings are to each other, the more similar the things are that they represent.\n",
+    "We plan to use document embeddings to fetch the most relevant part of parts of our document library and insert them into the prompt that we provide to GPT-3. We therefore need to break up the document library into \"sections\" of context, which can be searched and retrieved separately. \n",
     "\n",
-    "This indexing stage can be executed offline and only runs once to precompute the indexes for the dataset so that each piece of content can be retrieved later. Since this is a small example, we will store and search the embeddings locally. If you have a larger dataset, consider using a vector search engine like Pinecone or Weaviate to power the search.\n",
-    "\n",
-    "For the purposes of this tutorial we chose to use Curie embeddings, which are at a very good price and performance point. Since we will be using these embeddings for retrieval, we’ll use the search embeddings. "
+    "Sections should be large enough to contain enough information to answer a question; but small enough to fit one or several into the GPT-3 prompt. We find that approximately a paragraph of text is usually a good length, but you should experiment for your particular use case. In this example, Wikipedia articles are already grouped into semantically related headers, so we will use these to define our sections. This preprocessing has already been done in [this notebook](examples/fine-tuned_qa/olympics-1-collect-data.ipynb), so we will load the results and use them."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 8,
    "id": "cc9c8d69-e234-48b4-87e3-935970e1523a",
    "metadata": {},
    "outputs": [
@@ -161,7 +208,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3980 rows in the data.\n"
+      "3964 rows in the data.\n"
      ]
     },
     {
@@ -198,154 +245,189 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>United States at the 2020 Summer Olympics</th>\n",
-       "      <th>Diving</th>\n",
-       "      <td>U.S. divers qualified for the following indivi...</td>\n",
-       "      <td>89</td>\n",
+       "      <th>Volleyball at the 2020 Summer Olympics – Women's tournament</th>\n",
+       "      <th>Format</th>\n",
+       "      <td>The preliminary round was a competition betwee...</td>\n",
+       "      <td>132</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>Austria at the 2020 Summer Olympics</th>\n",
-       "      <th>Summary</th>\n",
-       "      <td>Austria competed at the 2020 Summer Olympics i...</td>\n",
-       "      <td>115</td>\n",
+       "      <th>Rugby sevens at the 2020 Summer Olympics – Women's qualification</th>\n",
+       "      <th>South America</th>\n",
+       "      <td>Sudamérica Rugby held a tournament on 1–2 June...</td>\n",
+       "      <td>56</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2020 Women's Rugby Sevens Final Olympic Qualification Tournament</th>\n",
-       "      <th>Knockout stage</th>\n",
-       "      <td>With two Olympic places available, the top eig...</td>\n",
-       "      <td>49</td>\n",
+       "      <th rowspan=\"2\" valign=\"top\">Canoeing at the 2020 Summer Olympics – Men's slalom C-1</th>\n",
+       "      <th>Competition format</th>\n",
+       "      <td>Slalom canoeing uses a three-round format, wit...</td>\n",
+       "      <td>136</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>Italy at the 2020 Summer Olympics</th>\n",
-       "      <th>Karate</th>\n",
-       "      <td>Italy entered five karateka into the inaugural...</td>\n",
-       "      <td>148</td>\n",
+       "      <th>Qualification</th>\n",
+       "      <td>A National Olympic Committee (NOC) entered onl...</td>\n",
+       "      <td>171</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2020 United States Olympic Team Trials (wrestling)</th>\n",
-       "      <th>Summary</th>\n",
-       "      <td>The 2020 United States Olympic Team Trials for...</td>\n",
-       "      <td>119</td>\n",
+       "      <th>Tunisia at the 2020 Summer Olympics</th>\n",
+       "      <th>Athletics</th>\n",
+       "      <td>Tunisian athletes further achieved the entry s...</td>\n",
+       "      <td>48</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                                                                                             content  \\\n",
-       "title                                              heading                                                             \n",
-       "United States at the 2020 Summer Olympics          Diving          U.S. divers qualified for the following indivi...   \n",
-       "Austria at the 2020 Summer Olympics                Summary         Austria competed at the 2020 Summer Olympics i...   \n",
-       "2020 Women's Rugby Sevens Final Olympic Qualifi... Knockout stage  With two Olympic places available, the top eig...   \n",
-       "Italy at the 2020 Summer Olympics                  Karate          Italy entered five karateka into the inaugural...   \n",
-       "2020 United States Olympic Team Trials (wrestling) Summary         The 2020 United States Olympic Team Trials for...   \n",
+       "                                                                                                                 content  \\\n",
+       "title                                              heading                                                                 \n",
+       "Volleyball at the 2020 Summer Olympics – Women'... Format              The preliminary round was a competition betwee...   \n",
+       "Rugby sevens at the 2020 Summer Olympics – Wome... South America       Sudamérica Rugby held a tournament on 1–2 June...   \n",
+       "Canoeing at the 2020 Summer Olympics – Men's sl... Competition format  Slalom canoeing uses a three-round format, wit...   \n",
+       "                                                   Qualification       A National Olympic Committee (NOC) entered onl...   \n",
+       "Tunisia at the 2020 Summer Olympics                Athletics           Tunisian athletes further achieved the entry s...   \n",
        "\n",
-       "                                                                   tokens  \n",
-       "title                                              heading                 \n",
-       "United States at the 2020 Summer Olympics          Diving              89  \n",
-       "Austria at the 2020 Summer Olympics                Summary            115  \n",
-       "2020 Women's Rugby Sevens Final Olympic Qualifi... Knockout stage      49  \n",
-       "Italy at the 2020 Summer Olympics                  Karate             148  \n",
-       "2020 United States Olympic Team Trials (wrestling) Summary            119  "
+       "                                                                       tokens  \n",
+       "title                                              heading                     \n",
+       "Volleyball at the 2020 Summer Olympics – Women'... Format                 132  \n",
+       "Rugby sevens at the 2020 Summer Olympics – Wome... South America           56  \n",
+       "Canoeing at the 2020 Summer Olympics – Men's sl... Competition format     136  \n",
+       "                                                   Qualification          171  \n",
+       "Tunisia at the 2020 Summer Olympics                Athletics               48  "
       ]
      },
-     "execution_count": 22,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Load the dataset, obtained from this notebook <LINK>.\n",
+    "# We have hosted the processed dataset, so you can download it directly without having to recreate it.\n",
     "# This dataset has already been split into sections, one row for each section of the Wikipedia page.\n",
     "\n",
-    "df = pd.read_csv('olympics_sections.csv')\n",
+    "df = pd.read_csv('https://cdn.openai.com/API/examples/data/olympics_sections_text.csv')\n",
     "df = df.set_index([\"title\", \"heading\"])\n",
     "print(f\"{len(df)} rows in the data.\")\n",
     "df.sample(5)"
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "a17b88b9-7ea2-491e-9727-12617c74a77d",
+   "metadata": {},
+   "source": [
+    "We preprocess the document sections by creating an embedding vector for each section. An embedding is a vector of numbers that helps us understand how semantically similar or different the texts are. The closer two embeddings are to each other, the more similar are their contents. See the [documentation on OpenAI embeddings](https://beta.api.openai.org/docs/guides/embeddings/) for more information.\n",
+    "\n",
+    "This indexing stage can be executed offline and only runs once to precompute the indexes for the dataset so that each piece of content can be retrieved later. Since this is a small example, we will store and search the embeddings locally. If you have a larger dataset, consider using a vector search engine like [Pinecone](https://www.pinecone.io/) or [Weaviate](https://github.com/semi-technologies/weaviate) to power the search.\n",
+    "\n",
+    "For the purposes of this tutorial we chose to use Curie embeddings, which are 4096-dimensional embeddings at a very good price and performance point. Since we will be using these embeddings for retrieval, we’ll use the \"search\" embeddings (see the [documentation](https://beta.api.openai.org/docs/guides/embeddings/))."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 215,
+   "execution_count": 9,
+   "id": "4b874907-5109-4eef-ad9a-add4367925a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MODEL_NAME = \"curie\"\n",
+    "\n",
+    "DOC_EMBEDDINGS_MODEL = f\"text-search-{MODEL_NAME}-doc-001\"\n",
+    "QUERY_EMBEDDINGS_MODEL = f\"text-search-{MODEL_NAME}-query-001\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "id": "ba475f30-ef7f-431c-b60d-d5970b62ad09",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_embedding(text: str, engine: str) -> np.array:\n",
-    "    result = openai.Engine(engine).embeddings(input=text)\n",
-    "    return np.array(result[\"data\"][0][\"embedding\"])\n",
+    "def get_embedding(text: str, model: str) -> list[float]:\n",
+    "    result = openai.Embedding.create(\n",
+    "      model=model,\n",
+    "      input=text\n",
+    "    )\n",
+    "    return result[\"data\"][0][\"embedding\"]\n",
     "\n",
-    "def get_doc_embedding(text: str) -> np.array:\n",
-    "    return get_embedding(text, DOC_EMBEDDING_MODEL)\n",
+    "def get_doc_embedding(text: str) -> list[float]:\n",
+    "    return get_embedding(text, DOC_EMBEDDINGS_MODEL)\n",
     "\n",
-    "def get_query_embedding(text: str) -> np.array:\n",
-    "    return get_embedding(text, QUERY_EMBEDDING_MODEL)\n",
+    "def get_query_embedding(text: str) -> list[float]:\n",
+    "    return get_embedding(text, QUERY_EMBEDDINGS_MODEL)\n",
     "\n",
-    "def compute_doc_embeddings(df: pd.DataFrame) -> pd.DataFrame:\n",
+    "def compute_doc_embeddings(df: pd.DataFrame) -> dict[tuple[str, str], list[float]]:\n",
     "    \"\"\"\n",
-    "    Create an embedding for each document in the dataframe using the OpenAI Embeddings API.\n",
+    "    Create an embedding for each row in the dataframe using the OpenAI Embeddings API.\n",
     "    \n",
     "    Return a dictionary that maps between each embedding vector and the index of the row that it corresponds to.\n",
     "    \"\"\"\n",
     "    return {\n",
-    "        idx: get_doc_embedding(r.content) for idx, r in tqdm(df.iterrows(), total=len(df))\n",
+    "        idx: get_doc_embedding(r.content.replace(\"\\n\", \" \")) for idx, r in df.iterrows()\n",
     "    }"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
-   "id": "ab50bfca-cb02-41c6-b338-4400abe1d86e",
+   "execution_count": 11,
+   "id": "737266aa-cbe7-4691-87c1-fce8a31632f1",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5d2192513f1349febdaef6ccb9ab1046",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/3980 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 1min 46s, sys: 7.92 s, total: 1min 54s\n",
-      "Wall time: 11min 16s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%%time\n",
-    "context_embeddings = compute_doc_embeddings(df)"
+    "def load_embeddings(fname: str) -> dict[tuple[str, str], list[float]]:\n",
+    "    \"\"\"\n",
+    "    Read the document embeddings and their keys from a CSV.\n",
+    "    \n",
+    "    fname is the path to a CSV with exactly these named columns: \n",
+    "        \"title\", \"heading\", \"0\", \"1\", ... up to the length of the embedding vectors.\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    df = pd.read_csv(fname, header=0)\n",
+    "    max_dim = max([int(c) for c in df.columns if c != \"title\" and c != \"heading\"])\n",
+    "    return {\n",
+    "           (r.title, r.heading): [r[str(i)] for i in range(max_dim + 1)] for _, r in df.iterrows()\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfe9c723-f838-4c75-8ed8-286b2e491a60",
+   "metadata": {},
+   "source": [
+    "Again, we have hosted the embeddings for you so you don't have to re-calculate them from scratch."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 249,
-   "id": "a298f666-f31f-4356-a882-e2170524a637",
+   "execution_count": 12,
+   "id": "ab50bfca-cb02-41c6-b338-4400abe1d86e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "document_embeddings = load_embeddings(\"https://cdn.openai.com/API/examples/data/olympics_sections_document_embeddings.csv\")\n",
+    "\n",
+    "# ===== OR, uncomment the below line to recaculate the embeddings from scratch. ========\n",
+    "\n",
+    "# context_embeddings = compute_doc_embeddings(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "b9a8c713-c8a9-47dc-85a4-871ee1395566",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "147.552"
-      ]
-     },
-     "execution_count": 249,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('2020 Summer Olympics', 'Summary') : [-0.00089670566, 0.0027141054, -0.00030984893, 0.0066024954, -0.009860336]... (4096 entries)\n"
+     ]
     }
    ],
    "source": [
-    "import sys\n",
-    "sys.getsizeof(context_embeddings) / 1000"
+    "# An example embedding:\n",
+    "example_entry = list(document_embeddings.items())[0]\n",
+    "print(f\"{example_entry[0]} : {example_entry[1][:5]}... ({len(example_entry[1])} entries)\")"
    ]
   },
   {
@@ -355,65 +437,101 @@
     "tags": []
    },
    "source": [
+    "So we have split our document library into sections, and encoded them by creating embedding vectors that represent each chunk. Next we will use these embeddings to answer our users' questions.\n",
+    "\n",
     "# 2) Find the most similar context embeddings to the question embedding\n",
     "\n",
-    "At the time of question-answering, to answer the user's query we compute the embedding of the question and use it to find the most similar context chunks.\n"
+    "At the time of question-answering, to answer the user's query we compute the query embedding of the question and use it to find the most similar document sections. Since this is a small example, we store and search the embeddings locally. If you have a larger dataset, consider using a vector search engine like [Pinecone](https://www.pinecone.io/) or [Weaviate](https://github.com/semi-technologies/weaviate) to power the search."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 210,
+   "execution_count": 14,
    "id": "dcd680e9-f194-4180-b14f-fc357498eb92",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def vector_similarity(x: np.array, y: np.array) -> float:\n",
-    "    return np.dot(x, y)\n",
-    "\n",
-    "def order_contexts_by_query_similarity(query: str, contexts: dict[(str, str), np.array]) -> list[(float, (str, str))]:\n",
+    "def vector_similarity(x: list[float], y: list[float]) -> float:\n",
     "    \"\"\"\n",
-    "    Find the query embedding for the supplied query, and compare it against all of the pre-calculated context embeddings\n",
-    "    to find the most relevant contexts. \n",
+    "    We could use cosine similarity or dot product to calculate the similarity between vectors.\n",
+    "    In practice, we have found it makes little difference. \n",
+    "    \"\"\"\n",
+    "    return np.dot(np.array(x), np.array(y))\n",
+    "\n",
+    "def order_document_sections_by_query_similarity(query: str, contexts: dict[(str, str), np.array]) -> list[(float, (str, str))]:\n",
+    "    \"\"\"\n",
+    "    Find the query embedding for the supplied query, and compare it against all of the pre-calculated document embeddings\n",
+    "    to find the most relevant sections. \n",
     "    \n",
-    "    Return the list of contexts, sorted by relevance in descending order.\n",
+    "    Return the list of document sections, sorted by relevance in descending order.\n",
     "    \"\"\"\n",
     "    query_embedding = get_query_embedding(query)\n",
     "    \n",
-    "    context_similarities = sorted([\n",
+    "    document_similarities = sorted([\n",
     "        (vector_similarity(query_embedding, doc_embedding), doc_index) for doc_index, doc_embedding in contexts.items()\n",
     "    ], reverse=True)\n",
     "    \n",
-    "    return context_similarities"
+    "    return document_similarities"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 211,
+   "execution_count": 15,
    "id": "e3a27d73-f47f-480d-b336-079414f749cb",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(0.4296262686167575,\n",
+       "[(0.42962625596241333,\n",
        "  (\"Athletics at the 2020 Summer Olympics – Men's high jump\", 'Summary')),\n",
-       " (0.4067051275316437,\n",
+       " (0.40670511466655435,\n",
        "  (\"Athletics at the 2020 Summer Olympics – Women's high jump\", 'Summary')),\n",
-       " (0.4046927788902179,\n",
+       " (0.40469276614514266,\n",
        "  (\"Athletics at the 2020 Summer Olympics – Men's high jump\", 'Background')),\n",
-       " (0.40424431005550354,\n",
+       " (0.4042442976710604,\n",
        "  (\"Athletics at the 2020 Summer Olympics – Men's triple jump\", 'Summary')),\n",
-       " (0.4021923762547752,\n",
+       " (0.4021923631988294,\n",
        "  (\"Athletics at the 2020 Summer Olympics – Women's long jump\", 'Summary'))]"
       ]
      },
-     "execution_count": 211,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "order_contexts_by_query_similarity(\"Who won the men's high jump?\", context_embeddings)[:5]"
+    "order_document_sections_by_query_similarity(\"Who won the men's high jump?\", document_embeddings)[:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "729c2ce7-8540-4ab2-bb3a-76c4dfcb689c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(0.42879291463492475,\n",
+       "  (\"Athletics at the 2020 Summer Olympics – Women's high jump\", 'Summary')),\n",
+       " (0.4194122846175017,\n",
+       "  (\"Athletics at the 2020 Summer Olympics – Women's long jump\", 'Summary')),\n",
+       " (0.41152657076657995,\n",
+       "  (\"Athletics at the 2020 Summer Olympics – Women's triple jump\", 'Summary')),\n",
+       " (0.4096367709206329,\n",
+       "  (\"Athletics at the 2020 Summer Olympics – Men's high jump\", 'Summary')),\n",
+       " (0.4059521236876147,\n",
+       "  (\"Athletics at the 2020 Summer Olympics – Women's pole vault\", 'Summary'))]"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "order_document_sections_by_query_similarity(\"Who won the women's high jump?\", document_embeddings)[:5]"
    ]
   },
   {
@@ -421,7 +539,7 @@
    "id": "3cf71fae-abb1-46b2-a483-c1b2f1a915c2",
    "metadata": {},
    "source": [
-    "We can see that summaries information about the men's and women's high jump competitions are judged to be the most relevant contexts for this question, which is in line with what we would expect."
+    "We can see that the most relevant document sections for each question are the summaries for the Men's and Women's high jump competitions - which is exactly what we would expect."
    ]
   },
   {
@@ -436,7 +554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 214,
+   "execution_count": 18,
    "id": "b763ace2-1946-48e0-8ff1-91ba335d47a0",
    "metadata": {},
    "outputs": [
@@ -446,61 +564,61 @@
        "'Context separator contains 3 tokens'"
       ]
      },
-     "execution_count": 214,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "MAX_CONTEXT_LEN = 500\n",
-    "CONTEXT_SEPARATOR = \"\\n* \"\n",
+    "MAX_SECTION_LEN = 500\n",
+    "SEPARATOR = \"\\n* \"\n",
     "\n",
     "tokenizer = GPT2TokenizerFast.from_pretrained(\"gpt2\")\n",
-    "context_separator_len = len(tokenizer.tokenize(CONTEXT_SEPARATOR))\n",
+    "separator_len = len(tokenizer.tokenize(SEPARATOR))\n",
     "\n",
-    "f\"Context separator contains {context_separator_len} tokens\""
+    "f\"Context separator contains {separator_len} tokens\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 160,
+   "execution_count": 19,
    "id": "0c5c0509-eeb9-4552-a5d4-6ace04ef73dd",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def construct_prompt(question: str, contexts: dict, df: pd.DataFrame) -> str:\n",
+    "def construct_prompt(question: str, context_embeddings: dict, df: pd.DataFrame) -> str:\n",
     "    \"\"\"\n",
-    "    \n",
+    "    Fetch relevant \n",
     "    \"\"\"\n",
-    "    most_relevant_contexts = order_contexts_by_query_similarity(question, doc_embeddings)\n",
+    "    most_relevant_document_sections = order_document_sections_by_query_similarity(question, context_embeddings)\n",
     "    \n",
-    "    chosen_contexts = []\n",
-    "    chosen_contexts_indexes = []\n",
-    "    chosen_contexts_len = 0\n",
+    "    chosen_sections = []\n",
+    "    chosen_sections_len = 0\n",
+    "    chosen_sections_indexes = []\n",
     "     \n",
-    "    for _, context_index in most_relevant_contexts:\n",
-    "        # Add contexts until we run out of space.\n",
-    "        # In this version, we will not add the final context that overflows our limit; \n",
-    "        # you may wish to \"partially add\" that final context.\n",
+    "    for _, section_index in most_relevant_document_sections:\n",
+    "        # Add contexts until we run out of space.        \n",
+    "        document_section = df.loc[section_index]\n",
     "        \n",
-    "        context = df.loc[context_index]\n",
-    "        \n",
-    "        chosen_contexts_len += context.tokens + context_separator_len\n",
-    "        if chosen_contexts_len > MAX_CONTEXT_LEN:\n",
+    "        chosen_sections_len += document_section.tokens + separator_len\n",
+    "        if chosen_sections_len > MAX_SECTION_LEN:\n",
     "            break\n",
     "            \n",
-    "        chosen_contexts.append(CONTEXT_SEPARATOR + context.content)\n",
-    "        chosen_contexts_indexes.append(str(context_index))\n",
-    "        \n",
-    "    print(f\"Selected {len(chosen_contexts)} contexts:\")\n",
-    "    print(\"\\n\".join(chosen_contexts_indexes))\n",
-    "        \n",
-    "    return \"\".join(chosen_contexts) + \"\\n\\n\" + question + \"\\n\""
+    "        chosen_sections.append(SEPARATOR + document_section.content.replace(\"\\n\", \" \"))\n",
+    "        chosen_sections_indexes.append(str(section_index))\n",
+    "            \n",
+    "    # Useful diagnostic information\n",
+    "    print(f\"Selected {len(chosen_sections)} document sections:\")\n",
+    "    print(\"\\n\".join(chosen_sections_indexes))\n",
+    "    \n",
+    "    header = \"\"\"Answer the question as truthfully as possible using the provided context, and if the answer is not contained within the text below, say \"I don't know.\"\\n\\nContext:\\n\"\"\"\n",
+    "    \n",
+    "    return header + \"\".join(chosen_sections) + \"\\n\\n Q: \" + question + \"\\n A:\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 161,
+   "execution_count": 20,
    "id": "f614045a-3917-4b28-9643-7e0c299ec1a7",
    "metadata": {},
    "outputs": [
@@ -508,25 +626,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Selected 3 contexts:\n",
+      "Selected 3 document sections:\n",
       "(\"Athletics at the 2020 Summer Olympics – Women's high jump\", 'Summary')\n",
       "(\"Athletics at the 2020 Summer Olympics – Men's high jump\", 'Summary')\n",
       "(\"Athletics at the 2020 Summer Olympics – Men's triple jump\", 'Summary')\n",
       "===\n",
-      " \n",
+      " Answer the question as truthfully as possible using the provided context, and if the answer is not contained within the text below, say \"I don't know.\"\n",
+      "\n",
+      "Context:\n",
+      "\n",
       "* The women's high jump event at the 2020 Summer Olympics took place on 5 and 7 August 2021 at the Japan National Stadium. Even though 32 athletes qualified through the qualification system for the Games, only 31 took part in the competition. This was the 22nd appearance of the event, having appeared at every Olympics since women's athletics was introduced in 1928.\n",
       "* The men's high jump event at the 2020 Summer Olympics took place between 30 July and 1 August 2021 at the Olympic Stadium. 33 athletes from 24 nations competed; the total possible number depended on how many nations would use universality places to enter athletes in addition to the 32 qualifying through mark or ranking (no universality places were used in 2021). Italian athlete Gianmarco Tamberi along with Qatari athlete Mutaz Essa Barshim emerged as joint winners of the event following a tie between both of them as they cleared 2.37m. Both Tamberi and Barshim agreed to share the gold medal in a rare instance where the athletes of different nations had agreed to share the same medal in the history of Olympics. Barshim in particular was heard to ask a competition official \"Can we have two golds?\" in response to being offered a 'jump off'. Maksim Nedasekau of Belarus took bronze. The medals were the first ever in the men's high jump for Italy and Belarus, the first gold in the men's high jump for Italy and Qatar, and the third consecutive medal in the men's high jump for Qatar (all by Barshim). Barshim became only the second man to earn three medals in high jump, joining Patrik Sjöberg of Sweden (1984 to 1992).\n",
       "* The men's triple jump event at the 2020 Summer Olympics took place between 3 and 5 August 2021 at the Japan National Stadium. Approximately 35 athletes were expected to compete; the exact number was dependent on how many nations use universality places to enter athletes in addition to the 32 qualifying through time or ranking (2 universality places were used in 2016). 32 athletes from 19 nations competed. Pedro Pichardo of Portugal won the gold medal, the nation's second victory in the men's triple jump (after Nelson Évora in 2008). China's Zhu Yaming took silver, while Hugues Fabrice Zango earned Burkina Faso's first Olympic medal in any event.\n",
       "\n",
-      "Who won the 2020 Summer Olympics men's high jump?\n",
-      "\n"
+      " Q: Who won the 2020 Summer Olympics men's high jump?\n",
+      " A:\n"
      ]
     }
    ],
    "source": [
     "prompt = construct_prompt(\n",
     "    \"Who won the 2020 Summer Olympics men's high jump?\",\n",
-    "    doc_embeddings,\n",
+    "    document_embeddings,\n",
     "    df\n",
     ")\n",
     "\n",
@@ -540,32 +661,31 @@
     "tags": []
    },
    "source": [
-    "# 4) Submit the extended query to the Completions API.\n",
+    "We have now obtained the document sections that are most relevant to the question. As a final step, let's put it all together to get an answer to the question.\n",
     "\n",
-    "Now that we've retrieved the relevant context, we can finally use the Completions API to answer the user's query."
+    "# 4) Answer the user's question based on the context.\n",
+    "\n",
+    "Now that we've retrieved the relevant context and constructed our prompt, we can finally use the Completions API to answer the user's query."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 233,
+   "execution_count": 21,
    "id": "b0edfec7-9243-4573-92e0-253d31c771ad",
    "metadata": {},
    "outputs": [],
    "source": [
     "COMPLETIONS_API_PARAMS = {\n",
+    "    # We use temperature of 0.0 because it gives the most predictable, factual answer.\n",
     "    \"temperature\": 0.0,\n",
     "    \"max_tokens\": 300,\n",
-    "    \"top_p\": 1,\n",
-    "    \"frequency_penalty\": 0,\n",
-    "    \"presence_penalty\": 0,\n",
-    "    \"engine\": COMPLETIONS_MODEL,\n",
-    "    \"stop\": \"\\n\\n\"\n",
+    "    \"model\": COMPLETIONS_MODEL,\n",
     "}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 234,
+   "execution_count": 22,
    "id": "9c1c9a69-848e-4099-a90d-c8da36c153d5",
    "metadata": {},
    "outputs": [],
@@ -573,25 +693,29 @@
     "def answer_query_with_context(\n",
     "    query: str,\n",
     "    df: pd.DataFrame,\n",
-    "    context_embeddings: dict[(str, str), np.array]\n",
+    "    document_embeddings: dict[(str, str), np.array],\n",
+    "    show_prompt: bool = False\n",
     ") -> str:\n",
     "    prompt = construct_prompt(\n",
     "        query,\n",
-    "        context_embeddings,\n",
+    "        document_embeddings,\n",
     "        df\n",
     "    )\n",
+    "    \n",
+    "    if show_prompt:\n",
+    "        print(prompt)\n",
     "\n",
     "    response = openai.Completion.create(\n",
     "                prompt=prompt,\n",
     "                **COMPLETIONS_API_PARAMS\n",
     "            )\n",
     "\n",
-    "    return response[\"choices\"][0][\"text\"].strip(\"\\n\")"
+    "    return response[\"choices\"][0][\"text\"].strip(\" \\n\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 235,
+   "execution_count": 24,
    "id": "c233e449-bf33-4c9e-b095-6a4dd278c8fd",
    "metadata": {},
    "outputs": [
@@ -599,7 +723,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Selected 3 contexts:\n",
+      "Selected 3 document sections:\n",
       "(\"Athletics at the 2020 Summer Olympics – Women's high jump\", 'Summary')\n",
       "(\"Athletics at the 2020 Summer Olympics – Men's high jump\", 'Summary')\n",
       "(\"Athletics at the 2020 Summer Olympics – Men's triple jump\", 'Summary')\n"
@@ -608,16 +732,16 @@
     {
      "data": {
       "text/plain": [
-       "\"Gianmarco Tamberi and Mutaz Essa Barshim both cleared 2.37m to win the gold medal in the men's high jump event at the 2020 Summer Olympics.\""
+       "'Gianmarco Tamberi and Mutaz Essa Barshim emerged as joint winners of the event following a tie between both of them as they cleared 2.37m.'"
       ]
      },
-     "execution_count": 235,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "answer_query_with_context(\"Who won the 2020 Summer Olympics men's high jump?\", df, context_embeddings)"
+    "answer_query_with_context(\"Who won the 2020 Summer Olympics men's high jump?\", df, document_embeddings)"
    ]
   },
   {
@@ -625,12 +749,18 @@
    "id": "7b48d155-d2d4-447c-ab8e-5a5b4722b07c",
    "metadata": {},
    "source": [
-    "# More Examples"
+    "Wow! By combining the Embeddings and Completions APIs, we have created a question-answering model which can answer questions using a large base of additional knowledge. It also understands when it doesn't know the answer! \n",
+    "\n",
+    "For this example we have used a dataset of Wikipedia articles, but that dataset could be replaced with books, articles, documentation, service manuals, or much much more. **We can't wait to see what you create with GPT-3!**\n",
+    "\n",
+    "# More Examples\n",
+    "\n",
+    "Let's have some fun and try some more examples."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 242,
+   "execution_count": 27,
    "id": "1127867b-2884-44bb-9439-0e8ae171c835",
    "metadata": {},
    "outputs": [
@@ -638,29 +768,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Selected 1 contexts:\n",
-      "('2020 Summer Olympics', 'Postponement to 2021')\n"
+      "Selected 1 document sections:\n",
+      "('2020 Summer Olympics', 'Postponement to 2021')\n",
+      "\n",
+      "Q: Why was the 2020 Summer Olympics originally postponed?\n",
+      "A: The 2020 Summer Olympics were originally postponed due to the COVID-19 pandemic.\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'The 2020 Summer Olympics were originally postponed due to the COVID-19 pandemic. The outbreak of the pandemic began in China in December 2019, and spread to Japan in January 2020. The outbreak was declared a Public Health Emergency of International Concern by the World Health Organization on 30 January 2020. On 25 February 2020, the IOC announced that it would hold a meeting on the following day to discuss the outbreak and its potential impact on the Games.'"
-      ]
-     },
-     "execution_count": 242,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
     "query = \"Why was the 2020 Summer Olympics originally postponed?\"\n",
-    "answer_query_with_context(query, df, context_embeddings)"
+    "answer = answer_query_with_context(query, df, document_embeddings)\n",
+    "\n",
+    "print(f\"\\nQ: {query}\\nA: {answer}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 236,
+   "execution_count": 28,
    "id": "720d9e0b-b189-4101-91ee-babf736199e6",
    "metadata": {},
    "outputs": [
@@ -668,29 +793,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Selected 1 contexts:\n",
-      "('2020 Summer Olympics medal table', 'Summary')\n"
+      "Selected 1 document sections:\n",
+      "('2020 Summer Olympics medal table', 'Summary')\n",
+      "\n",
+      "Q: In the 2020 Summer Olympics, how many gold medals did the country which won the most medals win?\n",
+      "A: The United States won the most medals overall, with 113, and the most gold medals, with 39.\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'The United States won the most medals overall, with 113, and the most gold medals, with 39.'"
-      ]
-     },
-     "execution_count": 236,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
     "query = \"In the 2020 Summer Olympics, how many gold medals did the country which won the most medals win?\"\n",
-    "answer_query_with_context(query, df, context_embeddings)"
+    "answer = answer_query_with_context(query, df, document_embeddings)\n",
+    "\n",
+    "print(f\"\\nQ: {query}\\nA: {answer}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 238,
+   "execution_count": 29,
    "id": "4e8e51cc-e4eb-4557-9e09-2929d4df5b7f",
    "metadata": {},
    "outputs": [
@@ -698,31 +818,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Selected 3 contexts:\n",
+      "Selected 3 document sections:\n",
       "(\"Athletics at the 2020 Summer Olympics – Men's shot put\", 'Summary')\n",
       "(\"Athletics at the 2020 Summer Olympics – Men's shot put\", 'Background')\n",
-      "(\"Athletics at the 2020 Summer Olympics – Men's hammer throw\", 'Competition format')\n"
+      "(\"Athletics at the 2020 Summer Olympics – Men's hammer throw\", 'Competition format')\n",
+      "\n",
+      "Q: What was unusual about the men’s shotput competition?\n",
+      "A: The same three competitors received the same medals in back-to-back editions of an the same individual event.\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'The men’s shotput competition at the 2020 Summer Olympics was unusual because the same three competitors received the same medals in back-to-back editions of the same individual event. Americans Ryan Crouser and Joe Kovacs and New Zealander Tom Walsh repeated their gold, silver, and bronze (respectively) performances from the 2016 Summer Olympics. They became the 15th, 16th, and 17th men to earn multiple medals in the shot put; Crouser was the 4th to repeat as champion.'"
-      ]
-     },
-     "execution_count": 238,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
     "query = \"What was unusual about the men’s shotput competition?\"\n",
-    "answer_query_with_context(query, df, context_embeddings)"
+    "answer = answer_query_with_context(query, df, document_embeddings)\n",
+    "\n",
+    "print(f\"\\nQ: {query}\\nA: {answer}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 239,
+   "execution_count": 30,
    "id": "37c83519-e3c6-4c44-8b4a-98cbb3a5f5ba",
    "metadata": {},
    "outputs": [
@@ -730,24 +845,117 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Selected 1 contexts:\n",
-      "('Italy at the 2020 Summer Olympics', 'Summary')\n"
+      "Selected 1 document sections:\n",
+      "('Italy at the 2020 Summer Olympics', 'Summary')\n",
+      "\n",
+      "Q: In the 2020 Summer Olympics, how many silver medals did Italy win?\n",
+      "A: 10\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'10'"
-      ]
-     },
-     "execution_count": 239,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
     "query = \"In the 2020 Summer Olympics, how many silver medals did Italy win?\"\n",
-    "answer_query_with_context(query, df, context_embeddings)"
+    "answer = answer_query_with_context(query, df, document_embeddings)\n",
+    "\n",
+    "print(f\"\\nQ: {query}\\nA: {answer}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "177c945e-f5c4-4fa5-8331-44f328b25e44",
+   "metadata": {},
+   "source": [
+    "Our Q&A model is less prone to hallucinating answers, and has a better sense of what it does or doesn't know. This works when the information isn't contained in the context; when the question is nonsensical; or when the question is theoretically answerable but beyond GPT-3's powers!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "26a1a9ef-e1ee-4f80-a1b1-6164ccfa5bac",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Selected 3 document sections:\n",
+      "('France at the 2020 Summer Olympics', 'Taekwondo')\n",
+      "('2020 Summer Olympics medal table', 'Medal count')\n",
+      "('Taekwondo at the 2020 Summer Olympics – Qualification', 'Qualification summary')\n",
+      "\n",
+      "Q: What is the total number of medals won by France, multiplied by the number of Taekwondo medals given out to all countries?\n",
+      "A: I don't know.\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"What is the total number of medals won by France, multiplied by the number of Taekwondo medals given out to all countries?\"\n",
+    "answer = answer_query_with_context(query, df, document_embeddings)\n",
+    "\n",
+    "print(f\"\\nQ: {query}\\nA: {answer}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "9fba8a63-eb81-4661-ae17-59bb5e2933d6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Selected 7 document sections:\n",
+      "('Chile at the 2020 Summer Olympics', 'Mountain biking')\n",
+      "('South Korea at the 2020 Summer Olympics', 'Sport climbing')\n",
+      "(\"Cycling at the 2020 Summer Olympics – Men's cross-country\", 'Competition format')\n",
+      "(\"Ski mountaineering at the 2020 Winter Youth Olympics – Boys' individual\", 'Summary')\n",
+      "(\"Cycling at the 2020 Summer Olympics – Women's cross-country\", 'Competition format')\n",
+      "('Portugal at the 2020 Summer Olympics', 'Mountain biking')\n",
+      "('Slovenia at the 2020 Summer Olympics', 'Mountain biking')\n",
+      "\n",
+      "Q: What is the tallest mountain in the world?\n",
+      "A: I don't know.\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"What is the tallest mountain in the world?\"\n",
+    "answer = answer_query_with_context(query, df, document_embeddings)\n",
+    "\n",
+    "print(f\"\\nQ: {query}\\nA: {answer}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "2d4c693b-cdb9-4f4c-bd1b-f77b29097a1f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Selected 8 document sections:\n",
+      "(\"Gymnastics at the 2020 Summer Olympics – Women's trampoline\", 'Summary')\n",
+      "(\"Rowing at the 2020 Summer Olympics – Women's quadruple sculls\", 'Summary')\n",
+      "(\"Cycling at the 2020 Summer Olympics – Women's sprint\", 'Summary')\n",
+      "(\"Cycling at the 2020 Summer Olympics – Women's team sprint\", 'Summary')\n",
+      "(\"Wrestling at the 2020 Summer Olympics – Women's freestyle 62 kg\", 'Summary')\n",
+      "(\"Cycling at the 2020 Summer Olympics – Women's BMX freestyle\", 'Summary')\n",
+      "(\"Rowing at the 2020 Summer Olympics – Women's lightweight double sculls\", 'Summary')\n",
+      "(\"Wrestling at the 2020 Summer Olympics – Women's freestyle 68 kg\", 'Summary')\n",
+      "\n",
+      "Q: Who won the grimblesplatch competition at the 2020 Summer Olympic games?\n",
+      "A: I don't know.\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"Who won the grimblesplatch competition at the 2020 Summer Olympic games?\"\n",
+    "answer = answer_query_with_context(query, df, document_embeddings)\n",
+    "\n",
+    "print(f\"\\nQ: {query}\\nA: {answer}\")"
    ]
   }
  ],


### PR DESCRIPTION
Many use cases require GPT-3 to respond to user questions with insightful answers. For example, a customer support chatbot may need to provide answers to common questions. The GPT models have picked up a lot of general knowledge in training, but we often need to ingest and use a large library of more specific information.

In this notebook we demonstrate a method for enabling GPT-3 able to answer questions using a library of text as a reference, by using document embeddings and retrieval.