### PR TITLE
Fix typos in gpt-5_new_params_and_tools.ipynb

### DIFF
--- a/examples/gpt-5/gpt-5_new_params_and_tools.ipynb
+++ b/examples/gpt-5/gpt-5_new_params_and_tools.ipynb
@@ -356,7 +356,7 @@
    "source": [
     "### 2.3 Using Verbosity for Coding Use Cases \n",
     "\n",
-    "The verbosity parameter also influences the length and complexity of generated code, as well as the depth of accompanying explanations. Here's an example, wherein we use various verboisty levels for a task to generate a Python program that sorts an array of 1000000 random numbers. "
+    "The verbosity parameter also influences the length and complexity of generated code, as well as the depth of accompanying explanations. Here's an example, wherein we use various verbosity levels for a task to generate a Python program that sorts an array of 1000000 random numbers. "
    ]
   },
   {
@@ -503,7 +503,7 @@
    "id": "fa48bbeb",
    "metadata": {},
    "source": [
-    "Medium verboisty, generated richer code with additioanl explanations. Let's do the same with high. "
+    "Medium verbosity, generated richer code with additional explanations. Let's do the same with high. "
    ]
   },
   {
@@ -898,7 +898,7 @@
     "\n",
     "\n",
     "prompt = \"\"\"\n",
-    "Write code to sort the array of numbers in three languages: C++, Python and Java (10 times each)using code_exec functions.\n",
+    "Write code to sort the array of numbers in three languages: C++, Python and Java (10 times each) using code_exec functions.\n",
     "\n",
     "ALWAYS CALL THESE THREE FUNCTIONS EXACTLY ONCE: code_exec_python, code_exec_cpp and code_exec_java tools to sort the array in each language. Stop once you've called these three functions in each language once.\n",
     "\n",


### PR DESCRIPTION
## Summary

This pull request makes minor corrections to the `examples/gpt-5/gpt-5_new_params_and_tools.ipynb` notebook, fixing a few spelling errors in the documentation to improve clarity.

- Documentation spelling corrections:
  * Fixed "verboisty" to "verbosity" in the explanation of the verbosity parameter in code generation examples.
  * Corrected "verboisty" to "verbosity" and "additioanl" to "additional" in the descriptive text for medium verbosity output.