### PR TITLE
Add ability to store row-level metadata

### DIFF
--- a/examples/data/example_requests_to_parallel_process.jsonl
+++ b/examples/data/example_requests_to_parallel_process.jsonl
@@ -1,4 +1,4 @@
-{"model": "text-embedding-ada-002", "input": "0\n"}
+{"model": "text-embedding-ada-002", "input": "0\n", "metadata": {"row_id": 1}}
 {"model": "text-embedding-ada-002", "input": "1\n"}
 {"model": "text-embedding-ada-002", "input": "2\n"}
 {"model": "text-embedding-ada-002", "input": "3\n"}


### PR DESCRIPTION
This metadata field allows non API parameters to be stored which could be useful for when the results need to be associated with an external source. For example, if the user has several rows of text data within a database, and they want to calculate embeddings for each row, they can now use the metadata field to save the row id so that when they parse the results back, they know which embedding corresponds to which database row.