### PR TITLE
Only get_embedding once

### DIFF
--- a/examples/Obtain_dataset.ipynb
+++ b/examples/Obtain_dataset.ipynb
@@ -162,7 +162,7 @@
     "\n",
     "# This will take just between 5 and 10 minutes\n",
     "df['ada_similarity'] = df.combined.apply(lambda x: get_embedding(x, engine='text-embedding-ada-002'))\n",
-    "df['ada_search'] = df.combined.apply(lambda x: get_embedding(x, engine='text-embedding-ada-002'))\n",
+    "df['ada_search'] = df['ada_similarity']\n",
     "df.to_csv('data/fine_food_reviews_with_embeddings_1k.csv')"
    ]
   }


### PR DESCRIPTION
https://github.com/openai/openai-cookbook/commit/fd181ec78fa57e14583e27915ccdad3a084296ae updated what was previously two different get_embedding() calls w/ different models to be two identical calls. Rather than doing the same API call twice in a row, we can now just set the second variable to be equal to the first one.