### PR TITLE
S2S context summarization: Upgrade websockets.connect() call to v15

### DIFF
--- a/examples/Context_summarization_with_realtime_api.ipynb
+++ b/examples/Context_summarization_with_realtime_api.ipynb
@@ -71,7 +71,7 @@
     "import numpy as np\n",
     "import sounddevice as sd         # microphone capture\n",
     "import simpleaudio               # speaker playback\n",
-    "import websockets.legacy.client as websockets_legacy_client # WebSocket client\n",
+    "import websockets                # WebSocket client\n",
     "import openai                    # OpenAI Python SDK >= 1.14.0"
    ]
   },
@@ -492,7 +492,7 @@
     "    url = f\"wss://api.openai.com/v1/realtime?model={model}\"\n",
     "    headers = {\"Authorization\": f\"Bearer {openai.api_key}\"}\n",
     "\n",
-    "    async with websockets_legacy_client.connect(url, extra_headers=headers, max_size=1 << 24) as ws:\n",
+    "    async with websockets.connect(url, additional_headers=headers, max_size=1 << 24) as ws:\n",
     "        # ------------------------------------------------------------------- #\n",
     "        # Wait until server sends session.created                             #\n",
     "        # ------------------------------------------------------------------- #\n",


### PR DESCRIPTION
## Summary

In Websockets V15.0.1, the `extra_headers` parameter is replaced by the `additional_headers` parameter. Upgrade guide:
https://websockets.readthedocs.io/en/stable/howto/upgrade.html#arguments-of-connect

## Motivation

The current implementation throws the following error:

```
Cell In[12], line 20, in realtime_session(model, voice, enable_playback)
     17 url = f"wss://api.openai.com/v1/realtime?model={model}"
     18 headers = {"Authorization": f"Bearer {openai.api_key}"}
---> 20 async with websockets.connect(url, extra_headers=headers, max_size=1 << 24) as ws:

TypeError: BaseEventLoop.create_connection() got an unexpected keyword argument 'extra_headers'
```
