### PR TITLE
Add Qdrant notebooks

### DIFF
--- a/examples/vector_databases/qdrant/QA_with_Langchain_Qdrant_and_OpenAI.ipynb
+++ b/examples/vector_databases/qdrant/QA_with_Langchain_Qdrant_and_OpenAI.ipynb
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-02-16T17:06:29.193187Z",
@@ -106,61 +106,7 @@
     },
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: openai in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (0.26.5)\n",
-      "Requirement already satisfied: qdrant-client in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (1.0.1)\n",
-      "Collecting langchain==0.0.70\n",
-      "  Downloading langchain-0.0.70-py3-none-any.whl (175 kB)\n",
-      "\u001B[2K     \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m175.4/175.4 kB\u001B[0m \u001B[31m907.2 kB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0m00:01\u001B[0m00:01\u001B[0m\n",
-      "\u001B[?25hRequirement already satisfied: wget in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (3.2)\n",
-      "Requirement already satisfied: SQLAlchemy<2,>=1 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from langchain==0.0.70) (1.4.46)\n",
-      "Requirement already satisfied: numpy<2,>=1 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from langchain==0.0.70) (1.24.2)\n",
-      "Requirement already satisfied: pydantic<2,>=1 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from langchain==0.0.70) (1.10.5)\n",
-      "Requirement already satisfied: requests<3,>=2 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from langchain==0.0.70) (2.28.2)\n",
-      "Requirement already satisfied: PyYAML<7,>=6 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from langchain==0.0.70) (6.0)\n",
-      "Requirement already satisfied: aiohttp in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from openai) (3.8.4)\n",
-      "Requirement already satisfied: tqdm in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from openai) (4.64.1)\n",
-      "Requirement already satisfied: grpcio>=1.41.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from qdrant-client) (1.51.1)\n",
-      "Requirement already satisfied: httpx[http2]>=0.14.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from qdrant-client) (0.23.3)\n",
-      "Requirement already satisfied: grpcio-tools>=1.41.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from qdrant-client) (1.51.1)\n",
-      "Requirement already satisfied: typing-extensions<5.0.0,>=4.0.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from qdrant-client) (4.5.0)\n",
-      "Requirement already satisfied: setuptools in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from grpcio-tools>=1.41.0->qdrant-client) (66.0.0)\n",
-      "Requirement already satisfied: protobuf<5.0dev,>=4.21.6 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from grpcio-tools>=1.41.0->qdrant-client) (4.21.12)\n",
-      "Requirement already satisfied: certifi in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from httpx[http2]>=0.14.0->qdrant-client) (2022.12.7)\n",
-      "Requirement already satisfied: sniffio in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from httpx[http2]>=0.14.0->qdrant-client) (1.3.0)\n",
-      "Requirement already satisfied: httpcore<0.17.0,>=0.15.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from httpx[http2]>=0.14.0->qdrant-client) (0.16.3)\n",
-      "Requirement already satisfied: rfc3986[idna2008]<2,>=1.3 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from httpx[http2]>=0.14.0->qdrant-client) (1.5.0)\n",
-      "Requirement already satisfied: h2<5,>=3 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from httpx[http2]>=0.14.0->qdrant-client) (4.1.0)\n",
-      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from requests<3,>=2->langchain==0.0.70) (1.26.14)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from requests<3,>=2->langchain==0.0.70) (3.0.1)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from requests<3,>=2->langchain==0.0.70) (3.4)\n",
-      "Requirement already satisfied: greenlet!=0.4.17 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from SQLAlchemy<2,>=1->langchain==0.0.70) (2.0.2)\n",
-      "Requirement already satisfied: attrs>=17.3.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from aiohttp->openai) (22.2.0)\n",
-      "Requirement already satisfied: frozenlist>=1.1.1 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from aiohttp->openai) (1.3.3)\n",
-      "Requirement already satisfied: async-timeout<5.0,>=4.0.0a3 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from aiohttp->openai) (4.0.2)\n",
-      "Requirement already satisfied: aiosignal>=1.1.2 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from aiohttp->openai) (1.3.1)\n",
-      "Requirement already satisfied: multidict<7.0,>=4.5 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from aiohttp->openai) (6.0.4)\n",
-      "Requirement already satisfied: yarl<2.0,>=1.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from aiohttp->openai) (1.8.2)\n",
-      "Requirement already satisfied: hpack<5,>=4.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from h2<5,>=3->httpx[http2]>=0.14.0->qdrant-client) (4.0.0)\n",
-      "Requirement already satisfied: hyperframe<7,>=6.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from h2<5,>=3->httpx[http2]>=0.14.0->qdrant-client) (6.0.1)\n",
-      "Requirement already satisfied: anyio<5.0,>=3.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from httpcore<0.17.0,>=0.15.0->httpx[http2]>=0.14.0->qdrant-client) (3.6.2)\n",
-      "Requirement already satisfied: h11<0.15,>=0.13 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from httpcore<0.17.0,>=0.15.0->httpx[http2]>=0.14.0->qdrant-client) (0.14.0)\n",
-      "Installing collected packages: langchain\n",
-      "  Attempting uninstall: langchain\n",
-      "    Found existing installation: langchain 0.0.88\n",
-      "    Uninstalling langchain-0.0.88:\n",
-      "      Successfully uninstalled langchain-0.0.88\n",
-      "Successfully installed langchain-0.0.70\n",
-      "\n",
-      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip available: \u001B[0m\u001B[31;49m22.3.1\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m23.0\u001B[0m\n",
-      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "! pip install openai qdrant-client \"langchain==0.0.87\" wget"
    ]
@@ -394,28 +340,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-16T17:10:06.573641Z",
-     "start_time": "2023-02-16T17:10:06.567032Z"
+     "end_time": "2023-02-16T17:34:03.816845Z",
+     "start_time": "2023-02-16T17:34:03.808928Z"
     }
    },
    "outputs": [],
    "source": [
     "import random\n",
     "\n",
-    "random.seed(76)\n",
+    "random.seed(52)\n",
     "selected_questions = random.choices(questions, k=5)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-16T17:18:24.098392Z",
-     "start_time": "2023-02-16T17:18:11.847165Z"
+     "end_time": "2023-02-16T17:34:31.439642Z",
+     "start_time": "2023-02-16T17:34:04.170150Z"
     }
    },
    "outputs": [
@@ -423,20 +369,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "> what kind of music is scott joplin most famous for\n",
-      " Scott Joplin is most famous for composing ragtime music.\n",
+      "> where do frankenstein and the monster first meet\n",
+      " Victor retreats into the mountains and the Creature finds him and pleads for Victor to hear his tale, so they first meet in the mountains.\n",
       "\n",
-      "> who died from the band faith no more\n",
-      " Chuck Mosley died on November 9, 2017, due to \"the disease of addiction.\" He was 57 years old.\n",
+      "> who are the actors in fast and furious\n",
+      " The actors in Fast and Furious are Vin Diesel as Dominic Toretto, Paul Walker as Brian O'Conner, Michelle Rodriguez as Letty Ortiz, Jordana Brewster as Mia Toretto, Tyrese Gibson as Roman Pearce, Ludacris as Tej Parker, Lucas Black as Sean Boswell, Sung Kang as Han Lue, Gal Gadot as Gisele Yashar, Dwayne Johnson as Luke Hobbs, Matt Schulze as Vince, Chad Lindberg as Jesse, Johnny Strong as Leon, Eva Mendes as Monica Fuentes, Devon Aoki as Suki, Nathalie Kelley as Neela, Bow Wow as Twinkie, Tego Calderón as Tego Leo, Don Omar as Rico Santos, Elsa Pataky as Elena Neves, and Kurt Russell as Mr. Nobody.\n",
       "\n",
-      "> when does maggie come on grey's anatomy\n",
-      " Maggie (Kelly McCreary) first appears in the 14th season of Grey's Anatomy, which premiered on September 28, 2017.\n",
+      "> properties of red black tree in data structure\n",
+      " Red black trees have the following properties: each node is either red or black, the root is black, all leaves (NIL) are black, if a node is red, then both its children are black, and every path from a given node to any of its descendant NIL nodes contains the same number of black nodes.\n",
       "\n",
-      "> can't take my eyes off you lyrics meaning\n",
+      "> who designed the national coat of arms of south africa\n",
+      " Iaan Bekker\n",
+      "\n",
+      "> caravaggio's death of the virgin pamela askew\n",
       " I don't know.\n",
-      "\n",
-      "> who lasted the longest on alone season 2\n",
-      " David McIntyre lasted the longest on Alone season 2; he won the season with 66 days.\n",
       "\n"
      ]
     }

