### PR TITLE
Switch codex mcp -> codex mcp-server

### DIFF
--- a/examples/codex/codex_mcp_agents_sdk/building_consistent_workflows_codex_cli_agents_sdk.ipynb
+++ b/examples/codex/codex_mcp_agents_sdk/building_consistent_workflows_codex_cli_agents_sdk.ipynb
@@ -64,7 +64,7 @@
     "        name=\"Codex CLI\",\n",
     "        params={\n",
     "            \"command\": \"npx\",\n",
-    "            \"args\": [\"-y\", \"codex\", \"mcp\"],\n",
+    "            \"args\": [\"-y\", \"codex\", \"mcp-server\"],\n",
     "        },\n",
     "        client_session_timeout_seconds=360000,\n",
     "    ) as codex_mcp_server:\n",
@@ -146,7 +146,7 @@
     "        name=\"Codex CLI\",\n",
     "        params={\n",
     "            \"command\": \"npx\",\n",
-    "            \"args\": [\"-y\", \"codex\", \"mcp\"],\n",
+    "            \"args\": [\"-y\", \"codex\", \"mcp-server\"],\n",
     "        },\n",
     "        client_session_timeout_seconds=360000,\n",
     "    ) as codex_mcp_server:\n",
@@ -220,7 +220,7 @@
     "        name=\"Codex CLI\",\n",
     "        params={\n",
     "            \"command\": \"npx\",\n",
-    "            \"args\": [\"-y\", \"codex\", \"mcp\"],\n",
+    "            \"args\": [\"-y\", \"codex\", \"mcp-server\"],\n",
     "        },\n",
     "        client_session_timeout_seconds=360000,\n",
     "    ) as codex_mcp_server:\n",
@@ -447,7 +447,7 @@
     "async def main() -> None:\n",
     "    async with MCPServerStdio(\n",
     "        name=\"Codex CLI\",\n",
-    "        params={\"command\": \"npx\", \"args\": [\"-y\", \"codex\", \"mcp\"]},\n",
+    "        params={\"command\": \"npx\", \"args\": [\"-y\", \"codex\", \"mcp-server\"]},\n",
     "        client_session_timeout_seconds=360000,\n",
     "    ) as codex_mcp_server:\n",
     "\n",
@@ -681,9 +681,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (openai-cookbook)",
+   "display_name": "cookbook-env",
    "language": "python",
-   "name": "openai-cookbook"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -695,7 +695,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Updates the code sample to be runnable.

## Motivation

Codex changed the behavior of `codex mcp` to support 3rd party integrations, running Codex as an MCP server is now `codex mcp-server`.