### PR TITLE
Fix typo in `techniques_to_improve_reliability.md`

### DIFF
--- a/techniques_to_improve_reliability.md
+++ b/techniques_to_improve_reliability.md
@@ -201,7 +201,7 @@ Although the `Let's think step by step` trick works well on math problems, it's 
 
 To learn more, read the [full paper](https://arxiv.org/abs/2205.11916).
 
-If you apply this technique to your own tasks, don't be afraid to experiment with customizing the instruction. `Let's think step by step` is rather generic, so you may find better performance with instructions that hew to a stricter format customized to your use case. For example, if you were  you can try more structured variants like `First, think step by step about why X might be true. Second, think step by step about why Y might be true. Third, think step by step about whether X or Y makes more sense.`. And you can even give the model an example format to help keep it on track, e.g.:
+If you apply this technique to your own tasks, don't be afraid to experiment with customizing the instruction. `Let's think step by step` is rather generic, so you may find better performance with instructions that hew to a stricter format customized to your use case. For example, you can try more structured variants like `First, think step by step about why X might be true. Second, think step by step about why Y might be true. Third, think step by step about whether X or Y makes more sense.`. And you can even give the model an example format to help keep it on track, e.g.:
 
 ```text-davinci-002
 Using the IRS guidance below, answer the following questions using this format:


### PR DESCRIPTION
Propose the following change: 
 - "For example, if you were you can try more..." -> "For example, you can try more..."

I think that "wanted" instead of "were" was originally intended. However, I think "if you wanted" is unnecessary here.