### PR TITLE
Fixed link to "techniques to improve reliability"

### DIFF
--- a/examples/How_to_format_inputs_to_ChatGPT_models.ipynb
+++ b/examples/How_to_format_inputs_to_ChatGPT_models.ipynb
@@ -416,7 +416,7 @@
     "\n",
     "As an example, one developer discovered an increase in accuracy when they inserted a user message that said \"Great job so far, these have been perfect\" to help condition the model into providing higher quality responses.\n",
     "\n",
-    "For more ideas on how to lift the reliability of the models, consider reading our guide on [techniques to increase reliability](../techniques_to_improve_reliability.md). It was written for non-chat models, but many of its principles still apply."
+    "For more ideas on how to lift the reliability of the models, consider reading our guide on [techniques to increase reliability](../techniques_to_improve_reliability). It was written for non-chat models, but many of its principles still apply."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Fixed link to "techniques to improve reliability" by removing .md extension

## Motivation

Minor correction.