### PR TITLE
Update Question_answering_using_embeddings.ipynb

### DIFF
--- a/examples/Question_answering_using_embeddings.ipynb
+++ b/examples/Question_answering_using_embeddings.ipynb
@@ -68,7 +68,7 @@
     "- Graph-based search\n",
     "- Embedding-based search\n",
     "\n",
-    "This example notebook uses embedding-based search. [Embeddings](https://platform.openai.com/docs/guides/embeddings) are simple to implement and work especially well with questions, as questions often don't lexically overlap with their answers.\n",
+    "This example notebook uses embedding-based search. [Embeddings](https://platform.openai.com/docs/guides/embeddings) are simple to implement and work especially well with questions, as questions often lexically overlap with their answers.\n",
     "\n",
     "Consider embeddings-only search as a starting point for your own system. Better search systems might combine multiple search methods, along with features like popularity, recency, user history, redundancy with prior search results, click rate data, etc. Q&A retrieval performance may also be improved with techniques like [HyDE](https://arxiv.org/abs/2212.10496), in which questions are first transformed into hypothetical answers before being embedded. Similarly, GPT can also potentially improve search results by automatically transforming questions into sets of keywords or search terms."
    ]


### PR DESCRIPTION
removed "don't" from "questions often don't lexically overlap with their answers", because questions actually tend to lexically overlap with their answers.
