### PR TITLE
update wget to new langchain docs url

### DIFF
--- a/examples/vector_databases/pinecone/GPT4_Retrieval_Augmentation.ipynb
+++ b/examples/vector_databases/pinecone/GPT4_Retrieval_Augmentation.ipynb
@@ -103,7 +103,7 @@
         }
       ],
       "source": [
-        "!wget -r -A.html -P rtdocs https://langchain.readthedocs.io/en/latest/"
+        "!wget -r -A.html -P rtdocs https://python.langchain.com/en/latest/"
       ]
     },
     {


### PR DESCRIPTION
LangChain docs url has changed so the !wget in GPT4_Retrieval_Augmentation.ipynb no longer works as intended, as raised in #319 — this PR fixes that.