### PR TITLE
Removing broken link in cookbook example

### DIFF
--- a/examples/Embedding_Wikipedia_articles_for_search.ipynb
+++ b/examples/Embedding_Wikipedia_articles_for_search.ipynb
@@ -571,7 +571,7 @@
     "\n",
     "Now that we've split our library into shorter self-contained strings, we can compute embeddings for each.\n",
     "\n",
-    "(For large embedding jobs, use a script like [api_request_parallel_processor.py](api_request_parallel_processor.py) to parallelize requests while throttling to stay under rate limits.)"
+    "(For large embedding jobs, consider parallelizing requests and throttling them to stay within rate limits.)"
    ]
   },
   {

--- a/examples/Embedding_Wikipedia_articles_for_search.ipynb
+++ b/examples/Embedding_Wikipedia_articles_for_search.ipynb
@@ -571,7 +571,7 @@
     "\n",
     "Now that we've split our library into shorter self-contained strings, we can compute embeddings for each.\n",
     "\n",
-    "(For large embedding jobs, consider parallelizing requests and throttling them to stay within rate limits.)"
+    "(For large embedding jobs, use a script like [api_request_parallel_processor.py](https://github.com/openai/openai-cookbook/blob/main/examples/api_request_parallel_processor.py) to parallelize requests while throttling to stay under rate limits.)"
    ]
   },
   {


### PR DESCRIPTION
## Summary

I picked up this [github issue](https://github.com/openai/openai-cookbook/issues/1696) that noticed a broken link in the cookbook website. 

## Motivation

It would tidy up the cookbook a bit to remove/fix this broken link.

It appears that linking to a `.py` file is not supported for `cookbook.openai.com` as all the other files in the examples folder are `.ipynb`, so I thought best to remove this link. Alternatively we could specify the github url to the `api_request_parallel_processor.py` file but I thought simply removing this link would be better because the location/name of this file is likely to change in the future.


