### PR TITLE
Update How_to_call_functions_with_chat_models.ipynb

### DIFF
--- a/examples/How_to_call_functions_with_chat_models.ipynb
+++ b/examples/How_to_call_functions_with_chat_models.ipynb
@@ -81,7 +81,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@retry(wait=wait_random_exponential(min=1, max=40), stop=stop_after_attempt(3))\n",
+    "@retry(wait=wait_random_exponential(multiplier=1, max=40), stop=stop_after_attempt(3))\n",
     "def chat_completion_request(messages, functions=None, function_call=None, model=GPT_MODEL):\n",
     "    headers = {\n",
     "        \"Content-Type\": \"application/json\",\n",


### PR DESCRIPTION
The original had "min" and "max" parameters. "max" is a real parameter - the max time, i.e. timeout. There's no "min" parameter. It should be "multiplier".

https://tenacity.readthedocs.io/en/latest/api.html