### PR TITLE
Fix UTF-8 encoding in Chat_finetuning_data_prep.ipynb

### DIFF
--- a/examples/Chat_finetuning_data_prep.ipynb
+++ b/examples/Chat_finetuning_data_prep.ipynb
@@ -8,7 +8,6 @@
    "outputs": [],
    "source": [
     "import json\n",
-    "import os\n",
     "import tiktoken\n",
     "import numpy as np\n",
     "from collections import defaultdict"
@@ -32,7 +31,7 @@
    "outputs": [],
    "source": [
     "# Load dataset\n",
-    "with open(data_path) as f:\n",
+    "with open(data_path, 'r', encoding='utf-8') as f:\n",
     "    dataset = [json.loads(line) for line in f]"
    ]
   },


### PR DESCRIPTION
The following fixes checking .jsonl finetuning files that contain UTF-8 characters, specifically the error "UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 737: character maps to <undefined".

I also removed an unused "os" import.
