### PR TITLE
fix: adding authors for GPT-5 Troubleshooting Post

### DIFF
--- a/authors.yaml
+++ b/authors.yaml
@@ -58,6 +58,16 @@ theophile-oai:
   website: "https://www.linkedin.com/in/theophilesautory"
   avatar: "https://avatars.githubusercontent.com/u/206768658?v=4"
 
+bfioca-openai:
+  name: "Brian Fioca"
+  website: "https://www.linkedin.com/in/brian-fioca/"
+  avatar: "https://avatars.githubusercontent.com/u/206814564?v=4"
+
+carter-oai:
+  name: "Carter Mcclellan"
+  website: "https://www.linkedin.com/in/carter-mcclellan/"
+  avatar: "https://avatars.githubusercontent.com/u/219906258?v=4"
+
 robert-tinn:
   name: "Robert Tinn"
   website: "https://www.linkedin.com/in/robert-tinn/"


### PR DESCRIPTION
## Summary

Adding authors for GPT-5 troubleshooting post