--- a/examples/vector_databases/qdrant/QA_with_Langchain_Qdrant_and_OpenAI.ipynb
+++ b/examples/vector_databases/qdrant/QA_with_Langchain_Qdrant_and_OpenAI.ipynb
@@ -9,13 +9,13 @@
     "This notebook presents how to implement a Question Answering system with Langchain, Qdrant as a knowledge based and OpenAI embeddings. If you are not familiar with Qdrant, it's better to check out the [Getting_started_with_Qdrant_and_OpenAI.ipynb](Getting_started_with_Qdrant_and_OpenAI.ipynb) notebook.\n",
     "\n",
     "This notebook presents an end-to-end process of:\n",
-    "1. Using ra embeddings created by OpenAI API.\n",
+    "1. Calculating the embeddings with OpenAI API.\n",
     "2. Storing the embeddings in a local instance of Qdrant to build a knowledge base.\n",
     "3. Converting raw text query to an embedding with OpenAI API.\n",
     "4. Using Qdrant to perform the nearest neighbour search in the created collection to find some context.\n",
-    "5. Asking LLM to find the answer in given context.\n",
+    "5. Asking LLM to find the answer in a given context.\n",
     "\n",
-    "All the steps will be simplified to a calling some corresponding Langchain methods."
+    "All the steps will be simplified to calling some corresponding Langchain methods."
    ]
   },
   {
@@ -108,7 +108,7 @@
    },
    "outputs": [],
    "source": [
-    "! pip install openai qdrant-client \"langchain==0.0.87\" wget"
+    "! pip install openai qdrant-client \"langchain==0.0.100\" wget"
    ]
   },
   {

--- a/examples/vector_databases/qdrant/QA_with_Langchain_Qdrant_and_OpenAI.ipynb
+++ b/examples/vector_databases/qdrant/QA_with_Langchain_Qdrant_and_OpenAI.ipynb
@@ -41,8 +41,8 @@
    "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-16T17:06:25.477937Z",
-     "start_time": "2023-02-16T17:06:24.739247Z"
+     "end_time": "2023-03-03T16:17:00.430505Z",
+     "start_time": "2023-03-03T16:16:58.488129Z"
     }
    },
    "outputs": [
@@ -50,7 +50,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "qdrant_qdrant_1 is up-to-date\r\n"
+      "Starting qdrant_qdrant_1 ... \n",
+      "\u001B[1Bting qdrant_qdrant_1 ... \u001B[32mdone\u001B[0m"
      ]
     }
    ],
