### PR TITLE
Fix typo: Remove extra quotes from triple quotes

### DIFF
--- a/examples/Whisper_prompting_guide.ipynb
+++ b/examples/Whisper_prompting_guide.ipynb
@@ -413,7 +413,7 @@
    ],
    "source": [
     "# more natural, sentence-style prompt\n",
-    "transcribe(bbq_plans_filepath, prompt=\"\"\"\"Aimee and Shawn ate whisky, doughnuts, omelets at a BBQ.\"\"\")"
+    "transcribe(bbq_plans_filepath, prompt=\"\"\"Aimee and Shawn ate whisky, doughnuts, omelets at a BBQ.\"\"\")"
    ]
   },
   {


### PR DESCRIPTION
Thanks for Whisper prompting guide.
https://cookbook.openai.com/examples/whisper_prompting_guide#pass-names-in-the-prompt-to-prevent-misspellings

## Summary

Remove extra quotes

<img width="799" alt="image" src="https://github.com/user-attachments/assets/22ff8454-4b96-4ffc-9e31-935e4ca00f45" />

## Motivation

Fix typo
