### PR TITLE
Fix path in registry.yaml

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -4,14 +4,6 @@
 # should build pages for, and indicates metadata such as tags, creation date and
 # authors for each page.
 
-- title: How to run gpt-oss locally with LM Studio
-  path: articles/run-locally-lmstudio.md
-  date: 2025-08-07
-  authors:
-    - yagil
-  tags:
-    - gpt-oss
-    - open-models
 - title: GPT-5 Prompt Migration and Improvement Using the New Optimizer
   path: examples/gpt-5/prompt-optimization-cookbook.ipynb
   date: 2025-08-07
@@ -23,6 +15,15 @@
     - responses
     - reasoning
     - prompt-optimization
+
+- title: How to run gpt-oss locally with LM Studio
+  path: articles/gpt-oss/run-locally-lmstudio.md
+  date: 2025-08-07
+  authors:
+    - yagil
+  tags:
+    - gpt-oss
+    - open-models
 
 - title: GPT-5 prompting guide
   path: examples/gpt-5/gpt-5_prompting_guide.ipynb


### PR DESCRIPTION
## Summary

Fixing a typo in registry.yaml article path

```diff
-path: articles/run-locally-lmstudio.md
+path: articles/gpt-oss/run-locally-lmstudio.md
```