### PR TITLE
Refresh How to handle rate limits guidance

### DIFF
--- a/examples/How_to_handle_rate_limits.ipynb
+++ b/examples/How_to_handle_rate_limits.ipynb
@@ -7,21 +7,19 @@
    "source": [
     "# How to handle rate limits\n",
     "\n",
-    "When you call the OpenAI API repeatedly, you may encounter error messages that say `429: 'Too Many Requests'` or `RateLimitError`. These error messages come from exceeding the API's rate limits.\n",
+    "When you call the OpenAI API repeatedly, you may encounter error messages that say `429: 'Too Many Requests'` or `RateLimitError`. These errors mean your application is sending requests faster than your current request or token budget allows.\n",
     "\n",
-    "This guide shares tips for avoiding and handling rate limit errors.\n",
+    "This guide shares practical ways to avoid and handle rate limit errors. For new builds, it uses the **Responses API** as the primary path. If your application still uses Chat Completions, the retry and pacing patterns are the same.\n",
     "\n",
     "To see an example script for throttling parallel requests to avoid rate limit errors, see [api_request_parallel_processor.py](https://github.com/openai/openai-cookbook/blob/main/examples/api_request_parallel_processor.py).\n",
     "\n",
     "## Why rate limits exist\n",
     "\n",
-    "Rate limits are a common practice for APIs, and they're put in place for a few different reasons.\n",
+    "- Rate limits help protect the platform against abuse or accidental overload.\n",
+    "- They help ensure fair access so one workload does not crowd out everyone else.\n",
+    "- They let OpenAI manage aggregate infrastructure load while preserving reliable latency for users.\n",
     "\n",
-    "- First, they help protect against abuse or misuse of the API. For example, a malicious actor could flood the API with requests in an attempt to overload it or cause disruptions in service. By setting rate limits, OpenAI can prevent this kind of activity.\n",
-    "- Second, rate limits help ensure that everyone has fair access to the API. If one person or organization makes an excessive number of requests, it could bog down the API for everyone else. By throttling the number of requests that a single user can make, OpenAI ensures that everyone has an opportunity to use the API without experiencing slowdowns.\n",
-    "- Lastly, rate limits can help OpenAI manage the aggregate load on its infrastructure. If requests to the API increase dramatically, it could tax the servers and cause performance issues. By setting rate limits, OpenAI can help maintain a smooth and consistent experience for all users.\n",
-    "\n",
-    "Although hitting rate limits can be frustrating, rate limits exist to protect the reliable operation of the API for its users."
+    "Although rate limits can be frustrating, they are part of running production workloads safely and predictably.\n"
    ]
   },
   {
@@ -52,10 +50,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import openai\n",
     "import os\n",
+    "import time\n",
     "\n",
-    "client = openai.OpenAI(api_key=os.getenv(\"OPENAI_API_KEY\", \"<your OpenAI API key if not set as env var>\"))"
+    "import openai\n",
+    "\n",
+    "MODEL = os.getenv(\"OPENAI_RATE_LIMIT_MODEL\", \"gpt-4.1-mini\")\n",
+    "client = openai.OpenAI(api_key=os.getenv(\"OPENAI_API_KEY\", \"<your OpenAI API key if not set as env var>\"))\n"
    ]
   },
   {
@@ -64,13 +65,13 @@
    "source": [
     "## Example rate limit error\n",
     "\n",
-    "A rate limit error will occur when API requests are sent too quickly. If using the OpenAI Python library, they will look something like:\n",
+    "A rate limit error occurs when requests are sent too quickly for your current request-per-minute or token-per-minute budget. With the OpenAI Python SDK, a 429 will look something like:\n",
     "\n",
     "```\n",
-    "RateLimitError: Rate limit reached for default-codex in organization org-{id} on requests per min. Limit: 20.000000 / min. Current: 24.000000 / min. Contact support@openai.com if you continue to have issues or if you’d like to request an increase.\n",
+    "RateLimitError: Error code: 429 - {'error': {'message': 'Rate limit reached for requests per min. Please try again in 8.64s.', 'type': 'requests', 'code': 'rate_limit_exceeded'}}\n",
     "```\n",
     "\n",
-    "Below is example code for triggering a rate limit error."
+    "Below is example code that can trigger a rate limit error quickly.\n"
    ]
   },
   {
@@ -100,13 +101,13 @@
     }
    ],
    "source": [
-    "# request a bunch of completions in a loop\n",
+    "# request a bunch of responses in a loop\n",
     "for _ in range(100):\n",
-    "    client.chat.completions.create(\n",
-    "        model=\"gpt-4o-mini\",\n",
-    "        messages=[{\"role\": \"user\", \"content\": \"Hello\"}],\n",
-    "        max_tokens=10,\n",
-    "    )"
+    "    client.responses.create(\n",
+    "        model=MODEL,\n",
+    "        input=\"Hello\",\n",
+    "        max_output_tokens=10,\n",
+    "    )\n"
    ]
   },
   {
@@ -117,17 +118,17 @@
     "\n",
     "### Retrying with exponential backoff\n",
     "\n",
-    "One easy way to mitigate rate limit errors is to automatically retry requests with a random exponential backoff. Retrying with exponential backoff means performing a short sleep when a rate limit error is hit, then retrying the unsuccessful request. If the request is still unsuccessful, the sleep length is increased and the process is repeated. This continues until the request is successful or until a maximum number of retries is reached.\n",
+    "One easy way to mitigate rate limit errors is to automatically retry requests with a random exponential backoff. Retrying with exponential backoff means performing a short sleep when a rate limit error is hit, then retrying the unsuccessful request. If the request is still unsuccessful, the sleep length is increased and the process is repeated.\n",
     "\n",
-    "This approach has many benefits:\n",
+    "This approach has several benefits:\n",
     "\n",
-    "- Automatic retries means you can recover from rate limit errors without crashes or missing data\n",
-    "- Exponential backoff means that your first retries can be tried quickly, while still benefiting from longer delays if your first few retries fail\n",
-    "- Adding random jitter to the delay helps retries from all hitting at the same time\n",
+    "- Automatic retries let you recover from transient 429s without dropping work.\n",
+    "- Exponential backoff keeps your first retry quick, then gets more conservative if pressure stays high.\n",
+    "- Adding jitter reduces thundering-herd behavior across workers.\n",
     "\n",
-    "Note that unsuccessful requests contribute to your per-minute limit, so continuously resending a request won’t work.\n",
+    "Unsuccessful requests still count against your per-minute limit, so retries should be paired with proactive pacing. In production, log the request ID for both successes and failures so you can debug traffic spikes or share failing requests with OpenAI support.\n",
     "\n",
-    "Below are a few example solutions."
+    "Below are a few example solutions.\n"
    ]
   },
   {
@@ -160,18 +161,17 @@
     }
    ],
    "source": [
-    "from tenacity import (\n",
-    "    retry,\n",
-    "    stop_after_attempt,\n",
-    "    wait_random_exponential,\n",
-    ")  # for exponential backoff\n",
+    "from tenacity import retry, stop_after_attempt, wait_random_exponential\n",
+    "\n",
     "\n",
     "@retry(wait=wait_random_exponential(min=1, max=60), stop=stop_after_attempt(6))\n",
-    "def completion_with_backoff(**kwargs):\n",
-    "    return client.chat.completions.create(**kwargs)\n",
+    "def responses_with_backoff(**kwargs):\n",
+    "    return client.responses.create(**kwargs)\n",
     "\n",
     "\n",
-    "completion_with_backoff(model=\"gpt-4o-mini\", messages=[{\"role\": \"user\", \"content\": \"Once upon a time,\"}])"
+    "response = responses_with_backoff(model=MODEL, input=\"Once upon a time,\")\n",
+    "print(response.output_text)\n",
+    "print(response._request_id)\n"
    ]
   },
   {
@@ -202,14 +202,17 @@
     }
    ],
    "source": [
-    "import backoff  # for exponential backoff\n",
+    "import backoff\n",
+    "\n",
     "\n",
     "@backoff.on_exception(backoff.expo, openai.RateLimitError, max_time=60, max_tries=6)\n",
-    "def completions_with_backoff(**kwargs):\n",
-    "    return client.chat.completions.create(**kwargs)\n",
+    "def responses_with_backoff(**kwargs):\n",
+    "    return client.responses.create(**kwargs)\n",
     "\n",
     "\n",
-    "completions_with_backoff(model=\"gpt-4o-mini\", messages=[{\"role\": \"user\", \"content\": \"Once upon a time,\"}])\n"
+    "response = responses_with_backoff(model=MODEL, input=\"Once upon a time,\")\n",
+    "print(response.output_text)\n",
+    "print(response._request_id)\n"
    ]
   },
   {
@@ -238,9 +241,8 @@
     }
    ],
    "source": [
-    "# imports\n",
     "import random\n",
-    "import time\n",
+    "\n",
     "\n",
     "# define a retry decorator\n",
     "def retry_with_exponential_backoff(\n",
@@ -254,45 +256,33 @@
     "    \"\"\"Retry a function with exponential backoff.\"\"\"\n",
     "\n",
     "    def wrapper(*args, **kwargs):\n",
-    "        # Initialize variables\n",
     "        num_retries = 0\n",
     "        delay = initial_delay\n",
     "\n",
-    "        # Loop until a successful response or max_retries is hit or an exception is raised\n",
     "        while True:\n",
     "            try:\n",
     "                return func(*args, **kwargs)\n",
-    "\n",
-    "            # Retry on specified errors\n",
-    "            except errors as e:\n",
-    "                # Increment retries\n",
+    "            except errors:\n",
     "                num_retries += 1\n",
-    "\n",
-    "                # Check if max retries has been reached\n",
     "                if num_retries > max_retries:\n",
-    "                    raise Exception(\n",
-    "                        f\"Maximum number of retries ({max_retries}) exceeded.\"\n",
-    "                    )\n",
+    "                    raise Exception(f\"Maximum number of retries ({max_retries}) exceeded.\")\n",
     "\n",
-    "                # Increment the delay\n",
     "                delay *= exponential_base * (1 + jitter * random.random())\n",
-    "\n",
-    "                # Sleep for the delay\n",
     "                time.sleep(delay)\n",
-    "\n",
-    "            # Raise exceptions for any errors not specified\n",
-    "            except Exception as e:\n",
-    "                raise e\n",
+    "            except Exception as exc:\n",
+    "                raise exc\n",
     "\n",
     "    return wrapper\n",
     "\n",
     "\n",
     "@retry_with_exponential_backoff\n",
-    "def completions_with_backoff(**kwargs):\n",
-    "    return client.chat.completions.create(**kwargs)\n",
+    "def responses_with_manual_backoff(**kwargs):\n",
+    "    return client.responses.create(**kwargs)\n",
     "\n",
     "\n",
-    "completions_with_backoff(model=\"gpt-4o-mini\", messages=[{\"role\": \"user\", \"content\": \"Once upon a time,\"}])"
+    "response = responses_with_manual_backoff(model=MODEL, input=\"Once upon a time,\")\n",
+    "print(response.output_text)\n",
+    "print(response._request_id)\n"
    ]
   },
   {
@@ -301,11 +291,9 @@
    "source": [
     "### Backing off to another model\n",
     "\n",
-    "If you encounter rate limit errors on your primary model, one option is to switch to a secondary model. This approach helps keep your application responsive when your primary model is throttled or unavailable.\n",
+    "If you encounter rate limit errors on your primary model, one option is to switch to a secondary model. This can help keep your application responsive when the primary model is temporarily throttled.\n",
     "\n",
-    "However, fallback models can differ significantly in accuracy, latency, and cost. As a result, this strategy might not work for every use case; particularly those requiring highly consistent results. Additionally, keep in mind that some models share rate limits, which may reduce the effectiveness of simply switching models. You can see the models that share limits in your [organizations limit page](https://platform.openai.com/settings/organization/limits).\n",
-    "\n",
-    "Before deploying this approach to production, thoroughly test how it affects output quality, user experience, and operational budgets. Validate your fallback solution with relevant evaluations to ensure it meets your requirements and maintains acceptable performance under real-world conditions."
+    "However, fallback models can differ significantly in accuracy, latency, and cost. Some model families also share rate limits, so a fallback may not buy you any extra headroom. Before shipping this approach, validate it with representative evals and confirm the fallback actually lands in a different limit bucket on your [organization limits page](https://platform.openai.com/settings/organization/limits).\n"
    ]
   },
   {
@@ -325,28 +313,33 @@
     }
    ],
    "source": [
-    "def completions_with_fallback(fallback_model, **kwargs):\n",
+    "def responses_with_fallback(fallback_model: str, **kwargs):\n",
     "    try:\n",
-    "        return client.chat.completions.create(**kwargs)\n",
+    "        return client.responses.create(**kwargs)\n",
     "    except openai.RateLimitError:\n",
-    "        kwargs['model'] = fallback_model\n",
-    "        return client.chat.completions.create(**kwargs)\n",
-    "    \n",
-    "    \n",
-    "completions_with_fallback(fallback_model=\"gpt-4o\", model=\"gpt-4o-mini\", messages=[{\"role\": \"user\", \"content\": \"Once upon a time,\"}])"
+    "        kwargs[\"model\"] = fallback_model\n",
+    "        return client.responses.create(**kwargs)\n",
+    "\n",
+    "\n",
+    "response = responses_with_fallback(\n",
+    "    fallback_model=\"gpt-4.1\",\n",
+    "    model=MODEL,\n",
+    "    input=\"Once upon a time,\",\n",
+    ")\n",
+    "print(response.output_text)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Reducing `max_tokens` to match expected completions\n",
+    "### Reducing `max_output_tokens` to match expected completions\n",
     "\n",
     "Rate limit usage is calculated based on the greater of:\n",
-    "1. `max_tokens` - the maximum number of tokens allowed in a response.\n",
-    "2. Estimated tokens in your input – derived from your prompt’s character count.\n",
+    "1. Your requested output budget (`max_output_tokens` in the Responses API).\n",
+    "2. Estimated input tokens derived from your prompt size.\n",
     "\n",
-    "If you set `max_tokens` too high, your usage can be overestimated, even if the actual response is much shorter. To avoid hitting rate limits prematurely, configure `max_tokens` so it closely matches the size of the response you expect. This ensures more accurate usage calculations and helps prevent unintended throttling."
+    "If you set the output budget far above what you actually expect the model to produce, your traffic can be over-reserved even when the real responses are short. Keep `max_output_tokens` close to the expected completion size so capacity planning is more accurate and throttling is less surprising.\n"
    ]
   },
   {
@@ -366,11 +359,66 @@
     }
    ],
    "source": [
-    "def completions_with_max_tokens(**kwargs):\n",
-    "    return client.chat.completions.create(**kwargs)\n",
+    "def responses_with_output_cap(**kwargs):\n",
+    "    return client.responses.create(**kwargs)\n",
     "\n",
     "\n",
-    "completions_with_max_tokens(model=\"gpt-4o-mini\", messages=[{\"role\": \"user\", \"content\": \"Once upon a time,\"}], max_tokens=100)"
+    "response = responses_with_output_cap(\n",
+    "    model=MODEL,\n",
+    "    input=\"Once upon a time,\",\n",
+    "    max_output_tokens=100,\n",
+    ")\n",
+    "print(response.output_text)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reading rate-limit headers before you hit 429 again\n",
+    "\n",
+    "Reactive retries are useful, but the modern production pattern is to read the rate-limit headers on successful responses and adapt before the next request. The OpenAI API returns `x-ratelimit-limit-*`, `x-ratelimit-remaining-*`, and `x-ratelimit-reset-*` headers that you can use to slow down workers, reduce concurrency, or sleep until budget resets.\n",
+    "\n",
+    "You can access those headers in Python with `.with_raw_response`. That is also a good place to log the request ID for observability.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def seconds_until_reset(reset_value: str | None) -> float:\n",
+    "    if not reset_value:\n",
+    "        return 0.0\n",
+    "\n",
+    "    cleaned = reset_value.strip()\n",
+    "    if cleaned.endswith(\"ms\"):\n",
+    "        return max(float(cleaned[:-2]) / 1000.0, 0.0)\n",
+    "    if cleaned.endswith(\"s\"):\n",
+    "        return max(float(cleaned[:-1]), 0.0)\n",
+    "    return max(float(cleaned), 0.0)\n",
+    "\n",
+    "\n",
+    "raw_response = client.responses.with_raw_response.create(\n",
+    "    model=MODEL,\n",
+    "    input=\"Say hello in one short sentence.\",\n",
+    "    max_output_tokens=20,\n",
+    ")\n",
+    "headers = raw_response.headers\n",
+    "response = raw_response.parse()\n",
+    "\n",
+    "request_id = response._request_id or headers.get(\"x-request-id\")\n",
+    "remaining_requests = headers.get(\"x-ratelimit-remaining-requests\")\n",
+    "reset_requests = headers.get(\"x-ratelimit-reset-requests\")\n",
+    "\n",
+    "print(\"request_id:\", request_id)\n",
+    "print(\"remaining_requests:\", remaining_requests)\n",
+    "print(\"reset_requests:\", reset_requests)\n",
+    "print(response.output_text)\n",
+    "\n",
+    "if remaining_requests == \"0\":\n",
+    "    time.sleep(seconds_until_reset(reset_requests))\n"
    ]
   },
   {
@@ -380,17 +428,15 @@
    "source": [
     "## How to maximize throughput of batch processing given rate limits\n",
     "\n",
-    "If you're processing real-time requests from users, backoff and retry is a great strategy to minimize latency while avoiding rate limit errors.\n",
+    "If you're serving live user traffic, backoff and retry is usually the best latency-preserving strategy.\n",
     "\n",
-    "However, if you're processing large volumes of batch data, where throughput matters more than latency, there are a few other things you can do in addition to backoff and retry.\n",
+    "If you're processing large offline workloads, throughput matters more than single-request latency. In that case, use proactive pacing, track remaining quota from headers, and consider the **Batch API** for asynchronous jobs. The Batch API is the preferred path for high-volume non-real-time work because it runs against a separate asynchronous pipeline and offers a 50% cost discount.\n",
     "\n",
     "### Proactively adding delay between requests\n",
     "\n",
-    "If you are constantly hitting the rate limit, then backing off, then hitting the rate limit again, then backing off again, it's possible that a good fraction of your request budget will be 'wasted' on requests that need to be retried. This limits your processing throughput, given a fixed rate limit.\n",
+    "If you repeatedly hit the rate limit, then back off, then immediately saturate it again, a meaningful fraction of your request budget gets wasted on retries. One straightforward mitigation is to calculate a target delay from your limit budget and keep workers just below the ceiling.\n",
     "\n",
-    "Here, one potential solution is to calculate your rate limit and add a delay equal to its reciprocal (e.g., if your rate limit 20 requests per minute, add a delay of 3–6 seconds to each request). This can help you operate near the rate limit ceiling without hitting it and incurring wasted requests.\n",
-    "\n",
-    "#### Example of adding delay to a request"
+    "#### Example of adding delay to a request\n"
    ]
   },
   {
@@ -410,28 +456,23 @@
     }
    ],
    "source": [
-    "import time\n",
+    "# Define a function that adds a delay to a Responses API call\n",
+    "def delayed_response(delay_in_seconds: float = 1, **kwargs):\n",
+    "    \"\"\"Delay a request by a specified amount of time.\"\"\"\n",
     "\n",
-    "# Define a function that adds a delay to a Completion API call\n",
-    "def delayed_completion(delay_in_seconds: float = 1, **kwargs):\n",
-    "    \"\"\"Delay a completion by a specified amount of time.\"\"\"\n",
-    "\n",
-    "    # Sleep for the delay\n",
     "    time.sleep(delay_in_seconds)\n",
-    "\n",
-    "    # Call the Completion API and return the result\n",
-    "    return client.chat.completions.create(**kwargs)\n",
+    "    return client.responses.create(**kwargs)\n",
     "\n",
     "\n",
-    "# Calculate the delay based on your rate limit\n",
     "rate_limit_per_minute = 20\n",
     "delay = 60.0 / rate_limit_per_minute\n",
     "\n",
-    "delayed_completion(\n",
+    "response = delayed_response(\n",
     "    delay_in_seconds=delay,\n",
-    "    model=\"gpt-4o-mini\",\n",
-    "    messages=[{\"role\": \"user\", \"content\": \"Once upon a time,\"}]\n",
-    ")\n"
+    "    model=MODEL,\n",
+    "    input=\"Once upon a time,\",\n",
+    ")\n",
+    "print(response.output_text)\n"
    ]
   },
   {
@@ -440,14 +481,18 @@
    "source": [
     "### Batching requests\n",
     "\n",
-    "The OpenAI API enforces separate limits for requests per minute/day (RPM/RPD) and tokens per minute (TPM). If you’re hitting RPM limits but still have available TPM capacity, consider batching multiple tasks into each request.\n",
+    "The OpenAI API enforces separate limits for requests per minute/day (RPM/RPD) and tokens per minute (TPM). If you are bumping into RPM before you exhaust TPM, bundling multiple tasks into a single request can improve throughput.\n",
     "\n",
-    "By bundling several prompts together, you reduce the total number of requests sent per minute, which helps avoid hitting the RPM cap. This approach may also lead to higher overall throughput if you manage your TPM usage carefully. However, keep the following points in mind:\n",
-    "- Each model has a maximum number of tokens it can process in one request. If your batched prompt exceeds this limit, the request will fail or be truncated.\n",
-    "- Batching can introduce extra waiting time if tasks are delayed until they’re grouped into a single request. This might affect user experience for time-sensitive applications.\n",
-    "- When sending multiple prompts, the response object may not return in the same order or format as the prompts that were submitted. You should try to match each response back to its corresponding prompt by post-processing the output.\n",
+    "There are two different batching patterns:\n",
+    "- **Prompt bundling in one synchronous request** helps when you still need an immediate response.\n",
+    "- **The Batch API** is the better option for large asynchronous jobs because it uses separate rate-limit capacity and lower pricing.\n",
     "\n",
-    "#### Example without batching"
+    "If you do prompt bundling, keep the following in mind:\n",
+    "- Each model still has a maximum context window and output limit.\n",
+    "- Batching can increase per-user latency if you wait to accumulate work.\n",
+    "- You should include an explicit schema or identifier for each subtask so you can reliably map outputs back to inputs.\n",
+    "\n",
+    "#### Example without batching\n"
    ]
   },
   {
@@ -476,79 +521,80 @@
     "num_stories = 10\n",
     "content = \"Once upon a time,\"\n",
     "\n",
-    "# serial example, with one story completion per request\n",
+    "# serial example, with one story response per request\n",
     "for _ in range(num_stories):\n",
-    "    response = client.chat.completions.create(\n",
-    "        model=\"gpt-4o-mini\",\n",
-    "        messages=[{\"role\": \"user\", \"content\": content}],\n",
-    "        max_tokens=20,\n",
+    "    response = client.responses.create(\n",
+    "        model=MODEL,\n",
+    "        input=content,\n",
+    "        max_output_tokens=20,\n",
     "    )\n",
     "\n",
-    "    print(content + response.choices[0].message.content)\n"
+    "    print(content + response.output_text)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Example batching multiple prompts in a single request with Structured Outputs"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "OpenAI's [Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs) feature offers a robust way to batch multiple prompts in a single request. \n",
+    "#### Example batching multiple prompts in a single request with Structured Outputs\n",
     "\n",
-    "Here, rather than parsing raw text or hoping the model follows informal formatting, you specify a strict schema. This ensures your application can reliably parse the results by examining the defined structure. This eliminates the need for extensive validation or complicated parsing logic, as Structured Outputs guarantees consistent, type-safe data."
+    "OpenAI's [Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs) feature is a reliable way to batch several tasks into one synchronous request.\n",
+    "\n",
+    "Instead of parsing raw text or relying on informal formatting, you provide a schema and let the model return machine-readable data that matches it. For new builds, prefer the Responses API version of this flow.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\"stories\":[\"Once upon a time, in a lush green valley, there lived a curious little fox named Felix. Every day, he would explore the woods, finding hidden glades and sparkling streams. One day, while chasing a butterfly, he stumbled upon a magical oak tree that granted wishes. Felix wished for courage and became the bravest fox in the land, helping his friends as they faced challenges together.\",\"Once upon a time, a village known for its beautiful gardens fell into despair when a drought struck. The villagers prayed for rain but to no avail. One evening, a wise old woman arrived and told them of a hidden spring deep in the forest. With hope, the villagers embarked on a quest to find it, learning the value of teamwork and perseverance. Eventually, they found the spring, and the rain returned, reviving their gardens and spirits.\",\"Once upon a time, in a kingdom high atop the clouds, lived Princess Lumina who had the ability to control the stars. But she felt lonely and longed for a companion. One night, she captured a shooting star and transformed it into a dashing young man named Orion. Together, they painted the night skies with adventures until Lumina learned to find joy in her own light.\",\"Once upon a time, in a bustling bazaar in the heart of the city, there lived a clever merchant named Amina. She had a special talent for selling spices that made people fall in love. One day, a mysterious stranger entered her shop and bought a rare spice, causing an unexpected romance between two feuding families. Amina realized her spices held the power of unity, and she continued to spread love through her trade.\",\"Once upon a time, a little turtle named Tilly dreamed of flying. Every day she watched the birds soar above her, wishing she could join them. One night, she met an old owl who shared stories of how to fly in one's heart, rather than with wings. Inspired, Tilly began to paint her dreams on shells, and soon, her colorful art attracted the birds. They carried her art into the sky, proving that dreams can take flight in unexpected ways.\",\"Once upon a time, there was a forgotten castle hidden deep in the mountains. In this castle lived an ancient dragon named Ignis, who guarded a treasure of wisdom unlike any other. One day, a brave yet naive knight named Roland attempted to seize the treasure. But Ignis offered him a riddle instead. After solving it, Roland realized that the true treasure was knowledge and understanding. He left the castle as a wiser man, sharing Ignis's teachings with his kingdom.\",\"Once upon a time, in a world where colors had feelings, there lived a dull gray town where nobody smiled. One day, a little girl named Bloom arrived, carrying a bright yellow paintbrush. She began to paint laughter and joy on the walls. Slowly, the townspeople found happiness in her colors and learned to express their emotions. Eventually, the town transformed into a vibrant place where every day was a celebration of life.\",\"Once upon a time, an old clockmaker named Mr. Tick was known for creating the finest clocks in the town. But his favorite creation was an enchanted clock that could tell stories of the past. One day, a little girl named Clara stumbled into his shop and begged him to tell her a story. Mr. Tick set the clock and took her on a journey through time, where Clara learned the importance of history and family. Inspired, she decided to become a storyteller.\",\"Once upon a time, in a small fishing village, a mysterious blue whale appeared off the coast every summer. Legend had it that the whale could grant one wish to the person who dared to swim alongside it. A daring young boy named Leo decided to brave the waters. As he swam next to the majestic creature, he wished for prosperity for his village. From that day onward, the village thrived, and they celebrated the bond of friendship with the whale every summer.\",\"Once upon a time, in a land of giants, there lived a tiny girl named Fiona. Despite her size, she had a heart full of ambition. She dreamt of building a bridge between her village and the giants’ realm to facilitate friendship. With determination and ingenuity, she crafted a plan. When the giants saw her efforts, they helped her, and together they constructed a magnificent bridge. Fiona's courage became a legend, and the two realms flourished in harmony.\"],\"story_count\":10}\n"
-     ]
-    }
-   ],
    "source": [
     "from pydantic import BaseModel\n",
     "\n",
-    "# Define the Pydantic model for the structured output\n",
+    "\n",
     "class StoryResponse(BaseModel):\n",
     "    stories: list[str]\n",
     "    story_count: int\n",
     "\n",
+    "\n",
     "num_stories = 10\n",
     "content = \"Once upon a time,\"\n",
-    "\n",
-    "prompt_lines = [f\"Story #{i+1}: {content}\" for i in range(num_stories)]\n",
+    "prompt_lines = [f\"Story #{i + 1}: {content}\" for i in range(num_stories)]\n",
     "prompt_text = \"\\n\".join(prompt_lines)\n",
     "\n",
-    "messages = [\n",
-    "    {\n",
-    "        \"role\": \"developer\",\n",
-    "        \"content\": \"You are a helpful assistant. Please respond to each prompt as a separate short story.\"\n",
-    "    },\n",
-    "    {\n",
-    "        \"role\": \"user\",\n",
-    "        \"content\": prompt_text\n",
-    "    }\n",
-    "]\n",
-    "\n",
-    "# batched example, with all story completions in one request and using structured outputs\n",
-    "response = client.beta.chat.completions.parse(\n",
-    "    model=\"gpt-4o-mini\",\n",
-    "    messages=messages,\n",
-    "    response_format=StoryResponse,\n",
+    "response = client.responses.parse(\n",
+    "    model=MODEL,\n",
+    "    input=[\n",
+    "        {\n",
+    "            \"role\": \"developer\",\n",
+    "            \"content\": \"You are a helpful assistant. Return one short story per prompt.\",\n",
+    "        },\n",
+    "        {\n",
+    "            \"role\": \"user\",\n",
+    "            \"content\": prompt_text,\n",
+    "        },\n",
+    "    ],\n",
+    "    text_format=StoryResponse,\n",
     ")\n",
     "\n",
-    "print(response.choices[0].message.content)"
+    "print(response.output_parsed)\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example parallel processing script\n",
+    "\n",
+    "We've written an example script for parallel processing large quantities of API requests: [api_request_parallel_processor.py](https://github.com/openai/openai-cookbook/blob/main/examples/api_request_parallel_processor.py).\n",
+    "\n",
+    "The script combines some handy features:\n",
+    "- Streams requests from file so giant jobs do not exhaust memory.\n",
+    "- Makes requests concurrently to maximize throughput.\n",
+    "- Throttles both request and token usage to stay under rate limits.\n",
+    "- Retries failed requests and logs errors.\n",
+    "\n",
+    "For offline workloads, consider whether the [Batch API](https://platform.openai.com/docs/guides/batch/) is a better fit before building your own parallel runner. If you need lower-latency custom orchestration, this script remains a useful reference implementation.\n"
    ]
   },
   {


### PR DESCRIPTION
Implemented the cookbook refresh for `examples/How_to_handle_rate_limits.ipynb` based on the requested guidance.

Context for review:
## Review summary
This cookbook still addresses a real builder problem, and its core advice is mostly sound: exponential backoff with jitter, proactive throttling, batching, and caution around fallback models are all still worth teaching.

That said, it needs an update before it is safe to recommend broadly in 2026.

## What still works
- The conceptual explanation of **why rate limits exist** is fine.
- The guidance to use **randomized exponential backoff** on 429s is still aligned with OpenAI docs and broader distributed-systems best practice.
- The note that **failed requests still count against limits** is important and correct.
- The warning that **fallback models may share limits** and may change quality/cost/latency is still good production advice.
- The advice to **lower requested output tokens** to match expected completion size is still valid.

## What is outdated or risky
1. **API surface drift**
   - The notebook is written as if `chat.completions` is the default starting point.
   - Current OpenAI guidance positions the **Responses API** as the primary API for new builds.
   - Chat Completions is still supported, but this notebook should not teach it as the main path.

2. **Structured Outputs example uses a stale SDK pattern**
   - The batching example uses `client.beta.chat.completions.parse(...)`.
   - Current docs show `client.responses.parse(...)` and `client.chat.completions.parse(...)` without the `beta` namespace.
   - As written, this is the most concrete correctness risk in the notebook.

3. **Missing header-aware throttling**
   - The current rate-limits docs expose `x-ratelimit-limit-*`, `x-ratelimit-remaining-*`, and `x-ratelimit-reset-*` headers.
   - A modern rate-limit cookbook should teach readers to **adapt concurrency and sleep windows from headers**, not just react after a 429.

4. **Batch guidance is too weak for current best practice**
   - For offline / async workloads, OpenAI now explicitly offers the **Batch API** with **separate higher headroom** and **50% lower cost**.
   - The notebook discusses batching prompts into one synchronous request, which can help with RPM, but it should now also steer users to the actual Batch API for large jobs.

5. **Outdated error example**
   - The sample 429 string references `default-codex`, which reads as historical artifact rather than a good canonical current example.

6. **Model guidance should be less brittle**
   - `gpt-4o-mini` still works, so this is not a hard blocker.
   - But this cookbook is about rate-limit handling, not model selection, so it should avoid implying one hardcoded slug is the recommended default forever.
   - A placeholder plus a pointer to the current models page would age better.

## Recommended changes
- Rewrite the primary examples to use **`client.responses.create(...)`**.
- Replace **`client.beta.chat.completions.parse(...)`** with a current Structured Outputs example using **`client.responses.parse(...)`** or **`client.chat.completions.parse(...)`**.
- Add a short section on **reading rate-limit headers** and adapting request pacing from them.
- Add an example using **`.with_raw_response`** in the Python SDK to inspect headers.
- Add **request ID logging** guidance for debugging/support.
- Expand the throughput section to explicitly recommend the **Batch API** for non-real-time workloads.
- Replace the stale 429 sample with a generic current example.
- Use a **less brittle model selection pattern** instead of anchoring the notebook to one slug.

## Verdict
**Recommended action: Fix**

This should stay in the cookbook, but it needs a modernization pass. The topic is evergreen; the implementation guidance just needs to catch up with the current OpenAI API surface and production practices.

## Evidence
- OpenAI rate limits guide: https://developers.openai.com/api/docs/guides/rate-limits
- OpenAI migrate to Responses guide: https://developers.openai.com/api/docs/guides/migrate-to-responses
- OpenAI Structured Outputs guide: https://developers.openai.com/api/docs/guides/structured-outputs/
- OpenAI models page: https://developers.openai.com/api/docs/models
- OpenAI Batch API guide: https://platform.openai.com/docs/guides/batch/
- OpenAI Python SDK: https://github.com/openai/openai-python
- Google Cloud retry guidance: https://cloud.google.com/iam/docs/retry-strategy
- AWS backoff + jitter guidance: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
- Anthropic rate-limit headers / retry-after example: https://platform.claude.com/docs/en/api/rate-limits