### PR TITLE
Fix bug with name config

### DIFF
--- a/authors.yaml
+++ b/authors.yaml
@@ -174,6 +174,6 @@ joecasson-openai:
   avatar: "https://avatars.githubusercontent.com/u/178522625"
 
 ericning-o:
-  Name: "Eric Ning"
+  name: "Eric Ning"
   website: "https://github.com/ericning-o"
   avatar: "https://avatars.githubusercontent.com/u/182030612"


### PR DESCRIPTION
## Summary

The name should be lowercase otherwise it doesn't compile

## Motivation

See summary 

