### PR TITLE
Fix PLANS.md code fence rendering in exec plan article

### DIFF
--- a/articles/codex_exec_plans.md
+++ b/articles/codex_exec_plans.md
@@ -22,7 +22,7 @@ When writing complex features or significant refactors, use an ExecPlan (as desc
 
 Below is the entire document. The prompting in this document was carefully chosen to provide significant amounts of feedback to users and to guide the model to implement precisely what a plan specifies. Users may find that they benefit from customizing the file to meet their needs, or to add or remove required sections.
 
-````md
+~~~md
 # Codex Execution Plans (ExecPlans):
 
 This document describes the requirements for an execution plan ("ExecPlan"), a design document that a coding agent can follow to deliver a working feature or system change. Treat the reader as a complete beginner to this repository: they have only the current working tree and the single ExecPlan file you provide. There is no memory of prior plans and no external context.
@@ -175,4 +175,4 @@ In crates/foo/planner.rs, define:
 If you follow the guidance above, a single, stateless agent -- or a human novice -- can read your ExecPlan from top to bottom and produce a working, observable result. That is the bar: SELF-CONTAINED, SELF-SUFFICIENT, NOVICE-GUIDING, OUTCOME-FOCUSED.
 
 When you revise a plan, you must ensure your changes are comprehensively reflected across all sections, including the living document sections, and you must write a note at the bottom of the plan describing the change and the reason why. ExecPlans must describe not just the what but the why for almost everything.
-````
+~~~


### PR DESCRIPTION
### Motivation
- The `articles/codex_exec_plans.md` article was truncating when rendered because a nested triple-backtick code fence prematurely closed the outer fence. 
- Using a different fence delimiter prevents the nested Markdown from ending the outer block and preserves the full ExecPlan content.

### Description
- Replace the outer fenced block in `articles/codex_exec_plans.md` from a quadruple backtick style to a tilde fence by changing the opening and closing markers to ``~~~md`` and ``~~~``. 
- This is a purely documentation change contained in `articles/codex_exec_plans.md` with two insertions and two deletions to fix rendering. 
- No functional code or runtime behavior was modified.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_696660b4abc88326b78a2d75f0ad84bd)