### PR TITLE
Update Codex prompting guide for gpt-5.3-codex status updates

### DIFF
--- a/examples/gpt-5/codex_prompting_guide.ipynb
+++ b/examples/gpt-5/codex_prompting_guide.ipynb
@@ -172,7 +172,7 @@
     "\n",
     "## Mid-Rollout User Updates\n",
     "\n",
-    "The Codex model family uses reasoning summaries to communicate user updates as it’s working. This can be in the form of one-liner headings (which updates the ephemeral text in Codex-CLI), or both heading and a short body. This is done by a separate model and therefore is **not promptable**, and we advise against adding any instructions to the prompt related to intermediate plans or messages to the user. We’ve improved these summaries for Codex-Max to be more communicative and provide more critical information about what’s happening and why; some of our users are updating their UX to promote these summaries more prominently in their UI, similar to how intermediate messages are displayed for GPT-5 series models.\n",
+    "The Codex model family can surface mid-rollout user updates while it's working. For codex versions prior to gpt-5.3-codex, these updates are system-generated rather than promptable, so we advise against adding instructions to the prompt about intermediate plans or messages to the user for those. For gpt-5.3-codex and after, these updates are more communicative and provide more critical information about what's happening and why and work similarly to how intermediate messages work for other GPT-5 series models and can be prompted according to the Preambles & Personality section below.\n",
     "\n",
     "## Using agents.md\n",
     "\n",


### PR DESCRIPTION
## Summary
- Updates `examples/gpt-5/codex_prompting_guide.ipynb` to remove deprecated wording about “reasoning summaries.”
- Replaces it with version-specific guidance for mid-rollout user updates:
  - pre-`gpt-5.3-codex`: updates are system-generated and not promptable
  - `gpt-5.3-codex` and later: updates behave more like other GPT-5 intermediate messages and can be prompted per the preambles/personality guidance

## Motivation
- The existing text is out of date because it refers to deprecated reasoning summaries.
- This change keeps the cookbook aligned with current Codex behavior and makes the guidance clearer for readers authoring prompts across Codex versions.
- It improves accuracy in the prompting guide and reduces the chance that developers copy obsolete instructions into their prompts.

---

## For new content
- Not applicable — this PR updates existing content only and does not add new cookbook content.
