### PR TITLE
Update Philosophical_Quotes_CQL.ipynb

### DIFF
--- a/examples/vector_databases/cassandra_astradb/Philosophical_Quotes_CQL.ipynb
+++ b/examples/vector_databases/cassandra_astradb/Philosophical_Quotes_CQL.ipynb
@@ -96,7 +96,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install --quiet \"cassandra-driver>=0.28.0\" \"openai>=1.0.0\" datasets"
+    "!pip install --quiet \"cassandra-driver>=0.28.0\" \"openai>=1.0.0\" datasets tiktoken cohere"
    ]
   },
   {


### PR DESCRIPTION
## Summary

install tiktoken cohere

## Motivation

Otherwise it throws an error when running a notebook:

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
llmx 0.0.15a0 requires cohere, which is not installed.
llmx 0.0.15a0 requires tiktoken, which is not installed.
tensorflow-probability 0.22.0 requires typing-extensions<4.6.0, but you have typing-extensions 4.9.0 which is incompatible.
```
