### PR TITLE
Fix broken OpenAI API link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
  
 > ✨ Navigate at [cookbook.openai.com](https://cookbook.openai.com)
 
-Example code and guides for accomplishing common tasks with the [OpenAI API](https://openai.com/api/). To run these examples, you'll need an OpenAI account and associated API key ([create a free account here](https://beta.openai.com/signup)).
+Example code and guides for accomplishing common tasks with the [OpenAI API](https://platform.openai.com/). To run these examples, you'll need an OpenAI account and associated API key ([create a free account here](https://beta.openai.com/signup)).
 
 Most code examples are written in Python, though the concepts can be applied in any language.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
  
 > ✨ Navigate at [cookbook.openai.com](https://cookbook.openai.com)
 
-Example code and guides for accomplishing common tasks with the [OpenAI API](https://platform.openai.com/). To run these examples, you'll need an OpenAI account and associated API key ([create a free account here](https://beta.openai.com/signup)).
+Example code and guides for accomplishing common tasks with the [OpenAI API](https://platform.openai.com/docs/introduction). To run these examples, you'll need an OpenAI account and associated API key ([create a free account here](https://beta.openai.com/signup)).
 
 Most code examples are written in Python, though the concepts can be applied in any language.
 


### PR DESCRIPTION
## Summary

This link in the about/ page: https://openai.com/api/  is a 404. Updated the link to https://platform.openai.com/. 

Note - I could switch it to the actual API reference instead - https://platform.openai.com/docs/api-reference - happy to change the link.

## Changes

Update broken README link. 