### PR TITLE
Removed api_key when using Azure Active Directory

### DIFF
--- a/examples/azure/chat.ipynb
+++ b/examples/azure/chat.ipynb
@@ -115,7 +115,6 @@
     "\n",
     "if use_azure_active_directory:\n",
     "    endpoint = os.environ[\"AZURE_OPENAI_ENDPOINT\"]\n",
-    "    api_key = os.environ[\"AZURE_OPENAI_API_KEY\"]\n",
     "\n",
     "    client = openai.AzureOpenAI(\n",
     "        azure_endpoint=endpoint,\n",


### PR DESCRIPTION
## Summary

[The official document](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/switching-endpoints) states that an api_key is not necessary when using Azure Active Directory, and specifying an unnecessary api_key can lead to misunderstandings, so the api_key has been removed.

When using Azure Active Directory, [The official document](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/switching-endpoints) mentions that an api_key is not required. To avoid any misunderstanding that an api_key needs to be issued, the api_key has been removed.

