### PR TITLE
Add link to relevant code alongs for several Pinecone guides

### DIFF
--- a/examples/Whisper_prompting_guide.ipynb
+++ b/examples/Whisper_prompting_guide.ipynb
@@ -20,6 +20,8 @@
     "\n",
     "These techniques are not especially reliable, but can be useful in some situations.\n",
     "\n",
+    "If you would like to know more about transcription using the Whisper API, via an interactive tutorial with an accompanying video, try [this code-along](https://www.datacamp.com/code-along/multimodal-ai-applications-langchain-openai-api).\n",
+    "\n",
     "## Comparison with GPT prompting\n",
     "\n",
     "Prompting Whisper is not the same as prompting GPT. For example, if you submit an attempted instruction like \"Format lists in Markdown format\", the model will not comply, as it follows the style of the prompt, rather than any instructions contained within.\n",

--- a/examples/vector_databases/pinecone/GPT4_Retrieval_Augmentation.ipynb
+++ b/examples/vector_databases/pinecone/GPT4_Retrieval_Augmentation.ipynb
@@ -65,6 +65,13 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "If you prefer an interactive tutorial with an accompanying video, try [this code-along](https://www.datacamp.com/code-along/retrieval-augmented-generation-openai-api-pinecone)."
+      ]
+    },
+    {
       "attachments": {},
       "cell_type": "markdown",
       "metadata": {},

--- a/examples/vector_databases/pinecone/Semantic_Search.ipynb
+++ b/examples/vector_databases/pinecone/Semantic_Search.ipynb
@@ -34,6 +34,8 @@
         "\n",
         "![Architecture overview](https://files.readme.io/6a3ea5a-pinecone-openai-overview.png)\n",
         "\n",
+        "If you prefer an interactive tutorial with an accompanying video, try [this code-along](https://www.datacamp.com/code-along/semantic-search-pinecone).\n",
+        "\n",
         "Let's get started..."
       ]
     },

--- a/examples/vector_databases/pinecone/Using_Pinecone_for_embeddings_search.ipynb
+++ b/examples/vector_databases/pinecone/Using_Pinecone_for_embeddings_search.ipynb
@@ -9,6 +9,8 @@
     "\n",
     "This notebook takes you through a simple flow to download some data, embed it, and then index and search it using a selection of vector databases. This is a common requirement for customers who want to store and search our embeddings with their own data in a secure environment to support production use cases such as chatbots, topic modelling and more.\n",
     "\n",
+    "If you prefer an interactive tutorial with an accompanying video, try [this code-along](https://www.datacamp.com/code-along/semantic-search-pinecone).\n",
+    "\n",
     "### What is a Vector Database\n",
     "\n",
     "A vector database is a database made to store, manage and search embedding vectors. The use of embeddings to encode unstructured data (text, audio, video and more) as vectors for consumption by machine-learning models has exploded in recent years, due to the increasing effectiveness of AI in solving use cases involving natural language, image recognition and other unstructured forms of data. Vector databases have emerged as an effective solution for enterprises to deliver and scale these use cases.\n",


### PR DESCRIPTION
## Summary

This PR adds links to DataCamp code-along, which are interactive tutorials in a fully configured notebook environment, with an accompanying video that walks people through all the steps.

## Motivation

- These code-alongs are a great way for users to dive straight into the code and experiment without having to worry about setting up the right packages. Plus, it's free.
- To speak to the relevance / quality of these code-alongs:
  + [James Briggs](https://github.com/jamescalam) is the original author of the Semantic Search with Pinecone guide, and is also the presenter of the corresponding code along.
  + [Colin Jarvis](https://github.com/colin-openai) authored the notebook on Pinecone for Embeddings Search; he works with Logan Kilpatrick, who was a guest on DataCamp's DataFramed podcast.