@@ -70,8 +71,8 @@
    "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-16T17:06:25.621326Z",
-     "start_time": "2023-02-16T17:06:25.483947Z"
+     "end_time": "2023-03-03T16:17:00.650341Z",
+     "start_time": "2023-03-03T16:17:00.438332Z"
     }
    },
    "outputs": [
@@ -101,8 +102,8 @@
    "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-16T17:06:29.193187Z",
-     "start_time": "2023-02-16T17:06:25.624497Z"
+     "end_time": "2023-03-03T16:17:15.121014Z",
+     "start_time": "2023-03-03T16:17:00.653356Z"
     },
     "scrolled": true
    },
@@ -129,8 +130,8 @@
    "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-16T17:06:29.206718Z",
-     "start_time": "2023-02-16T17:06:29.202344Z"
+     "end_time": "2023-03-03T16:17:15.140434Z",
+     "start_time": "2023-03-03T16:17:15.130446Z"
     }
    },
    "outputs": [
@@ -170,8 +171,8 @@
    "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-16T17:06:30.144430Z",
-     "start_time": "2023-02-16T17:06:29.212729Z"
+     "end_time": "2023-03-03T16:17:16.184482Z",
+     "start_time": "2023-03-03T16:17:15.146386Z"
     }
    },
    "outputs": [
@@ -179,39 +180,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2023-02-16 18:06:29--  https://storage.googleapis.com/dataset-natural-questions/questions.json\n",
-      "Resolving storage.googleapis.com (storage.googleapis.com)... 142.250.203.208, 216.58.208.208, 142.250.75.16, ...\n",
-      "Connecting to storage.googleapis.com (storage.googleapis.com)|142.250.203.208|:443... connected.\n",
-      "HTTP request sent, awaiting response... 416 Requested range not satisfiable\n",
-      "\n",
-      "    The file is already fully retrieved; nothing to do.\n",
-      "\n",
-      "--2023-02-16 18:06:29--  https://storage.googleapis.com/dataset-natural-questions/answers.json\n",
-      "Resolving storage.googleapis.com (storage.googleapis.com)... 216.58.208.208, 142.250.186.208, 216.58.215.112, ...\n",
-      "Connecting to storage.googleapis.com (storage.googleapis.com)|216.58.208.208|:443... connected.\n",
-      "HTTP request sent, awaiting response... 416 Requested range not satisfiable\n",
-      "\n",
-      "    The file is already fully retrieved; nothing to do.\n",
-      "\n"
+      "100% [..............................................................................] 95372 / 95372"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'answers.json'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
+    "import wget\n",
+    "\n",
     "# All the examples come from https://ai.google.com/research/NaturalQuestions\n",
     "# This is a sample of the training set that we download and extract for some\n",
     "# futher processing.\n",
-    "\n",
-    "!wget -c https://storage.googleapis.com/dataset-natural-questions/questions.json\n",
-    "!wget -c https://storage.googleapis.com/dataset-natural-questions/answers.json"
+    "wget.download(\"https://storage.googleapis.com/dataset-natural-questions/questions.json\")\n",
+    "wget.download(\"https://storage.googleapis.com/dataset-natural-questions/answers.json\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-16T17:09:31.352487Z",
-     "start_time": "2023-02-16T17:09:31.343483Z"
+     "end_time": "2023-03-03T16:17:16.202633Z",
+     "start_time": "2023-03-03T16:17:16.189718Z"
     },
     "code_folding": []
    },
@@ -228,11 +227,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-16T17:09:31.915856Z",
-     "start_time": "2023-02-16T17:09:31.908270Z"
+     "end_time": "2023-03-03T16:17:16.280960Z",
+     "start_time": "2023-03-03T16:17:16.209442Z"
     }
    },
    "outputs": [
@@ -250,11 +249,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-16T17:09:32.777080Z",
-     "start_time": "2023-02-16T17:09:32.768859Z"
+     "end_time": "2023-03-03T16:17:16.286628Z",
+     "start_time": "2023-03-03T16:17:16.283546Z"
     }
    },
    "outputs": [
@@ -281,11 +280,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-16T17:10:06.470388Z",
-     "start_time": "2023-02-16T17:09:34.000011Z"
+     "end_time": "2023-03-03T16:17:22.922735Z",
+     "start_time": "2023-03-03T16:17:16.288631Z"
     }
    },
    "outputs": [],
@@ -309,11 +308,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-16T17:10:06.482311Z",
-     "start_time": "2023-02-16T17:10:06.476817Z"
+     "end_time": "2023-03-03T16:17:22.941289Z",
+     "start_time": "2023-03-03T16:17:22.931412Z"
     }
    },
    "outputs": [],
@@ -340,11 +339,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-16T17:34:03.816845Z",
-     "start_time": "2023-02-16T17:34:03.808928Z"
+     "end_time": "2023-03-03T16:17:22.960403Z",
+     "start_time": "2023-03-03T16:17:22.946040Z"
     }
    },
    "outputs": [],
