### PR TITLE
Specify Pre-v1.0.0 `openai` Library Version for Compatibility

### DIFF
--- a/examples/Fine_tuning_for_function_calling.ipynb
+++ b/examples/Fine_tuning_for_function_calling.ipynb
@@ -76,7 +76,7 @@
    "outputs": [],
    "source": [
     "# !pip install tenacity\n",
-    "# !pip insta openai\n",
+    "# !pip install openai==0.28.1\n",
     "# !pip install typing\n"
    ]
   },


### PR DESCRIPTION
## Summary

This PR includes a minor but crucial change to one of our Jupyter Notebook examples. The update specifically addresses an issue caused by the OpenAI Python library's transition to version 1.0.0, which altered the API and broke compatibility with our existing code. The change involves specifying that the notebook requires a version of the `openai` library that is older than v1.0.0 to function correctly. This ensures that users can run the notebook without encountering the API incompatibility issues.

## Motivation

The update is necessary to maintain the usability and reliability of our Cookbook. Since version 1.0.0 of the OpenAI Python library introduced breaking changes to the API, it directly impacted the functionality of our Jupyter Notebook. By specifying the required older version of the `openai` library, we ensure that users can seamlessly run and learn from the notebook without facing errors related to API changes. This small but significant change thus upholds the integrity and utility of our educational resources.