### PR TITLE
Qdrant notebook changes

### DIFF
--- a/examples/vector_databases/qdrant/Using_Qdrant_for_embeddings_search.ipynb
+++ b/examples/vector_databases/qdrant/Using_Qdrant_for_embeddings_search.ipynb
@@ -48,7 +48,7 @@
    "outputs": [],
    "source": [
     "# We'll need to install Qdrant client\n",
-    "!pip install qdrant-client"
+    "!pip install qdrant-client wget"
    ]
   },
   {
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "5dff8b55",
    "metadata": {
     "ExecuteTime": {
@@ -98,25 +98,7 @@
      "start_time": "2024-05-21T23:49:41.132888Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100% [......................................................................] 698933052 / 698933052"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'vector_database_wikipedia_articles_embedded (10).zip'"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import wget\n",
     "\n",
@@ -722,7 +704,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv (3.14.3)",
    "language": "python",
    "name": "python3"
   },
@@ -736,12 +718,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "fd16a328ca3d68029457069b79cb0b38eb39a0f5ccc4fe4473d3047707df8207"
-   }
+   "version": "3.14.3"
   }
  },
  "nbformat": 4,

--- a/examples/vector_databases/qdrant/Using_Qdrant_for_embeddings_search.ipynb
+++ b/examples/vector_databases/qdrant/Using_Qdrant_for_embeddings_search.ipynb
@@ -509,46 +509,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "9f39a8c395554ca3",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-05-21T23:56:21.577594Z",
-     "start_time": "2024-05-21T23:56:21.460740Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "vector_size = len(article_df['content_vector'][0])\n",
-    "\n",
-    "qdrant.recreate_collection(\n",
-    "    collection_name='Articles',\n",
-    "    vectors_config={\n",
-    "        'title': rest.VectorParams(\n",
-    "            distance=rest.Distance.COSINE,\n",
-    "            size=vector_size,\n",
-    "        ),\n",
-    "        'content': rest.VectorParams(\n",
-    "            distance=rest.Distance.COSINE,\n",
-    "            size=vector_size,\n",
-    "        ),\n",
-    "    }\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "e95be6e0c9af4c21",
    "metadata": {},
@@ -641,7 +601,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "f1bac4ef",
    "metadata": {
     "ExecuteTime": {
@@ -659,13 +619,12 @@
     "        model=EMBEDDING_MODEL,\n",
     "    ).data[0].embedding # We take the first embedding from the list\n",
     "    \n",
-    "    query_results = qdrant.search(\n",
+    "    query_response = qdrant.query_points(\n",
     "        collection_name=collection_name,\n",
-    "        query_vector=(\n",
-    "            vector_name, embedded_query\n",
-    "        ),\n",
-    "        limit=top_k, \n",
-    "        query_filter=None\n",
+    "        query=embedded_query,\n",
+    "        using=vector_name,\n",
+    "        limit=top_k,\n",
+    "        query_filter=None,\n",
     "    )\n",
     "    \n",
     "    return query_results"

--- a/examples/vector_databases/qdrant/Using_Qdrant_for_embeddings_search.ipynb
+++ b/examples/vector_databases/qdrant/Using_Qdrant_for_embeddings_search.ipynb
@@ -601,7 +601,7 @@
     "        model=EMBEDDING_MODEL,\n",
     "    ).data[0].embedding # We take the first embedding from the list\n",
     "    \n",
-    "    query_response = qdrant.query_points(\n",
+    "    query_results = qdrant.query_points(\n",
     "        collection_name=collection_name,\n",
     "        query=embedded_query,\n",
     "        using=vector_name,\n",


### PR DESCRIPTION
## Summary

This PR updates `examples/vector_databases/qdrant/Using_Qdrant_for_embeddings_search.ipynb` to align the notebook with the current Qdrant Python client and clean up notebook setup/output state.

Changes in this PR:
- update the query example from the deprecated `search()` flow to the current `query_points()` API
- add `wget` to the install cell so the notebook setup matches the imports used later
- remove stale notebook outputs and redundant setup content to keep the example cleaner and easier to run

## Motivation

The existing notebook relied on an older Qdrant client interface, which can cause runtime errors in current environments. This update makes the example more reliable for readers running the notebook today, reduces setup friction, and removes stale output noise that does not add instructional value.

---

## For new content

Not applicable. This PR updates existing cookbook content rather than adding a new entry.