### PR TITLE
Update the section token count from 1,000 to 1,600

### DIFF
--- a/examples/Embedding_Wikipedia_articles_for_search.ipynb
+++ b/examples/Embedding_Wikipedia_articles_for_search.ipynb
@@ -411,7 +411,7 @@
     "- Shorter sections allow more sections to be retrieved, which may help with recall\n",
     "- Overlapping sections may help prevent answers from being cut by section boundaries\n",
     "\n",
-    "Here, we'll use a simple approach and limit sections to 1,000 tokens each, recursively halving any sections that are too long. To avoid cutting in the middle of useful sentences, we'll split along paragraph boundaries when possible."
+    "Here, we'll use a simple approach and limit sections to 1,600 tokens each, recursively halving any sections that are too long. To avoid cutting in the middle of useful sentences, we'll split along paragraph boundaries when possible."
    ]
   },
   {


### PR DESCRIPTION
This resolves the mismatch between the values in markdown cell and code cell which may confuse readers.

(BTW, between this and the downstream Q&A example, I believe this notebook is a far more valuable example.)