### PR TITLE
Upload file size error default 4 mb extended to 30mb

### DIFF
--- a/apps/file-q-and-a/nextjs/src/pages/api/process-file.ts
+++ b/apps/file-q-and-a/nextjs/src/pages/api/process-file.ts
@@ -5,7 +5,19 @@ import { TextEmbedding } from "../../types/file";
 import extractTextFromFile from "../../services/extractTextFromFile";
 import { createEmbeddings } from "../../services/createEmbeddings";
 
-// Disable the default body parser to handle file uploads
+
+//insteade of disabling the default body parser we can define the fix sizelimit to :30mb   
+export const config = {
+    api: {
+        bodyParser: {
+            sizeLimit: '30mb',
+        }
+    }
+};
+
+
+
+
 export const config = { api: { bodyParser: false } };
 
 type Data = {


### PR DESCRIPTION
## Description
# API/process-files exceed the default file size that was set to default 4 MB by process.ts. 

## Related [Issue](https://github.com/openai/openai-cookbook/issues/248)

## Motivation and Context
# i changes that default size to a fixed size for API to handle a size equal to what was stated in the fronted to be 30 MB exact.

## How Has This Been Tested?
## i tried to test it but there was to test file present

## Screenshots (if appropriate):
### none