### PR TITLE
add evals tag to cookbook

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -12,6 +12,7 @@
   tags:
     - evals-api
     - images
+    - evals
 
 - title: Optimize Prompts
   path: examples/Optimize_Prompts.ipynb


### PR DESCRIPTION
Add dropped evals tag to 'Using Evals API on Image Inputs' cookbook
