### PR TITLE
remove an empty code block on video example

### DIFF
--- a/examples/GPT_with_vision_for_video_understanding.ipynb
+++ b/examples/GPT_with_vision_for_video_understanding.ipynb
@@ -252,13 +252,6 @@
     "    audio += chunk\n",
     "Audio(audio)\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -277,7 +270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/examples/GPT_with_vision_for_video_understanding.ipynb
+++ b/examples/GPT_with_vision_for_video_understanding.ipynb
@@ -270,7 +270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Removes an empty code block at the end of https://cookbook.openai.com/examples/gpt_with_vision_for_video_understanding

## Motivation

I thought that the page was cut off and kept refreshing; looks like it's just an unintentional empty code block in an otherwise complete example.

(The python patch version change was not an intentional part of the commit but it looks like there is a variety of different version numbers throughout so I figured it's not important but can change back if needed)

---

## For new content

When contributing new content, read through our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md), and mark the following action items as completed:

- [ ] I have added a new entry in [registry.yaml](/registry.yaml) (and, optionally, in [authors.yaml](/authors.yaml)) so that my content renders on the cookbook website.
- [ ] I have conducted a self-review of my content based on the [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md#rubric):
  - [ ] Relevance: This content is related to building with OpenAI technologies and is useful to others.
  - [ ] Uniqueness: I have searched for related examples in the OpenAI Cookbook, and verified that my content offers new insights or unique information compared to existing documentation.
  - [ ] Spelling and Grammar: I have checked for spelling or grammatical mistakes.
  - [ ] Clarity: I have done a final read-through and verified that my submission is well-organized and easy to understand.
  - [ ] Correctness: The information I include is correct and all of my code executes successfully.
  - [ ] Completeness: I have explained everything fully, including all necessary references and citations.

We will rate each of these areas on a scale from 1 to 4, and will only accept contributions that score 3 or higher on all areas. Refer to our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md) for more details.
