### PR TITLE
docs: unify get weather function name in openai-harmony for consistency

### DIFF
--- a/articles/openai-harmony.md
+++ b/articles/openai-harmony.md
@@ -100,14 +100,14 @@ convo = Conversation.from_messages(
         Message.from_role_and_content(Role.USER, "What is the weather in Tokyo?"),
         Message.from_role_and_content(
             Role.ASSISTANT,
-            'User asks: "What is the weather in Tokyo?" We need to use get_weather tool.',
+            'User asks: "What is the weather in Tokyo?" We need to use get_current_weather tool.',
         ).with_channel("analysis"),
         Message.from_role_and_content(Role.ASSISTANT, '{"location": "Tokyo"}')
         .with_channel("commentary")
-        .with_recipient("functions.get_weather")
+        .with_recipient("functions.get_current_weather")
         .with_content_type("json"),
         Message.from_author_and_content(
-            Author.new(Role.TOOL, "functions.lookup_weather"),
+            Author.new(Role.TOOL, "functions.get_current_weather"),
             '{ "temperature": 20, "sunny": true }',
         ).with_recipient("assistant").with_channel("commentary"),
     ]
@@ -383,7 +383,7 @@ If the model decides to call a tool it will define a `recipient` in the header o
 The model might also specify a `<|constrain|>` token to indicate the type of input for the tool call. In this case since it’s being passed in as JSON the `<|constrain|>` is set to `json`.
 
 ```
-<|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"San Francisco"}<|call|>
+<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco"}<|call|>
 ```
 
 #### Handling tool calls
@@ -399,7 +399,7 @@ A tool message has the following format:
 So in our example above
 
 ```
-<|start|>functions.get_weather to=assistant<|channel|>commentary<|message|>{"sunny": true, "temperature": 20}<|end|>
+<|start|>functions.get_current_weather to=assistant<|channel|>commentary<|message|>{"sunny": true, "temperature": 20}<|end|>
 ```
 
 Once you have gathered the output for the tool calls you can run inference with the complete content:
@@ -439,10 +439,10 @@ locations: string[],
 format?: "celsius" | "fahrenheit", // default: celsius
 }) => any;
 
-} // namespace functions<|end|><|start|>user<|message|>What is the weather like in SF?<|end|><|start|>assistant<|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"San Francisco"}<|call|><|start|>functions.get_weather to=assistant<|channel|>commentary<|message|>{"sunny": true, "temperature": 20}<|end|><|start|>assistant
+} // namespace functions<|end|><|start|>user<|message|>What is the weather like in SF?<|end|><|start|>assistant<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco"}<|call|><|start|>functions.get_current_weather to=assistant<|channel|>commentary<|message|>{"sunny": true, "temperature": 20}<|end|><|start|>assistant
 ```
 
-As you can see above we are passing not just the function out back into the model for further sampling but also the previous chain-of-thought (“Need to use function get_weather.”) to provide the model with the necessary information to continue its chain-of-thought or provide the final answer.
+As you can see above we are passing not just the function out back into the model for further sampling but also the previous chain-of-thought (“Need to use function get_current_weather.”) to provide the model with the necessary information to continue its chain-of-thought or provide the final answer.
 
 #### Preambles
 


### PR DESCRIPTION
## Summary

This pull request corrects an error in the tool-calling example where the function names used for invocation did not match the actual function name defined in the `tools` section.

The tool was defined with the name `get_current_weather`. However, the example code that demonstrated its usage was incorrectly using `get_weather` and `lookup_weather`, creating a discrepancy.

This commit fixes the example code to consistently use the function name, `get_current_weather`, throughout the entire request-response flow, aligning it with the existing tool definition.

## Motivation

The primary motivation for this change is to prevent confusion for anyone reading the code. 
By this fix, a developer following this code will see a clear and logical flow, free from the ambiguity caused by mismatched names, making the learning process much smoother.
