### PR TITLE
Added or link.startswith("tel:") in the condition to exclude tel: links from clean links.

### DIFF
--- a/apps/web-crawl-q-and-a/web-qa.py
+++ b/apps/web-crawl-q-and-a/web-qa.py
@@ -87,7 +87,11 @@ def get_domain_hyperlinks(local_domain, url):
         else:
             if link.startswith("/"):
                 link = link[1:]
-            elif link.startswith("#") or link.startswith("mailto:"):
+            elif (
+                link.startswith("#")
+                or link.startswith("mailto:")
+                or link.startswith("tel:")
+            ):
                 continue
             clean_link = "https://" + local_domain + "/" + link
 


### PR DESCRIPTION
Updated the get_domain_hyperlinks function to include handling of tel: links in addition to mailto: links, to exclude them from the clean links list.