### PR TITLE
Remove unmatched closing brackets ")"

### DIFF
--- a/solutions/web_crawl_Q&A/web-qa.ipynb
+++ b/solutions/web_crawl_Q&A/web-qa.ipynb
@@ -1018,7 +1018,7 @@
    "source": [
     "from openai.embeddings_utils import distances_from_embeddings\n",
     "\n",
-    "df['embeddings'] = df.text.apply(lambda x: openai.Embedding.create(input=x, engine='text-embedding-ada-002')['data'][0]['embedding']))\n",
+    "df['embeddings'] = df.text.apply(lambda x: openai.Embedding.create(input=x, engine='text-embedding-ada-002')['data'][0]['embedding'])\n",
     "\n",
     "df.to_csv('processed/embeddings.csv')\n",
     "df.head()"


### PR DESCRIPTION
Remove unmatched closing brackets ")". 

The added unmatched ")" causes a syntax error. Removing it fixes the error.