### PR TITLE
Fix typo in Codex CLI invocation

### DIFF
--- a/examples/codex/codex_mcp_agents_sdk/building_consistent_workflows_codex_cli_agents_sdk.ipynb
+++ b/examples/codex/codex_mcp_agents_sdk/building_consistent_workflows_codex_cli_agents_sdk.ipynb
@@ -64,7 +64,7 @@
     "        name=\"Codex CLI\",\n",
     "        params={\n",
     "            \"command\": \"npx\",\n",
-    "            \"args\": [\"-y\", \"codex\", \"mcp\"],\n",
+    "            \"args\": [\"-y\", \"codex\", \"mcp-server\"],\n",
     "        },\n",
     "        client_session_timeout_seconds=360000,\n",
     "    ) as codex_mcp_server:\n",


### PR DESCRIPTION
## Summary

Update Codex invocation to start its MCP server rather than its MCP configuration flow.

## Motivation

The example code depends on running the Codex MCP server, and the current example does not.
