### PR TITLE
Fix clearly broken link in Cookbook (addresses #1370)

### DIFF
--- a/examples/chatgpt/gpt_actions_library/gpt_action_canvaslms.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_canvaslms.ipynb
@@ -28,7 +28,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This particular GPT Action provides an overview of how to connect to Canvas (infrastructure.canvas.com), a widely used LMS tool for course material, grading and general education purposes. "
+    "This particular GPT Action provides an overview of how to connect to [Canvas](https://www.instructure.com/canvas), a widely used LMS tool for course material, grading and general education purposes. "
    ]
   },
   {


### PR DESCRIPTION


This was raised in #1370 . Maybe we don't want it to be a live link but right now it clearly seems like a valid link 

