### PR TITLE
Add chatgpt-productivity tag to GitHub GPT.

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -1666,6 +1666,7 @@
   tags:
     - gpt-actions-library
     - chatgpt
+    - chatgpt-productivity
 
 - title: Custom LLM as a Judge to Detect Hallucinations with Braintrust
   path: examples/Custom-LLM-as-a-Judge.ipynb


### PR DESCRIPTION
## Summary

Add the chatgpt-productivity tag to the registry so we have it show up as a card on our landing page.

