### PR TITLE
Add Cassandra/Astra DB to the vector databases overall README

### DIFF
--- a/examples/vector_databases/README.md
+++ b/examples/vector_databases/README.md
@@ -8,6 +8,7 @@ Each provider has their own named directory, with a standard notebook to introdu
 
 ## Guides & deep dives
 - [AnalyticDB](https://www.alibabacloud.com/help/en/analyticdb-for-postgresql/latest/get-started-with-analyticdb-for-postgresql)
+- [Cassandra/Astra DB](https://docs.datastax.com/en/astra-serverless/docs/vector-search/overview.html)
 - [Chroma](https://docs.trychroma.com/getting-started)
 - [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html)
 - [Hologres](https://www.alibabacloud.com/help/en/hologres/latest/procedure-to-use-hologres)

--- a/examples/vector_databases/README.md
+++ b/examples/vector_databases/README.md
@@ -8,7 +8,7 @@ Each provider has their own named directory, with a standard notebook to introdu
 
 ## Guides & deep dives
 - [AnalyticDB](https://www.alibabacloud.com/help/en/analyticdb-for-postgresql/latest/get-started-with-analyticdb-for-postgresql)
-- [Cassandra/Astra DB](https://docs.datastax.com/en/astra-serverless/docs/vector-search/overview.html)
+- [Cassandra/Astra DB](https://docs.datastax.com/en/astra-serverless/docs/vector-search/qandasimsearch-quickstart.html)
 - [Chroma](https://docs.trychroma.com/getting-started)
 - [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html)
 - [Hologres](https://www.alibabacloud.com/help/en/hologres/latest/procedure-to-use-hologres)


### PR DESCRIPTION
As a complement to #655 , this adds the "Cassandra/Astra DB" entry to the `vector_databases/README.md` listing of vector-DB providers.

