### PR TITLE
Fix wget download updated parameters

### DIFF
--- a/examples/vector_databases/redis/nbutils.py
+++ b/examples/vector_databases/redis/nbutils.py
@@ -23,7 +23,7 @@ def download_wikipedia_data(
         else:
             print("File not found, downloading now...")
             # Download the data
-            wget.download(data_url, out=download_path, bar=True)
+            wget.download(data_url, out=download_path)
 
         # Unzip the data
         with zipfile.ZipFile(zip_file_path, 'r') as zip_ref:


### PR DESCRIPTION
Execution of getting-started-with-redis-and-openai.ipynb was failing due to broken parameters in wget call in nbutils.py
@Spartee @colin-openai 