### PR TITLE
Fix SyntaxError: unmatched ')' in openai-harmony.md example code

### DIFF
--- a/articles/openai-harmony.md
+++ b/articles/openai-harmony.md
@@ -91,7 +91,6 @@ developer_message = (
                 ),
             ]
         )
-	)
 )
 
 convo = Conversation.from_messages(


### PR DESCRIPTION
## Summary
Example code in `openai-harmony.md` has mismatched parentheses.

