### PR TITLE
Fix broken fine-tuning doc links and correct AGENTS.md location guidance

### DIFF
--- a/examples/codex/code_modernization.md
+++ b/examples/codex/code_modernization.md
@@ -35,10 +35,10 @@ These 4 files help lay out what code is being changed, what the new system shoul
 
 **Goal**: Give Codex a lightweight contract for how planning works in this repo, without overwhelming people with process.
 
-We’re taking inspiration from the [Using PLANS.md for multi-hour problem solving](https://cookbook.openai.com/articles/codex_exec_plans) cookbook to create an AGENTS.md and PLANS.md file that will be placed in a .agent folder.
+We're taking inspiration from the [Using PLANS.md for multi-hour problem solving](https://cookbook.openai.com/articles/codex_exec_plans) cookbook to create an AGENTS.md file at the repository root and a PLANS.md file in a .agent folder.
 
-* AGENTS.md: If you haven’t created an AGENTS.md for your repository yet, I suggest using the /init command. Once generated, reference the add a section in your AGENTS.md to instruct the agent to reference the PLANS.md. 
-* PLANS.md: Use the example provided in the cookbook as a starting point
+* AGENTS.md: If you haven't created an AGENTS.md for your repository yet, use the /init command, which places it at the repository root where Codex automatically discovers it. Once generated, add a section in your AGENTS.md to instruct the agent to reference .agent/PLANS.md.
+* PLANS.md: Use the example provided in the cookbook as a starting point and place it in the .agent folder
 
 These explain what an ExecPlan is, when to create or update one, where it lives, and what sections every plan must have.
 
@@ -46,7 +46,7 @@ These explain what an ExecPlan is, when to create or update one, where it lives,
 If you want Codex to tighten AGENTS or PLANS for your specific repo, you can run:
 
 ```md
-Please read the directory structure and refine .agent/AGENTS.md and .agent/PLANS.md so they are a clear, opinionated standard for how we plan COBOL modernization work here. Keep the ExecPlan skeleton but add one or two concrete examples.
+Please read the directory structure and refine AGENTS.md and .agent/PLANS.md so they are a clear, opinionated standard for how we plan COBOL modernization work here. Keep the ExecPlan skeleton but add one or two concrete examples.
 ```
 
 ---

--- a/examples/fine-tuned_qa/ft_retrieval_augmented_generation_qdrant.ipynb
+++ b/examples/fine-tuned_qa/ft_retrieval_augmented_generation_qdrant.ipynb
@@ -485,17 +485,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 4. Fine-tuning and Answering using Fine-tuned model\n",
-    "\n",
-    "For the complete fine-tuning process, please refer to the [OpenAI Fine-Tuning Docs](https://platform.openai.com/docs/guides/fine-tuning/use-a-fine-tuned-model).\n",
-    "\n",
-    "### 4.1 Prepare the Fine-Tuning Data\n",
-    "\n",
-    "We need to prepare the data for fine-tuning. We'll use a few samples from train split of same dataset as before, but we'll add the answer to the context. This will help the model learn to retrieve the answer from the context. \n",
-    "\n",
-    "Our instruction prompt is the same as before, and so is the system prompt. "
-   ]
+   "source": "## 4. Fine-tuning and Answering using Fine-tuned model\n\nFor the complete fine-tuning process, please refer to the [OpenAI Fine-Tuning Docs](https://platform.openai.com/docs/guides/supervised-fine-tuning).\n\n### 4.1 Prepare the Fine-Tuning Data\n\nWe need to prepare the data for fine-tuning. We'll use a few samples from train split of same dataset as before, but we'll add the answer to the context. This will help the model learn to retrieve the answer from the context. \n\nOur instruction prompt is the same as before, and so is the system prompt. "
   },
   {
    "cell_type": "code",
@@ -531,15 +521,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "**Tip: 💡 Verify the Fine-Tuning Data**\n",
-    "\n",
-    "You can see this [cookbook](https://github.com/openai/openai-cookbook/blob/main/examples/Chat_finetuning_data_prep.ipynb) for more details on how to prepare the data for fine-tuning.\n",
-    "\n",
-    "### 4.2 Fine-Tune OpenAI Model\n",
-    "\n",
-    "If you're new to OpenAI Model Fine-Tuning, please refer to the [How to finetune Chat models](https://github.com/openai/openai-cookbook/blob/448a0595b84ced3bebc9a1568b625e748f9c1d60/examples/How_to_finetune_chat_models.ipynb) notebook. You can also refer to the [OpenAI Fine-Tuning Docs](platform.openai.com/docs/guides/fine-tuning/use-a-fine-tuned-model) for more details."
-   ]
+   "source": "**Tip: 💡 Verify the Fine-Tuning Data**\n\nYou can see this [cookbook](https://github.com/openai/openai-cookbook/blob/main/examples/Chat_finetuning_data_prep.ipynb) for more details on how to prepare the data for fine-tuning.\n\n### 4.2 Fine-Tune OpenAI Model\n\nIf you're new to OpenAI Model Fine-Tuning, please refer to the [How to finetune Chat models](https://github.com/openai/openai-cookbook/blob/448a0595b84ced3bebc9a1568b625e748f9c1d60/examples/How_to_finetune_chat_models.ipynb) notebook. You can also refer to the [OpenAI Fine-Tuning Docs](https://platform.openai.com/docs/guides/supervised-fine-tuning) for more details."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

- **Fix broken documentation links in RAG with Qdrant notebook** (Fixes #2320): The two links pointing to `/docs/guides/fine-tuning/use-a-fine-tuned-model` now 404 since OpenAI restructured their docs. Updated both to `https://platform.openai.com/docs/guides/supervised-fine-tuning`. Also fixed a missing `https://` prefix on the second link.

- **Correct AGENTS.md location in code_modernization.md** (Fixes #2311): The guide incorrectly stated that `AGENTS.md` should be placed in a `.agent/` folder, but Codex CLI only auto-discovers `AGENTS.md` in directories along the CWD path — not inside subfolders. Clarified that `AGENTS.md` belongs at the repo root (where `/init` places it), while `PLANS.md` remains in `.agent/`. Also fixed a grammar issue ("reference the add a section" → "add a section").

## Test plan

- [ ] Verify the updated fine-tuning doc links resolve correctly in a browser
- [ ] Confirm the code_modernization.md instructions now align with Codex CLI's documented discovery behavior