### PR TITLE
Adds Tembo VectorDB to list of vector databases

### DIFF
--- a/examples/vector_databases/README.md
+++ b/examples/vector_databases/README.md
@@ -24,6 +24,7 @@ Each provider has their own named directory, with a standard notebook to introdu
 - [Redis](https://github.com/RedisVentures/simple-vecsim-intro)
 - [SingleStoreDB](https://www.singlestore.com/blog/how-to-get-started-with-singlestore/)
 - [Supabase](https://supabase.com/docs/guides/ai)
+- [Tembo](https://tembo.io/docs/tembo-stacks/vector-db)
 - [Typesense](https://typesense.org/docs/guide/)
 - [Weaviate](https://weaviate.io/developers/weaviate/quickstart)
 - [Zilliz](https://docs.zilliz.com/docs/quick-start-1)


### PR DESCRIPTION
## Summary

Adds [Tembo's](https://tembo.io/) [VectorDB Stack](https://tembo.io/docs/tembo-stacks/vector-db) to the list of vector databases.

## Motivation

The Tembo quick-start guide shows the user how to use the [pg_vectorize](https://github.com/tembo-io/pg_vectorize) extension, which is built on OpenAI's embeddings api and [pg vector](https://github.com/pgvector/pgvector). It is a high level API intended to be the quickest way to get started w/ OpenAI embeddings on Postgres.