### PR TITLE
Fix the template repo URL (GPT Actions library - AWS Middleware)

### DIFF
--- a/examples/chatgpt/gpt_actions_library/gpt_middleware_aws_function.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_middleware_aws_function.ipynb
@@ -190,7 +190,7 @@
     "You can clone the openai-cookbook repository & take the sample python code & SAM template from the `lambda-middleware` directory:\n",
     "\n",
     "```\n",
-    "git clone https://github.com/pap-openai/lambda-middleware\n",
+    "git clone https://github.com/pap-openai/aws-lambda-middleware\n",
     "cd lambda-middleware\n",
     "```\n",
     "\n",


### PR DESCRIPTION
## Summary

This pull request corrects a wrong repo URL in this cookbook: https://cookbook.openai.com/examples/chatgpt/gpt_actions_library/gpt_middleware_aws_function

Specifically, pap-openai/lambda-middleware needs to be pap-openai/aws-lambda-middleware
