### PR TITLE
Fixes logging to use Flask's default logging config

### DIFF
--- a/apps/file-q-and-a/nextjs-with-flask-server/server/answer_question.py
+++ b/apps/file-q-and-a/nextjs-with-flask-server/server/answer_question.py
@@ -1,3 +1,4 @@
+import logging
 from utils import get_embedding
 from flask import jsonify
 from config import *

--- a/apps/file-q-and-a/nextjs-with-flask-server/server/app.py
+++ b/apps/file-q-and-a/nextjs-with-flask-server/server/app.py
@@ -10,27 +10,11 @@ import logging
 from flask import Flask, jsonify
 from flask_cors import CORS, cross_origin
 from flask import request
+from flask.logging import default_handler
 
 from handle_file import handle_file
 from answer_question import get_answer_from_files
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[
-        logging.FileHandler("debug.log"),
-        logging.StreamHandler(sys.stdout)
-    ]
-)
-
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[
-        logging.FileHandler("debug.log"),
-        logging.StreamHandler(sys.stdout)
-    ]
-)
 
 def load_pinecone_index() -> pinecone.Index:
     """
@@ -97,4 +81,8 @@ def healthcheck():
     return "OK"
 
 if __name__ == "__main__":
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    # add flask's logging handler to the root logger
+    root.addHandler(default_handler)
     app.run(debug=True, port=SERVER_PORT, threaded=True)

--- a/apps/file-q-and-a/nextjs-with-flask-server/server/handle_file.py
+++ b/apps/file-q-and-a/nextjs-with-flask-server/server/handle_file.py
@@ -9,15 +9,6 @@ from config import *
 
 from utils import get_embeddings, get_pinecone_id_for_file_chunk
 
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[
-        logging.FileHandler("debug.log"),
-        logging.StreamHandler(sys.stdout)
-    ]
-)
 
 # Handle a file by extracting its text, creating embeddings, and upserting them to Pinecone
 def handle_file(file, session_id, pinecone_index, tokenizer):

--- a/apps/file-q-and-a/nextjs-with-flask-server/server/utils.py
+++ b/apps/file-q-and-a/nextjs-with-flask-server/server/utils.py
@@ -5,14 +5,6 @@ import time
 
 from config import *
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[
-        logging.FileHandler("debug.log"),
-        logging.StreamHandler(sys.stdout)
-    ]
-)
 
 def get_pinecone_id_for_file_chunk(session_id, filename, chunk_index):
     return str(session_id+"-!"+filename+"-!"+str(chunk_index))


### PR DESCRIPTION
Flask sets up its logger and doesn't touch the root python logger. This patch centralizes the logging code in app.py and copies the default flask logger config to the root logger