### PR TITLE
Adds Supabase to list of vector databases

### DIFF
--- a/examples/vector_databases/README.md
+++ b/examples/vector_databases/README.md
@@ -23,6 +23,7 @@ Each provider has their own named directory, with a standard notebook to introdu
 - [Qdrant](https://qdrant.tech/documentation/quick-start/)
 - [Redis](https://github.com/RedisVentures/simple-vecsim-intro)
 - [SingleStoreDB](https://www.singlestore.com/blog/how-to-get-started-with-singlestore/)
+- [Supabase](https://supabase.com/docs/guides/ai)
 - [Typesense](https://typesense.org/docs/guide/)
 - [Weaviate](https://weaviate.io/developers/weaviate/quickstart)
 - [Zilliz](https://docs.zilliz.com/docs/quick-start-1)


### PR DESCRIPTION
## Summary

This adds Supabase (Postgres + pgvector) to the [list of vector databases](https://cookbook.openai.com/examples/vector_databases/readme).

## Motivation

Provides another vector database option (open source) that users can use alongside OpenAI.

Let me know if you have any thoughts or questions!