### PR TITLE
Fix broken fine-tuning documentation link

### DIFF
--- a/examples/fine-tuned_qa/ft_retrieval_augmented_generation_qdrant.ipynb
+++ b/examples/fine-tuned_qa/ft_retrieval_augmented_generation_qdrant.ipynb
@@ -488,7 +488,7 @@
    "source": [
     "## 4. Fine-tuning and Answering using Fine-tuned model\n",
     "\n",
-    "For the complete fine-tuning process, please refer to the [OpenAI Fine-Tuning Docs](https://platform.openai.com/docs/guides/fine-tuning/use-a-fine-tuned-model).\n",
+    "For the complete fine-tuning process, please refer to the [OpenAI Fine-Tuning Docs](https://platform.openai.com/docs/guides/fine-tuning).\n",
     "\n",
     "### 4.1 Prepare the Fine-Tuning Data\n",
     "\n",
@@ -538,7 +538,7 @@
     "\n",
     "### 4.2 Fine-Tune OpenAI Model\n",
     "\n",
-    "If you're new to OpenAI Model Fine-Tuning, please refer to the [How to finetune Chat models](https://github.com/openai/openai-cookbook/blob/448a0595b84ced3bebc9a1568b625e748f9c1d60/examples/How_to_finetune_chat_models.ipynb) notebook. You can also refer to the [OpenAI Fine-Tuning Docs](platform.openai.com/docs/guides/fine-tuning/use-a-fine-tuned-model) for more details."
+    "If you're new to OpenAI Model Fine-Tuning, please refer to the [How to finetune Chat models](https://github.com/openai/openai-cookbook/blob/448a0595b84ced3bebc9a1568b625e748f9c1d60/examples/How_to_finetune_chat_models.ipynb) notebook. You can also refer to the [OpenAI Fine-Tuning Docs](https://platform.openai.com/docs/guides/fine-tuning) for more details."
    ]
   },
   {


### PR DESCRIPTION
Fixes #2320. Updates broken documentation links to use the correct OpenAI fine-tuning docs URL.