### PR TITLE
Fix syntax error in W&B weave notebook

### DIFF
--- a/examples/third_party/Openai_monitoring_with_wandb_weave.ipynb
+++ b/examples/third_party/Openai_monitoring_with_wandb_weave.ipynb
@@ -119,7 +119,7 @@
       },
       "outputs": [],
       "source": [
-        "WB_ENTITY = # set to your wandb username or team name\n",
+        "WB_ENTITY = \"\" # set to your wandb username or team name\n",
         "WB_PROJECT = \"weave\" # top-level directory for this work\n",
         "STREAM_NAME = \"openai_logs\" # record table which stores the logs of OpenAI API calls as they stream in"
       ]


### PR DESCRIPTION
## Summary

This is a very minor change which updates the W&B Weave example notebook to use valid syntax.

## Motivation

For context, there's a variable which they want the user to assign a value to e.g. `FOO = # set a value` but this is invalid syntax and could be confusing to some users. I've edited it to be  `FOO = "" # set a value`. I discovered this while attempting to include this project in Ruff's ecosystem checks at https://github.com/astral-sh/ruff/pull/9293.

There is a minor chance that this would _increase_ confusion as the notebook will no longer fail with a syntax error if the user does not set a value. It'd be trivial to add additional code that checks the value of the variable and raises an informative error if that's a concern. I am happy to do so, but wanted to start with the smaller changer.
