### PR TITLE
Fix formidable 2.1.1 compatibility

### DIFF
--- a/apps/file-q-and-a/nextjs/src/pages/api/process-file.ts
+++ b/apps/file-q-and-a/nextjs/src/pages/api/process-file.ts
@@ -26,8 +26,10 @@ export default async function handler(
   }
 
   // Create a formidable instance to parse the request as a multipart form
-  const form = new formidable.IncomingForm();
-  form.maxFileSize = 30 * 1024 * 1024; // Set the max file size to 30MB
+  const form = new formidable.IncomingForm({
+    maxFileSize: 30 * 1024 * 1024
+  });
+  // Set the max file size to 30MB
 
   try {
     const { fields, files } = await new Promise<{


### PR DESCRIPTION
The `file-q-and-a` application is not compatible to the current `formidable.js 2.1.1` library. The error occurs when running `npm run build`.