### PR TITLE
Remove empty website from authors.yaml

### DIFF
--- a/authors.yaml
+++ b/authors.yaml
@@ -10,7 +10,6 @@
 
 cathykc:
   name: "Kai Chen"
-  website: ""
   avatar: "https://pbs.twimg.com/profile_images/1657816900817272832/ioGq5O0t_400x400.jpg"
 
 shyamal-anadkat:


### PR DESCRIPTION
## Summary

Website attribute must be in URI format but is not required, so removing it instead of having it empty