### PR TITLE
Fix for counting rate limited errors as response has changed

### DIFF
--- a/authors.yaml
+++ b/authors.yaml
@@ -68,7 +68,7 @@ ggrn:
   website: "https://twitter.com/ggrdson"
   avatar: "https://pbs.twimg.com/profile_images/1371549909820657664/ZG-HDNlI_400x400.jpg"
 
-kshitijcosw:
+kshitijcode:
   name: "Kshitij Sharma"
   website: "https://www.linkedin.com/in/ikshitijsharma/"
   avatar: "https://media.licdn.com/dms/image/C4D03AQGZX7P4uZXlng/profile-displayphoto-shrink_200_200/0/1626322927298?e=1713398400&v=beta&t=0-Olbyxvy57xmHxobVkvAkYk9EAX6Luyg1oRbEAioE8"

--- a/authors.yaml
+++ b/authors.yaml
@@ -67,3 +67,8 @@ ggrn:
   name: "Greg Richardson"
   website: "https://twitter.com/ggrdson"
   avatar: "https://pbs.twimg.com/profile_images/1371549909820657664/ZG-HDNlI_400x400.jpg"
+
+kshitijcosw:
+  name: "Kshitij Sharma"
+  website: "https://www.linkedin.com/in/ikshitijsharma/"
+  avatar: "https://media.licdn.com/dms/image/C4D03AQGZX7P4uZXlng/profile-displayphoto-shrink_200_200/0/1626322927298?e=1713398400&v=beta&t=0-Olbyxvy57xmHxobVkvAkYk9EAX6Luyg1oRbEAioE8"

--- a/examples/api_request_parallel_processor.py
+++ b/examples/api_request_parallel_processor.py
@@ -322,7 +322,7 @@ class APIRequest:
                 )
                 status_tracker.num_api_errors += 1
                 error = response
-                if "Rate limit" in response["error"].get("message", ""):
+                if error['error']['code'] == '429':
                     status_tracker.time_of_last_rate_limit_error = time.time()
                     status_tracker.num_rate_limit_errors += 1
                     status_tracker.num_api_errors -= (


### PR DESCRIPTION
## Summary

Fix for counting rate limited errors as response has changed and the current code doesnt increase the count. 

This check is never true even if rate limited :  

`if "Rate limit" in response["error"].get("message", ""):`


## Motivation

Why are these changes necessary? How do they improve the cookbook?

Gives the correct count for num_rate_limit_errors.


---

## For new content

When contributing new content, read through our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md), and mark the following action items as completed:

- [x] I have added a new entry in [registry.yaml](https://github.com/openai/openai-cookbook/blob/main/registry.yaml) (and, optionally, in [authors.yaml](https://github.com/openai/openai-cookbook/blob/main/authors.yaml)) so that my content renders on the cookbook website.
- [x] I have conducted a self-review of my content based on the [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md#rubric):
  - [x] Relevance: This content is related to building with OpenAI technologies and is useful to others.
  - [x] Uniqueness: I have searched for related examples in the OpenAI Cookbook, and verified that my content offers new insights or unique information compared to existing documentation.
  - [x] Spelling and Grammar: I have checked for spelling or grammatical mistakes.
  - [x] Clarity: I have done a final read-through and verified that my submission is well-organized and easy to understand.
  - [x] Correctness: The information I include is correct and all of my code executes successfully.
  - [x] Completeness: I have explained everything fully, including all necessary references and citations.

We will rate each of these areas on a scale from 1 to 4, and will only accept contributions that score 3 or higher on all areas. Refer to our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md) for more details.