@@ -357,11 +356,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-16T17:34:31.439642Z",
-     "start_time": "2023-02-16T17:34:04.170150Z"
+     "end_time": "2023-03-03T16:17:42.330331Z",
+     "start_time": "2023-03-03T16:17:22.962450Z"
     }
    },
    "outputs": [
@@ -370,13 +369,13 @@
      "output_type": "stream",
      "text": [
       "> where do frankenstein and the monster first meet\n",
-      " Victor retreats into the mountains and the Creature finds him and pleads for Victor to hear his tale, so they first meet in the mountains.\n",
+      " Victor and the Creature first meet in the mountains.\n",
       "\n",
       "> who are the actors in fast and furious\n",
-      " The actors in Fast and Furious are Vin Diesel as Dominic Toretto, Paul Walker as Brian O'Conner, Michelle Rodriguez as Letty Ortiz, Jordana Brewster as Mia Toretto, Tyrese Gibson as Roman Pearce, Ludacris as Tej Parker, Lucas Black as Sean Boswell, Sung Kang as Han Lue, Gal Gadot as Gisele Yashar, Dwayne Johnson as Luke Hobbs, Matt Schulze as Vince, Chad Lindberg as Jesse, Johnny Strong as Leon, Eva Mendes as Monica Fuentes, Devon Aoki as Suki, Nathalie Kelley as Neela, Bow Wow as Twinkie, Tego Calderón as Tego Leo, Don Omar as Rico Santos, Elsa Pataky as Elena Neves, and Kurt Russell as Mr. Nobody.\n",
+      " The actors in the Fast and Furious films are Vin Diesel, Paul Walker, Michelle Rodriguez, Jordana Brewster, Tyrese Gibson, Ludacris, Lucas Black, Sung Kang, Gal Gadot, Dwayne Johnson, Matt Schulze, Chad Lindberg, Johnny Strong, Eva Mendes, Devon Aoki, Nathalie Kelley, Bow Wow, Tego Calderón, Don Omar, Elsa Pataky, Kurt Russell, Nathalie Emmanuel, Scott Eastwood, Noel Gugliemi, Ja Rule, Thom Barry, Ted Levine, Minka Kelly, James Remar, Amaury Nolasco, Michael Ealy, MC Jin, Brian Goodman, Lynda Boyd, Jason Tobin, Neela, Liza Lapira, Alimi Ballard, Yorgo Constantine, Geoff Meed, Jeimy Osorio, Max William Crane, Charlie & Miller Kimsey, Eden Estrella, Romeo Santos, John Brotherton, Helen Mirren, Celestino Cornielle, Janmarco Santiago, Carlos De La Hoz, James Ayoub, Rick Yune, Cole Hauser, Brian Tee, John Ortiz, Luke Evans, Jason Statham, Charlize Theron, Reggie Lee, Mo Gallini, Roberto Sanchez, Leonardo\n",
       "\n",
       "> properties of red black tree in data structure\n",
-      " Red black trees have the following properties: each node is either red or black, the root is black, all leaves (NIL) are black, if a node is red, then both its children are black, and every path from a given node to any of its descendant NIL nodes contains the same number of black nodes.\n",
+      " Red black trees are a type of binary tree with a special set of properties. Each node is either red or black, the root is black, and if a node is red, then both its children are black. Every path from a given node to any of its descendant NIL nodes contains the same number of black nodes. The number of black nodes from the root to a node is the node's black depth, and the uniform number of black nodes in all paths from root to the leaves is called the black-height of the red-black tree.\n",
       "\n",
       "> who designed the national coat of arms of south africa\n",
       " Iaan Bekker\n",
@@ -394,11 +393,139 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "### Custom prompt templates\n",
+    "\n",
+    "The `stuff` chain type in Langchain uses a specific prompt with question and context documents incorporated. This is what the default prompt looks like:\n",
+    "\n",
+    "```text\n",
+    "Use the following pieces of context to answer the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.\n",
+    "{context}\n",
+    "Question: {question}\n",
+    "Helpful Answer:\n",
+    "```\n",
+    "\n",
+    "We can, however, provide our prompt template and change the behaviour of the OpenAI LLM, while still using the `stuff` chain type. It is important to keep `{context}` and `{question}` as placeholders.\n",
+    "\n",
+    "#### Experimenting with custom prompts\n",
+    "\n",
+    "We can try using a different prompt template, so the model:\n",
+    "1. Responds with a single-sentence answer if it knows it.\n",
+    "2. Suggests a random song title if it doesn't know the answer to our question."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-03-03T16:28:04.907231Z",
+     "start_time": "2023-03-03T16:28:04.898528Z"
+    }
+   },
    "outputs": [],
