### PR TITLE
fix : Correct image path in deep research agents notebook

### DIFF
--- a/examples/deep_research_api/introduction_to_deep_research_api.ipynb
+++ b/examples/deep_research_api/introduction_to_deep_research_api.ipynb
@@ -454,7 +454,7 @@
         "\n",
         "This setup gives developers full control over how research tasks are framed, but also places greater responsibility on the quality of the input prompt. Here's an example of a generic rewriting_prompt to better direct the subsequent deep research query.\n",
         "\n",
-        "![../../images/intro_dr.png](../../../images/intro_dr.png)\n",
+        "![../../images/intro_dr.png](../../images/intro_dr.png)\n",
         "\n",
         "Here's an example of a rewriting prompt:"
       ]


### PR DESCRIPTION
Fixed the incorrect image path so the diagram renders properly in the notebook.

## Summary

- Updated the image reference from a broken relative path to the correct one.
- Ensures the diagram displays properly in `examples/deep_research_api/introduction_to_deep_research_api_agents.ipynb`.

## Motivation

- The previous image path was broken, causing the diagram to not render on GitHub.
- This fix improves documentation readability for users referencing the Deep Research API.

