### PR TITLE
Fix error in compute_doc_embeddings example to return expected value/shape in Question_answering_using_embeddings.ipynb

### DIFF
--- a/examples/Question_answering_using_embeddings.ipynb
+++ b/examples/Question_answering_using_embeddings.ipynb
@@ -340,7 +340,7 @@
     "    Return a dictionary that maps between each embedding vector and the index of the row that it corresponds to.\n",
     "    \"\"\"\n",
     "    return {\n",
-    "        idx: get_embedding(r.content) for idx, r in df.iterrows()\n",
+    "        (r.title, r.heading): get_embedding(r.content) for idx, r in df.iterrows()\n",
     "    }"
    ]
   },


### PR DESCRIPTION
From reading the code sample in the notebook below this change I can see that these 2 functions (compute_doc_embeddings and load_embeddings) were supposed to return the same "shape". This PR is to fix this issue that may not be noticed because the code calling compute_doc_embeddings is commented out.

```

    document_embeddings = load_embeddings("https://cdn.openai.com/API/examples/data/olympics_sections_document_embeddings.csv")

    # ===== OR, uncomment the below line to recaculate the embeddings from scratch. ========

    # document_embeddings = compute_doc_embeddings(df)
```