### PR TITLE
Add support for Azure deployment endpoints

### DIFF
--- a/examples/api_request_parallel_processor.py
+++ b/examples/api_request_parallel_processor.py
@@ -132,6 +132,9 @@ async def process_api_requests_from_file(
     # infer API endpoint and construct request header
     api_endpoint = api_endpoint_from_url(request_url)
     request_header = {"Authorization": f"Bearer {api_key}"}
+    # use api-key header for Azure deployments
+    if '/deployments' in request_url:
+        request_header = {"api-key": f"{api_key}"}
 
     # initialize trackers
     queue_of_requests_to_retry = asyncio.Queue()
@@ -366,6 +369,9 @@ class APIRequest:
 def api_endpoint_from_url(request_url):
     """Extract the API endpoint from the request URL."""
     match = re.search("^https://[^/]+/v\\d+/(.+)$", request_url)
+    if match is None:
+        # for Azure OpenAI deployment urls
+        match = re.search(r"^https://[^/]+/openai/deployments/[^/]+/(.+?)(\?|$)", request_url)
     return match[1]
 
 


### PR DESCRIPTION
## Summary

Updates api_request_parallel_processor.py to be used with Azure OpenAI service endpoints.

Changes: 
 * Extract Azure endpoints also
 * Use "api-key" header instead of "Authorization" for them
 
## Motivation

Using the script with Azure OpenAI deployments throws `NotImplementedError` error even though the 'completions' and 'embeddings' requests are implemented.
