### PR TITLE
Fix embedding model mismatch between Question_answering_using_embeddi…

### DIFF
--- a/examples/Question_answering_using_embeddings.ipynb
+++ b/examples/Question_answering_using_embeddings.ipynb
@@ -137,7 +137,7 @@
     "from scipy import spatial  # for calculating vector similarities for search\n",
     "\n",
     "# models\n",
-    "EMBEDDING_MODEL = \"text-embedding-ada-002\"\n",
+    "EMBEDDING_MODEL = \"text-embedding-3-small\"\n",
     "GPT_MODEL = \"gpt-3.5-turbo\"\n",
     "\n",
     "client = OpenAI(api_key=os.environ.get(\"OPENAI_API_KEY\", \"<your OpenAI API key if not set as env var>\"))\n"


### PR DESCRIPTION
## Summary

The article on "Embedding_Wikipedia_articles_for_search" is intended to show how the embeddings were generated for the article on "Question_answering_using_embeddings." However, the "Embedding_Wikipedia" code specifies a different EMBEDDING_MODEL than the "Question_answering" model. As a result, the "Question_answering" code fails to understand the embeddings and returns returns "I could not find an answer" when it tries to answer the questions. This pull request fixes that EMBEDDING_MODEL mismatch.
