### PR TITLE
Adding github author link as website (required value)

### DIFF
--- a/authors.yaml
+++ b/authors.yaml
@@ -10,6 +10,7 @@
 
 cathykc:
   name: "Kai Chen"
+  website: "https://github.com/cathykc"
   avatar: "https://pbs.twimg.com/profile_images/1657816900817272832/ioGq5O0t_400x400.jpg"
 
 shyamal-anadkat:
@@ -159,4 +160,5 @@ lxing-oai:
 
 gladstone-openai:
   name: "Kevin Gladstone"
+  website: "https://github.com/gladstone-openai"
   avatar: "https://avatars.githubusercontent.com/u/149190645"


### PR DESCRIPTION
authors.yml require a website per https://github.com/openai/openai-cookbook/blob/main/.github/authors_schema.json#L20
which I've mistakenly grasped when doing https://github.com/openai/openai-cookbook/pull/1376

Putting back website attribute and a placeholder value (being the GitHub author's page) as we require a value for it.