### PR TITLE
Refresh Codex Prompting Guide metadata

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -3023,9 +3023,10 @@
     - gpt-5-1-codex-max_prompting_guide
     - gpt-5-codex-prompting-guide
     - gpt-5-codex_prompting_guide
-  date: 2025-12-04
+  date: 2026-02-25
   authors:
     - nm-openai
+    - bfioca-openai
   tags:
     - codex
     - responses


### PR DESCRIPTION
### Motivation
- Ensure the `Codex Prompting Guide` appears current to developers by updating its displayed publish date and to reflect current attribution by adding Brian to the authors list.

### Description
- Update `registry.yaml` entry for `examples/gpt-5/codex_prompting_guide.ipynb` to set the `date` to `2026-02-25`.
- Add the `bfioca-openai` author slug alongside the existing `nm-openai` entry in the guide's `authors` list in `registry.yaml`.

### Testing
- Verified YAML parseability by running `ruby -e 'require "yaml"; YAML.unsafe_load_file("registry.yaml"); YAML.unsafe_load_file("authors.yaml"); puts "yaml-ok"'`, which succeeded.
- Confirmed the `bfioca-openai` author slug is present in `authors.yaml` by inspecting the file contents.
- Attempted `python`-based checks (`python -c 'import yaml; yaml.safe_load(open("registry.yaml"))'` and `python .github/scripts/check_notebooks.py`) which failed due to missing Python dependencies (`PyYAML` and `nbformat`) in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_699ed5432a288326b6232fd8b37264ed)