-   "source": []
+   "source": [
+    "from langchain.prompts import PromptTemplate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-03-03T16:45:25.130450Z",
+     "start_time": "2023-03-03T16:45:25.121744Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "custom_prompt = \"\"\"\n",
+    "Use the following pieces of context to answer the question at the end. Please provide\n",
+    "a short single-sentence summary answer only. If you don't know the answer or if it's \n",
+    "not present in given context, don't try to make up an answer, but suggest me a random \n",
+    "unrelated song title I could listen to. \n",
+    "Context: {context}\n",
+    "Question: {question}\n",
+    "Helpful Answer:\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-03-03T16:45:25.563255Z",
+     "start_time": "2023-03-03T16:45:25.559014Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "custom_prompt_template = PromptTemplate(\n",
+    "    template=custom_prompt, input_variables=[\"context\", \"question\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-03-03T16:45:25.850729Z",
+     "start_time": "2023-03-03T16:45:25.845721Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "custom_qa = VectorDBQA.from_chain_type(\n",
+    "    llm=llm, \n",
+    "    chain_type=\"stuff\", \n",
+    "    vectorstore=doc_store,\n",
+    "    return_source_documents=False,\n",
+    "    chain_type_kwargs={\"prompt\": custom_prompt_template},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-03-03T16:46:49.553646Z",
+     "start_time": "2023-03-03T16:46:40.710304Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> what was uncle jesse's original last name on full house\n",
+      "Uncle Jesse's original last name on Full House was Cochran.\n",
+      "\n",
+      "> when did the volcano erupt in indonesia 2018\n",
+      "No volcanic eruption is mentioned in the given context. Suggested Song: \"Ring of Fire\" by Johnny Cash.\n",
+      "\n",
+      "> what does a dualist way of thinking mean\n",
+      "Dualist way of thinking means that the mind and body are separate entities, with the mind being a non-physical substance.\n",
+      "\n",
+      "> the first civil service commission in india was set up on the basis of recommendation of\n",
+      "The first Civil Service Commission in India was not set up on the basis of a recommendation.\n",
+      "\n",
+      "> how old do you have to be to get a tattoo in utah\n",
+      "In Utah, you must be at least 18 years old to get a tattoo.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "random.seed(41)\n",
+    "for question in random.choices(questions, k=5):\n",
+    "    print(\">\", question)\n",
+    "    print(custom_qa.run(question), end=\"\\n\\n\")"
+   ]
   }
  ],
  "metadata": {

--- a/examples/vector_databases/qdrant/QA_with_Langchain_Qdrant_and_OpenAI.ipynb
+++ b/examples/vector_databases/qdrant/QA_with_Langchain_Qdrant_and_OpenAI.ipynb
@@ -1,0 +1,479 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Question Answering with Langchain, Qdrant and OpenAI\n",
+    "\n",
+    "This notebook presents how to implement a Question Answering system with Langchain, Qdrant as a knowledge based and OpenAI embeddings. If you are not familiar with Qdrant, it's better to check out the [Getting_started_with_Qdrant_and_OpenAI.ipynb](Getting_started_with_Qdrant_and_OpenAI.ipynb) notebook.\n",
+    "\n",
+    "This notebook presents an end-to-end process of:\n",
+    "1. Using ra embeddings created by OpenAI API.\n",
+    "2. Storing the embeddings in a local instance of Qdrant to build a knowledge base.\n",
+    "3. Converting raw text query to an embedding with OpenAI API.\n",
+    "4. Using Qdrant to perform the nearest neighbour search in the created collection to find some context.\n",
+    "5. Asking LLM to find the answer in given context.\n",
+    "\n",
+    "All the steps will be simplified to a calling some corresponding Langchain methods."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "For the purposes of this exercise we need to prepare a couple of things:\n",
+    "\n",
+    "1. Qdrant server instance. In our case a local Docker container.\n",
+    "2. The [qdrant-client](https://github.com/qdrant/qdrant_client) library to interact with the vector database.\n",
+    "3. [Langchain](https://github.com/hwchase17/langchain) as a framework.\n",
+    "3. An [OpenAI API key](https://beta.openai.com/account/api-keys).\n",
+    "\n",
+    "### Start Qdrant server\n",
+    "\n",
+    "We're going to use a local Qdrant instance running in a Docker container. The easiest way to launch it is to use the attached [docker-compose.yaml] file and run the following command:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-16T17:06:25.477937Z",
+     "start_time": "2023-02-16T17:06:24.739247Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "qdrant_qdrant_1 is up-to-date\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "! docker-compose up -d"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We might validate if the server was launched successfully by running a simple curl command:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-16T17:06:25.621326Z",
+     "start_time": "2023-02-16T17:06:25.483947Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"title\":\"qdrant - vector search engine\",\"version\":\"1.0.1\"}"
+     ]
+    }
+   ],
+   "source": [
+    "! curl http://localhost:6333"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install requirements\n",
+    "\n",
+    "This notebook obviously requires the `openai`, `langchain` and `qdrant-client` packages.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-16T17:06:29.193187Z",
+     "start_time": "2023-02-16T17:06:25.624497Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: openai in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (0.26.5)\n",
+      "Requirement already satisfied: qdrant-client in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (1.0.1)\n",
+      "Collecting langchain==0.0.70\n",
+      "  Downloading langchain-0.0.70-py3-none-any.whl (175 kB)\n",
+      "\u001B[2K     \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m175.4/175.4 kB\u001B[0m \u001B[31m907.2 kB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0m00:01\u001B[0m00:01\u001B[0m\n",
+      "\u001B[?25hRequirement already satisfied: wget in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (3.2)\n",
+      "Requirement already satisfied: SQLAlchemy<2,>=1 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from langchain==0.0.70) (1.4.46)\n",
+      "Requirement already satisfied: numpy<2,>=1 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from langchain==0.0.70) (1.24.2)\n",
+      "Requirement already satisfied: pydantic<2,>=1 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from langchain==0.0.70) (1.10.5)\n",
+      "Requirement already satisfied: requests<3,>=2 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from langchain==0.0.70) (2.28.2)\n",
+      "Requirement already satisfied: PyYAML<7,>=6 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from langchain==0.0.70) (6.0)\n",
+      "Requirement already satisfied: aiohttp in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from openai) (3.8.4)\n",
+      "Requirement already satisfied: tqdm in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from openai) (4.64.1)\n",
+      "Requirement already satisfied: grpcio>=1.41.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from qdrant-client) (1.51.1)\n",
+      "Requirement already satisfied: httpx[http2]>=0.14.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from qdrant-client) (0.23.3)\n",
+      "Requirement already satisfied: grpcio-tools>=1.41.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from qdrant-client) (1.51.1)\n",
+      "Requirement already satisfied: typing-extensions<5.0.0,>=4.0.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from qdrant-client) (4.5.0)\n",
+      "Requirement already satisfied: setuptools in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from grpcio-tools>=1.41.0->qdrant-client) (66.0.0)\n",
+      "Requirement already satisfied: protobuf<5.0dev,>=4.21.6 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from grpcio-tools>=1.41.0->qdrant-client) (4.21.12)\n",
+      "Requirement already satisfied: certifi in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from httpx[http2]>=0.14.0->qdrant-client) (2022.12.7)\n",
+      "Requirement already satisfied: sniffio in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from httpx[http2]>=0.14.0->qdrant-client) (1.3.0)\n",
+      "Requirement already satisfied: httpcore<0.17.0,>=0.15.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from httpx[http2]>=0.14.0->qdrant-client) (0.16.3)\n",
+      "Requirement already satisfied: rfc3986[idna2008]<2,>=1.3 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from httpx[http2]>=0.14.0->qdrant-client) (1.5.0)\n",
+      "Requirement already satisfied: h2<5,>=3 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from httpx[http2]>=0.14.0->qdrant-client) (4.1.0)\n",
+      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from requests<3,>=2->langchain==0.0.70) (1.26.14)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from requests<3,>=2->langchain==0.0.70) (3.0.1)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from requests<3,>=2->langchain==0.0.70) (3.4)\n",
+      "Requirement already satisfied: greenlet!=0.4.17 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from SQLAlchemy<2,>=1->langchain==0.0.70) (2.0.2)\n",
+      "Requirement already satisfied: attrs>=17.3.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from aiohttp->openai) (22.2.0)\n",
+      "Requirement already satisfied: frozenlist>=1.1.1 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from aiohttp->openai) (1.3.3)\n",
+      "Requirement already satisfied: async-timeout<5.0,>=4.0.0a3 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from aiohttp->openai) (4.0.2)\n",
+      "Requirement already satisfied: aiosignal>=1.1.2 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from aiohttp->openai) (1.3.1)\n",
+      "Requirement already satisfied: multidict<7.0,>=4.5 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from aiohttp->openai) (6.0.4)\n",
+      "Requirement already satisfied: yarl<2.0,>=1.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from aiohttp->openai) (1.8.2)\n",
+      "Requirement already satisfied: hpack<5,>=4.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from h2<5,>=3->httpx[http2]>=0.14.0->qdrant-client) (4.0.0)\n",
+      "Requirement already satisfied: hyperframe<7,>=6.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from h2<5,>=3->httpx[http2]>=0.14.0->qdrant-client) (6.0.1)\n",
+      "Requirement already satisfied: anyio<5.0,>=3.0 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from httpcore<0.17.0,>=0.15.0->httpx[http2]>=0.14.0->qdrant-client) (3.6.2)\n",
+      "Requirement already satisfied: h11<0.15,>=0.13 in /home/kacper/.virtualenvs/openai-cookbook/lib/python3.10/site-packages (from httpcore<0.17.0,>=0.15.0->httpx[http2]>=0.14.0->qdrant-client) (0.14.0)\n",
+      "Installing collected packages: langchain\n",
+      "  Attempting uninstall: langchain\n",
+      "    Found existing installation: langchain 0.0.88\n",
+      "    Uninstalling langchain-0.0.88:\n",
+      "      Successfully uninstalled langchain-0.0.88\n",
+      "Successfully installed langchain-0.0.70\n",
+      "\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip available: \u001B[0m\u001B[31;49m22.3.1\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m23.0\u001B[0m\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "! pip install openai qdrant-client \"langchain==0.0.87\" wget"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Prepare your OpenAI API key\n",
+    "\n",
+    "The OpenAI API key is used for vectorization of the documents and queries.\n",
+    "\n",
+    "If you don't have an OpenAI API key, you can get one from [https://beta.openai.com/account/api-keys](https://beta.openai.com/account/api-keys).\n",
+    "\n",
+    "Once you get your key, please add it to your environment variables as `OPENAI_API_KEY`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-16T17:06:29.206718Z",
+     "start_time": "2023-02-16T17:06:29.202344Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OPENAI_API_KEY is ready\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Test that your OpenAI API key is correctly set as an environment variable\n",
+    "# Note. if you run this notebook locally, you will need to reload your terminal and the notebook for the env variables to be live.\n",
+    "import os\n",
+    "\n",
+    "# Note. alternatively you can set a temporary env variable like this:\n",
+    "# os.environ[\"OPENAI_API_KEY\"] = \"sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"\n",
+    "\n",
+    "if os.getenv(\"OPENAI_API_KEY\") is not None:\n",
+    "    print(\"OPENAI_API_KEY is ready\")\n",
+    "else:\n",
+    "    print(\"OPENAI_API_KEY environment variable not found\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load data\n",
+    "\n",
+    "In this section we are going to load the data containing some natural questions and answers to them. All the data will be used to create a Langchain application with Qdrant being the knowledge base."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-16T17:06:30.144430Z",
+     "start_time": "2023-02-16T17:06:29.212729Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--2023-02-16 18:06:29--  https://storage.googleapis.com/dataset-natural-questions/questions.json\n",
+      "Resolving storage.googleapis.com (storage.googleapis.com)... 142.250.203.208, 216.58.208.208, 142.250.75.16, ...\n",
+      "Connecting to storage.googleapis.com (storage.googleapis.com)|142.250.203.208|:443... connected.\n",
+      "HTTP request sent, awaiting response... 416 Requested range not satisfiable\n",
+      "\n",
+      "    The file is already fully retrieved; nothing to do.\n",
+      "\n",
+      "--2023-02-16 18:06:29--  https://storage.googleapis.com/dataset-natural-questions/answers.json\n",
+      "Resolving storage.googleapis.com (storage.googleapis.com)... 216.58.208.208, 142.250.186.208, 216.58.215.112, ...\n",
+      "Connecting to storage.googleapis.com (storage.googleapis.com)|216.58.208.208|:443... connected.\n",
+      "HTTP request sent, awaiting response... 416 Requested range not satisfiable\n",
+      "\n",
+      "    The file is already fully retrieved; nothing to do.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# All the examples come from https://ai.google.com/research/NaturalQuestions\n",
+    "# This is a sample of the training set that we download and extract for some\n",
+    "# futher processing.\n",
+    "\n",
+    "!wget -c https://storage.googleapis.com/dataset-natural-questions/questions.json\n",
+    "!wget -c https://storage.googleapis.com/dataset-natural-questions/answers.json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-16T17:09:31.352487Z",
+     "start_time": "2023-02-16T17:09:31.343483Z"
+    },
+    "code_folding": []
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "with open(\"questions.json\", \"r\") as fp:\n",
+    "    questions = json.load(fp)\n",
+    "\n",
+    "with open(\"answers.json\", \"r\") as fp:\n",
+    "    answers = json.load(fp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-16T17:09:31.915856Z",
+     "start_time": "2023-02-16T17:09:31.908270Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "when is the last episode of season 8 of the walking dead\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(questions[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-16T17:09:32.777080Z",
+     "start_time": "2023-02-16T17:09:32.768859Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No . overall No. in season Title Directed by Written by Original air date U.S. viewers ( millions ) 100 `` Mercy '' Greg Nicotero Scott M. Gimple October 22 , 2017 ( 2017 - 10 - 22 ) 11.44 Rick , Maggie , and Ezekiel rally their communities together to take down Negan . Gregory attempts to have the Hilltop residents side with Negan , but they all firmly stand behind Maggie . The group attacks the Sanctuary , taking down its fences and flooding the compound with walkers . With the Sanctuary defaced , everyone leaves except Gabriel , who reluctantly stays to save Gregory , but is left behind when Gregory abandons him . Surrounded by walkers , Gabriel hides in a trailer , where he is trapped inside with Negan . 101 `` The Damned '' Rosemary Rodriguez Matthew Negrete & Channing Powell October 29 , 2017 ( 2017 - 10 - 29 ) 8.92 Rick 's forces split into separate parties to attack several of the Saviors ' outposts , during which many members of the group are killed ; Eric is critically injured and rushed away by Aaron . Jesus stops Tara and Morgan from executing a group of surrendered Saviors . While clearing an outpost with Daryl , Rick is confronted and held at gunpoint by Morales , a survivor he met in the initial Atlanta camp , who is now with the Saviors . 102 `` Monsters '' Greg Nicotero Matthew Negrete & Channing Powell November 5 , 2017 ( 2017 - 11 - 05 ) 8.52 Daryl finds Morales threatening Rick and kills him ; the duo then pursue a group of Saviors who are transporting weapons to another outpost . Gregory returns to Hilltop , and after a heated argument , Maggie ultimately allows him back in the community . Eric dies from his injuries , leaving Aaron distraught . Despite Tara and Morgan 's objections , Jesus leads the group of surrendered Saviors to Hilltop . Ezekiel 's group attacks another Savior compound , during which several Kingdommers are shot while protecting Ezekiel . 103 `` Some Guy '' Dan Liu David Leslie Johnson November 12 , 2017 ( 2017 - 11 - 12 ) 8.69 Ezekiel 's group is overwhelmed by the Saviors , who kill all of them except for Ezekiel himself and Jerry . Carol clears the inside of the compound , killing all but two Saviors , who almost escape but are eventually caught by Rick and Daryl . En route to the Kingdom , Ezekiel , Jerry , and Carol are surrounded by walkers , but Shiva sacrifices herself to save them . The trio returns to the Kingdom , where Ezekiel 's confidence in himself as a leader has diminished . 104 5 `` The Big Scary U '' Michael E. Satrazemis Story by : Scott M. Gimple & David Leslie Johnson & Angela Kang Teleplay by : David Leslie Johnson & Angela Kang November 19 , 2017 ( 2017 - 11 - 19 ) 7.85 After confessing their sins to each other , Gabriel and Negan manage to escape from the trailer . Simon and the other lieutenants grow suspicious of each other , knowing that Rick 's forces must have inside information . The workers in the Sanctuary become increasingly frustrated with their living conditions , and a riot nearly ensues , until Negan returns and restores order . Gabriel is locked in a cell , where Eugene discovers him sick and suffering . Meanwhile , Rick and Daryl argue over how to take out the Saviors , leading Daryl to abandon Rick . 105 6 `` The King , the Widow , and Rick '' John Polson Angela Kang & Corey Reed November 26 , 2017 ( 2017 - 11 - 26 ) 8.28 Rick visits Jadis in hopes of convincing her to turn against Negan ; Jadis refuses , and locks Rick in a shipping container . Carl encounters Siddiq in the woods and recruits him to Alexandria . Daryl and Tara plot to deviate from Rick 's plans by destroying the Sanctuary . Ezekiel isolates himself at the Kingdom , where Carol tries to encourage him to be the leader his people need . Maggie has the group of captured Saviors placed in a holding area and forces Gregory to join them as punishment for betraying Hilltop . 106 7 `` Time for After '' Larry Teng Matthew Negrete & Corey Reed December 3 , 2017 ( 2017 - 12 - 03 ) 7.47 After learning of Dwight 's association with Rick 's group , Eugene affirms his loyalty to Negan and outlines a plan to get rid of the walkers surrounding the Sanctuary . With help from Morgan and Tara , Daryl drives a truck through the Sanctuary 's walls , flooding its interior with walkers , killing many Saviors . Rick finally convinces Jadis and the Scavengers to align with him , and they plan to force the Saviors to surrender . However , when they arrive at the Sanctuary , Rick is horrified to see the breached walls and no sign of the walker herd . 107 8 `` How It 's Gotta Be '' Michael E. Satrazemis David Leslie Johnson & Angela Kang December 10 , 2017 ( 2017 - 12 - 10 ) 7.89 Eugene 's plan allows the Saviors to escape , and separately , the Saviors waylay the Alexandria , Hilltop , and Kingdom forces . The Scavengers abandon Rick , after which he returns to Alexandria . Ezekiel ensures that the Kingdom residents are able to escape before locking himself in the community with the Saviors . Eugene aids Gabriel and Doctor Carson in escaping the Sanctuary in order to ease his conscience . Negan attacks Alexandria , but Carl devises a plan to allow the Alexandria residents to escape into the sewers . Carl reveals he was bitten by a walker while escorting Siddiq to Alexandria . 108 9 `` Honor '' Greg Nicotero Matthew Negrete & Channing Powell February 25 , 2018 ( 2018 - 02 - 25 ) 8.28 After the Saviors leave Alexandria , the survivors make for the Hilltop while Rick and Michonne stay behind to say their final goodbyes to a dying Carl , who pleads with Rick to build a better future alongside the Saviors before killing himself . In the Kingdom , Morgan and Carol launch a rescue mission for Ezekiel . Although they are successful and retake the Kingdom , the Saviors ' lieutenant Gavin is killed by Benjamin 's vengeful brother Henry . 109 10 `` The Lost and the Plunderers '' TBA TBA March 4 , 2018 ( 2018 - 03 - 04 ) TBD 110 11 `` Dead or Alive Or '' TBA TBA March 11 , 2018 ( 2018 - 03 - 11 ) TBD 111 12 `` The Key '' TBA TBA March 18 , 2018 ( 2018 - 03 - 18 ) TBD\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(answers[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Chain definition\n",
+    "\n",
+    "Langchain is already integrated with Qdrant and performs all the indexing for given list of documents. In our case we are going to store the set of answers we have."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-16T17:10:06.470388Z",
+     "start_time": "2023-02-16T17:09:34.000011Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from langchain.vectorstores import Qdrant\n",
+    "from langchain.embeddings import OpenAIEmbeddings\n",
+    "from langchain import VectorDBQA, OpenAI\n",
+    "\n",
+    "embeddings = OpenAIEmbeddings()\n",
+    "doc_store = Qdrant.from_texts(\n",
+    "    answers, embeddings, host=\"localhost\" \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At this stage all the possible answers are already stored in Qdrant, so we can define the whole QA chain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-16T17:10:06.482311Z",
+     "start_time": "2023-02-16T17:10:06.476817Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "llm = OpenAI()\n",
+    "qa = VectorDBQA.from_chain_type(\n",
+    "    llm=llm, \n",
+    "    chain_type=\"stuff\", \n",
+    "    vectorstore=doc_store,\n",
+    "    return_source_documents=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Search data\n",
+    "\n",
+    "Once the data is put into Qdrant we can start asking some questions. A question will be automatically vectorized by OpenAI model, and the created vector will be used to find some possibly matching answers in Qdrant. Once retrieved, the most similar answers will be incorporated into the prompt sent to OpenAI Large Language Model. The communication between all the services is shown on a graph:\n",
+    "\n",
+    "![](https://qdrant.tech/articles_data/langchain-integration/flow-diagram.png)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-16T17:10:06.573641Z",
+     "start_time": "2023-02-16T17:10:06.567032Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "\n",
+    "random.seed(76)\n",
+    "selected_questions = random.choices(questions, k=5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-16T17:18:24.098392Z",
+     "start_time": "2023-02-16T17:18:11.847165Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> what kind of music is scott joplin most famous for\n",
+      " Scott Joplin is most famous for composing ragtime music.\n",
+      "\n",
+      "> who died from the band faith no more\n",
+      " Chuck Mosley died on November 9, 2017, due to \"the disease of addiction.\" He was 57 years old.\n",
+      "\n",
+      "> when does maggie come on grey's anatomy\n",
+      " Maggie (Kelly McCreary) first appears in the 14th season of Grey's Anatomy, which premiered on September 28, 2017.\n",
+      "\n",
+      "> can't take my eyes off you lyrics meaning\n",
+      " I don't know.\n",
+      "\n",
+      "> who lasted the longest on alone season 2\n",
+      " David McIntyre lasted the longest on Alone season 2; he won the season with 66 days.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for question in selected_questions:\n",
+    "    print(\">\", question)\n",
+    "    print(qa.run(question), end=\"\\n\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/examples/vector_databases/qdrant/docker-compose.yaml
+++ b/examples/vector_databases/qdrant/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   qdrant:
-    image: qdrant/qdrant:v0.11.7
+    image: qdrant/qdrant:v1.0.1
     restart: on-failure
     ports:
       - "6333:6333"


### PR DESCRIPTION
This PR adds two additional notebooks on how to use Qdrant as a vector database with OpenAI embeddings. The changes include the following:
- "Getting started with Qdrant and OpenAI" notebook with end-to-end processing of search using the embeddings
- "QA with Langchain Qdrant and OpenAI" notebook with an example of using Qdrant and OpenAI in a Langchain application to create a Question-Answering system. The library is becoming popular, and due to many questions around that, I want to show that case.

@colin-openai, Could you please review the notebooks?