### PR TITLE
fix(#1937): use dot notation for ActionSearch to fix TypeError

### DIFF
--- a/examples/deep_research_api/introduction_to_deep_research_api.ipynb
+++ b/examples/deep_research_api/introduction_to_deep_research_api.ipynb
@@ -252,7 +252,7 @@
       "source": [
         "# Find the first web search step\n",
         "search = next(item for item in response.output if item.type == \"web_search_call\")\n",
-        "print(\"Query:\", search.action[\"query\"])\n",
+        "print(\"Query:\", search.action.query)\n",
         "print(\"Status:\", search.status)"
       ]
     },


### PR DESCRIPTION

This fix addresses a `TypeError: 'ActionSearch' object is not subscriptable` caused by treating an `ActionSearch` object like a dictionary. The code now correctly uses dot notation (`search.action.query` instead of `search.action["query"]`).

### Summary

Replaced subscript notation with dot notation for accessing properties of the `ActionSearch` object. This resolves the following error:

```
TypeError: 'ActionSearch' object is not subscriptable
```

### Changes

* Replaced `search.action["query"]` with `search.action.query`

### Motivation

Ensure compatibility with the `ActionSearch` class interface and prevent runtime errors when processing search steps.

### Testing

* [x] Ran local tests to confirm error no longer appears
* [x] Verified `query` and `status` values are printed correctly
