### PR TITLE
fix: bug on the unused arguments query and top_k in function get_arti…

### DIFF
--- a/examples/How_to_call_functions_for_knowledge_retrieval.ipynb
+++ b/examples/How_to_call_functions_for_knowledge_retrieval.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "80e71f33",
    "metadata": {
     "pycharm": {
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 16,
    "id": "dab872c5",
    "metadata": {},
    "outputs": [],
@@ -73,7 +73,7 @@
     "\n",
     "GPT_MODEL = \"gpt-3.5-turbo-0613\"\n",
     "EMBEDDING_MODEL = \"text-embedding-ada-002\"\n",
-    "client = OpenAI()"
+    "client = OpenAI(api_key=\"\")"
    ]
   },
   {
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 10,
    "id": "57217b9d",
    "metadata": {},
    "outputs": [],
@@ -146,14 +146,14 @@
     "\n",
     "\n",
     "@retry(wait=wait_random_exponential(min=1, max=40), stop=stop_after_attempt(3))\n",
-    "def get_articles(query, library=paper_dir_filepath, top_k=5):\n",
+    "def get_articles(query, library=paper_dir_filepath, top_k=10):\n",
     "    \"\"\"This function gets the top_k articles based on a user's query, sorted by relevance.\n",
     "    It also downloads the files and stores them in arxiv_library.csv to be retrieved by the read_article_and_summarize.\n",
     "    \"\"\"\n",
     "    client = arxiv.Client()\n",
     "    search = arxiv.Search(\n",
-    "        query = \"quantum\",\n",
-    "        max_results = 10,\n",
+    "        query = query,\n",
+    "        max_results = top_k,\n",
     "        sort_by = arxiv.SortCriterion.SubmittedDate\n",
     "    )\n",
     "    result_list = []\n",
@@ -185,20 +185,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "id": "dda02bdb",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'title': 'Quantum types: going beyond qubits and quantum gates',\n",
-       " 'summary': 'Quantum computing is a growing field with significant potential applications.\\nLearning how to code quantum programs means understanding how qubits work and\\nlearning to use quantum gates. This is analogous to creating classical\\nalgorithms using logic gates and bits. Even after learning all concepts, it is\\ndifficult to create new algorithms, which hinders the acceptance of quantum\\nprogramming by most developers. This article outlines the need for higher-level\\nabstractions and proposes some of them in a developer-friendly programming\\nlanguage called Rhyme. The new quantum types are extensions of classical types,\\nincluding bits, integers, floats, characters, arrays, and strings. We show how\\nto use such types with code snippets.',\n",
-       " 'article_url': 'http://arxiv.org/abs/2401.15073v1',\n",
-       " 'pdf_url': 'http://arxiv.org/pdf/2401.15073v1'}"
+       "{'title': 'Unsolvable Problem Detection: Evaluating Trustworthiness of Vision Language Models',\n",
+       " 'summary': \"This paper introduces a novel and significant challenge for Vision Language\\nModels (VLMs), termed Unsolvable Problem Detection (UPD). UPD examines the\\nVLM's ability to withhold answers when faced with unsolvable problems in the\\ncontext of Visual Question Answering (VQA) tasks. UPD encompasses three\\ndistinct settings: Absent Answer Detection (AAD), Incompatible Answer Set\\nDetection (IASD), and Incompatible Visual Question Detection (IVQD). To deeply\\ninvestigate the UPD problem, extensive experiments indicate that most VLMs,\\nincluding GPT-4V and LLaVA-Next-34B, struggle with our benchmarks to varying\\nextents, highlighting significant room for the improvements. To address UPD, we\\nexplore both training-free and training-based solutions, offering new insights\\ninto their effectiveness and limitations. We hope our insights, together with\\nfuture efforts within the proposed UPD settings, will enhance the broader\\nunderstanding and development of more practical and reliable VLMs.\",\n",
+       " 'article_url': 'http://arxiv.org/abs/2403.20331v1',\n",
+       " 'pdf_url': 'http://arxiv.org/pdf/2403.20331v1'}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -206,12 +206,12 @@
    "source": [
     "# Test that the search is working\n",
     "result_output = get_articles(\"ppo reinforcement learning\")\n",
-    "result_output[0]\n"
+    "result_output[0]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 13,
    "id": "11675627",
    "metadata": {},
    "outputs": [],
@@ -236,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 17,
    "id": "7211df2c",
    "metadata": {},
    "outputs": [],
@@ -352,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 18,
    "id": "898b94d4",
    "metadata": {},
    "outputs": [
@@ -368,7 +368,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 6/6 [00:06<00:00,  1.08s/it]\n"
+      "100%|██████████| 8/8 [00:05<00:00,  1.43it/s]\n"
      ]
     },
     {
@@ -386,7 +386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 19,
    "id": "c715f60d",
    "metadata": {},
    "outputs": [
@@ -395,29 +395,28 @@
      "output_type": "stream",
      "text": [
       "Core Argument:\n",
-      "- The academic paper explores the connection between the transverse field Ising (TFI) model and the ϕ4 model, highlighting the analogy between topological solitary waves in the ϕ4 model and the effect of the transverse field on spin flips in the TFI model.\n",
-      "- The study reveals regimes of memory/loss of memory and coherence/decoherence in the classical ϕ4 model subjected to periodic perturbations, which are essential in annealing phenomena.\n",
-      "- The exploration of the analogy between lower-dimensional linear quantum systems and higher-dimensional classical nonlinear systems can lead to a deeper understanding of information processing in these systems.\n",
+      "- The academic paper introduces ConvPrompt, a novel approach for continual learning (CL) that combines convolutional prompting with language models.\n",
+      "- ConvPrompt addresses the limitations of existing CL approaches by allowing for both layer-specific learning and better concept transfer across tasks.\n",
+      "- ConvPrompt uses convolution to create task-specific prompts based on task-shared embeddings, enabling efficient adaptation to new tasks with low parameter overhead.\n",
+      "- Language models are leveraged to determine task similarity and dynamically decide the number of prompts to be learned.\n",
       "\n",
       "Evidence:\n",
-      "- The authors analyze the dynamics and relaxation of weakly coupled ϕ4 chains through numerical simulations, observing kink and breather excitations and investigating the structural phase transition associated with the double well potential.\n",
-      "- The critical temperature (Tc) approaches zero as the inter-chain coupling strength (C⊥) approaches zero, but there is a finite Tc for C⊥>0.\n",
-      "- The spectral function shows peaks corresponding to particle motion across the double-well potential at higher temperatures and oscillations in a single well at lower temperatures.\n",
-      "- The soft-mode frequency (ωs) decreases as temperature approaches Ts, the dynamical crossover temperature.\n",
-      "- The relaxation process of the average displacement (QD) is controlled by spatially extended vibrations and large kink densities.\n",
-      "- The mean domain size (⟨DS⟩) exhibits an algebraic decay for finite C⊥>0.\n",
-      "- The probability of larger domain sizes is higher before a kick compared to after a kick for C⊥>0.\n",
+      "- Experimental results show that ConvPrompt outperforms state-of-the-art prompt-based CL approaches with a lower number of parameters.\n",
+      "- The paper provides a comprehensive analysis of different components and their importance.\n",
+      "- ConvPrompt achieves high accuracy and low forgetting rates while reducing the number of parameters.\n",
+      "- ConvPrompt utilizes shared inter-task concepts better than other prompt-based approaches, leading to higher maximum accuracy by the tasks.\n",
+      "- ConvPrompt combined with Slow Learner with Classifier Alignment (SLCA) outperforms SLCA in two out of three datasets, achieving a new state-of-the-art in continual learning.\n",
       "\n",
       "Conclusions:\n",
-      "- The authors suggest further exploration of the crossover between decoherence and finite coherence in periodic-kick strength space.\n",
-      "- They propose extending the study to different kick profiles, introducing kink defects, and studying weakly-coupled chains in higher dimensions.\n",
-      "- Recognizing similarities between classical nonlinear equations and quantum linear ones in information processing is important.\n",
-      "- Future research directions include investigating the dynamics of quantum annealing, measurement and memory in the periodically driven complex Ginzburg-Landau equation, and the behavior of solitons and domain walls in various systems.\n"
+      "- ConvPrompt is a promising approach for continual learning in computer vision tasks, outperforming existing methods while using fewer parameters.\n",
+      "- ConvPrompt allows for efficient adaptation to new tasks and better concept transfer across tasks.\n",
+      "- The use of convolution and language models in ConvPrompt improves knowledge transfer and task similarity determination.\n",
+      "- ConvPrompt achieves high accuracy and low forgetting rates, making it a valuable approach for continual learning.\n"
      ]
     }
    ],
    "source": [
-    "print(chat_test_response.choices[0].message.content)\n"
+    "print(chat_test_response.choices[0].message.content)"
    ]
   },
   {
@@ -433,7 +432,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 20,
    "id": "77a6fb4f",
    "metadata": {},
    "outputs": [],
@@ -450,12 +449,12 @@
     "    except Exception as e:\n",
     "        print(\"Unable to generate ChatCompletion response\")\n",
     "        print(f\"Exception: {e}\")\n",
-    "        return e\n"
+    "        return e"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 21,
    "id": "73f7672d",
    "metadata": {},
    "outputs": [],
@@ -486,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 22,
    "id": "978b7877",
    "metadata": {},
    "outputs": [],
@@ -526,12 +525,12 @@
     "            \"required\": [\"query\"],\n",
     "        },\n",
     "    }\n",
-    "]\n"
+    "]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 23,
    "id": "0c88ae15",
    "metadata": {},
    "outputs": [],
@@ -605,7 +604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 29,
    "id": "c39a1d80",
    "metadata": {},
    "outputs": [],
@@ -621,7 +620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 30,
    "id": "253fd0f7",
    "metadata": {},
    "outputs": [
@@ -637,21 +636,13 @@
     {
      "data": {
       "text/markdown": [
-       "PPO (Proximal Policy Optimization) is a reinforcement learning algorithm that aims to find the optimal policy for an agent by optimizing the policy parameters in an iterative manner. Here are a few papers that discuss PPO in more detail:\n",
+       "PPO (Proximal Policy Optimization) is a reinforcement learning algorithm that is designed to optimize policies for sequential decision-making tasks. Here is a paper that provides an overview of PPO and its workings:\n",
        "\n",
-       "1. Title: \"Proximal Policy Optimization Algorithms\"\n",
-       "   Article URL: [arxiv.org/abs/1707.06347v2](http://arxiv.org/abs/1707.06347v2)\n",
-       "   Summary: This paper introduces two algorithms, PPO (Proximal Policy Optimization) and TRPO (Trust Region Policy Optimization), that address the issue of sample efficiency and stability in reinforcement learning. PPO uses a surrogate objective function that makes smaller updates to the policy parameters, resulting in more stable and efficient learning.\n",
+       "Title: \"Proximal Policy Optimization Algorithms\"\n",
+       "Article URL: [arxiv.org/abs/1707.06347v2](http://arxiv.org/abs/1707.06347v2)\n",
+       "Summary: This paper introduces Proximal Policy Optimization (PPO), an algorithm for reinforcement learning. PPO is designed to strike a balance between stability and sample efficiency in policy optimization. It uses a surrogate objective function that is updated iteratively through multiple epochs of optimization. The authors demonstrate the effectiveness of PPO by comparing it with other popular algorithms on a range of benchmark tasks.\n",
        "\n",
-       "2. Title: \"Emergence of Locomotion Behaviours in Rich Environments with PPO\"\n",
-       "   Article URL: [arxiv.org/abs/1707.02286v3](http://arxiv.org/abs/1707.02286v3)\n",
-       "   Summary: This paper explores the use of PPO in training agents to learn locomotion behaviors in complex and dynamic environments. The authors demonstrate the effectiveness of PPO in learning a variety of locomotion skills, such as walking, jumping, and climbing.\n",
-       "\n",
-       "3. Title: \"Proximal Policy Optimization for Multi-Agent Systems\"\n",
-       "   Article URL: [arxiv.org/abs/2006.14171v2](http://arxiv.org/abs/2006.14171v2)\n",
-       "   Summary: This paper extends PPO to the domain of multi-agent systems, where multiple agents interact and learn together. The authors propose a decentralized version of PPO that allows each agent to update its policy independently based on its local observations, resulting in more scalable and efficient learning in multi-agent environments.\n",
-       "\n",
-       "These papers provide detailed explanations of the PPO algorithm, its advantages, and its applications in different scenarios. Reading them can give you a deeper understanding of how PPO reinforcement learning works."
+       "Reading this paper will provide a detailed understanding of how PPO works and its key components."
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -669,12 +660,12 @@
     ")\n",
     "assistant_message = chat_response.choices[0].message.content\n",
     "paper_conversation.add_message(\"assistant\", assistant_message)\n",
-    "display(Markdown(assistant_message))\n"
+    "display(Markdown(assistant_message))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 31,
    "id": "3ca3e18a",
    "metadata": {},
    "outputs": [
@@ -692,7 +683,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 6/6 [00:07<00:00,  1.19s/it]\n"
+      "100%|██████████| 7/7 [00:06<00:00,  1.07it/s]\n"
      ]
     },
     {
@@ -706,24 +697,20 @@
      "data": {
       "text/markdown": [
        "Core Argument:\n",
-       "- The academic paper explores the connection between the transverse field Ising (TFI) model and the ϕ4 model, highlighting the analogy between the coupling of topological solitary waves in the ϕ4 model and the effect of the transverse field on spin flips in the TFI model.\n",
-       "- The study reveals regimes of memory/loss of memory and coherence/decoherence in the classical ϕ4 model subjected to periodic perturbations, which are essential in annealing phenomena.\n",
-       "- The exploration of the analogy between lower-dimensional linear quantum systems and higher-dimensional classical nonlinear systems can lead to a deeper understanding of information processing in these systems.\n",
+       "- The paper proposes using heuristic search methods on the output probability distribution of machine learning policies to improve the performance of multi-agent path finding (MAPF) algorithms.\n",
+       "- The main contributions of the paper are the creation of a \"smart\" collision shield using heuristic search and a neural network agnostic framework for using a learnt 1-step policy with heuristic search for full horizon planning.\n",
        "\n",
        "Evidence:\n",
-       "- The authors analyze the dynamics and relaxation of weakly coupled ϕ4 chains through numerical simulations, studying the behavior of kink and breather excitations and the structural phase transition associated with the double well potential.\n",
-       "- The critical temperature (Tc) approaches zero as the inter-chain coupling strength (C⊥) approaches zero, but there is a finite Tc for C⊥>0.\n",
-       "- The spectral function shows peaks corresponding to particle motion across the double-well potential at higher temperatures and oscillations in a single well at lower temperatures.\n",
-       "- The soft-mode frequency (ωs) decreases as temperature approaches Ts, the dynamical crossover temperature.\n",
-       "- The relaxation process of the average displacement (QD) is controlled by spatially extended vibrations and large kink densities.\n",
-       "- The mean domain size (⟨DS⟩) exhibits an algebraic decay for finite C⊥>0.\n",
-       "- The probability of larger domain sizes is higher before a kick compared to after a kick for C⊥>0.\n",
+       "- The paper discusses the limitations of current ML approaches for MAPF, which produce \"local\" policies that only plan for a single timestep and have poor success rates and scalability.\n",
+       "- The paper demonstrates several model-agnostic ways to use heuristic search with learnt policies, which significantly improve the policies' success rates and scalability.\n",
+       "- The paper compares ML-based approaches with classical heuristic search approaches and discusses the strengths and weaknesses of each approach.\n",
+       "- Experimental results show the effectiveness of the proposed method in improving success rates and scalability.\n",
        "\n",
        "Conclusions:\n",
-       "- The study of weakly-coupled classical ϕ4 chains provides insights into quantum annealing architectures and the role of topological excitations in these systems.\n",
-       "- The equilibration of the system is faster for higher kick strengths, and the mean domain size increases with higher final temperatures.\n",
-       "- Further exploration of the crossover between decoherence and finite coherence in periodic-kick strength space is suggested.\n",
-       "- The paper highlights the importance of recognizing similarities between classical nonlinear equations and quantum linear ones in information processing and suggests future research directions in this area."
+       "- The proposed method of using heuristic search with learnt policies improves the success rates and scalability of MAPF algorithms.\n",
+       "- The combination of a learnt policy with a heuristic in the LaCAM framework shows promising results.\n",
+       "- CS-PIBT is an effective collision shield that improves performance in MAPF problems.\n",
+       "- The best way of combining the learnt policy with the heuristic depends on the specific scenario and can be determined through experimentation."
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -744,6 +731,14 @@
     ")\n",
     "display(Markdown(updated_response.choices[0].message.content))\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5d88f8e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -762,7 +757,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.1"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

When reading through [How to use functions with a knowledge base](https://cookbook.openai.com/examples/how_to_call_functions_for_knowledge_retrieval), I notice there are two declared arguments not used in the get_article funciton. As a result, both query value and topk value are set to constant. Therefore I made this fixing request.
