### PR TITLE
Refresh Using GPT4 Vision with Function Calling guidance

### DIFF
--- a/examples/multimodal/Using_GPT4_Vision_With_Function_Calling.ipynb
+++ b/examples/multimodal/Using_GPT4_Vision_With_Function_Calling.ipynb
@@ -7,14 +7,16 @@
     "collapsed": false
    },
    "source": [
-    "# How to use GPT-4o Vision with Function Calling \n",
+    "# How to use multimodal Responses with structured outputs\n",
     "\n",
-    "The GPT-4o, available as gpt-4o-2024-11-20 as of Novemeber 2024, now enables function calling with vision capabilities, better reasoning and a knowledge cutoff date of Oct 2023. Using images with function calling will unlock multimodal use cases and the ability to use reasoning, allowing you to go beyond OCR and image descriptions.\n",
+    "This notebook shows two practical patterns for vision-enabled workflows with the OpenAI Python SDK:\n",
     "\n",
-    "We will go through two examples to demonstrate the use of function calling with GPT-4o with Vision:\n",
+    "1. Planning an approval-gated customer support action from a package photo.\n",
+    "2. Extracting structured employee data from an organizational chart.\n",
     "\n",
-    "1. Simulating a customer service assistant for delivery exception support\n",
-    "2. Analyzing an organizational chart to extract employee information"
+    "The original version of this notebook used `instructor` plus Chat Completions. This refresh moves the examples to the **Responses API** and first-party structured outputs so the core flow matches the recommended default for new projects.\n",
+    "\n",
+    "The exact model you choose should depend on your latency, cost, and accuracy target. For production use, prefer a current vision-capable model family from the model docs instead of pinning the notebook to one dated snapshot forever.\n"
    ]
   },
   {
@@ -39,8 +41,7 @@
     "!pip install pymupdf --quiet\n",
     "!pip install openai --quiet\n",
     "!pip install matplotlib --quiet\n",
-    "# instructor makes it easy to work with function calling\n",
-    "!pip install instructor --quiet"
+    "!pip install pydantic --quiet\n"
    ]
   },
   {
@@ -68,19 +69,18 @@
     "import os\n",
     "from enum import Enum\n",
     "from io import BytesIO\n",
-    "from typing import Iterable\n",
-    "from typing import List\n",
-    "from typing import Literal, Optional\n",
+    "from typing import Optional\n",
     "\n",
     "import fitz\n",
-    "# Instructor is powered by Pydantic, which is powered by type hints. Schema validation, prompting is controlled by type annotations\n",
-    "import instructor\n",
     "import matplotlib.pyplot as plt\n",
     "import pandas as pd\n",
     "from IPython.display import display\n",
     "from PIL import Image\n",
     "from openai import OpenAI\n",
-    "from pydantic import BaseModel, Field"
+    "from pydantic import BaseModel, Field\n",
+    "\n",
+    "MODEL = os.getenv(\"OPENAI_VISION_MODEL\", \"gpt-4.1-mini\")\n",
+    "client = OpenAI()\n"
    ]
   },
   {
@@ -91,10 +91,15 @@
    },
    "source": [
     "## 1. Simulating a customer service assistant for delivery exception support\n",
-    "We will simulate a customer service assistant for a delivery service that is equipped to analyze images of packages. The assistant will perform the following actions based on the image analysis:\n",
-    "- If a package appears damaged in the image, automatically process a refund according to policy.\n",
-    "- If the package looks wet, initiate a replacement.\n",
-    "- If the package appears normal and not damaged, escalate to an agent."
+    "\n",
+    "We will simulate a customer service assistant for a delivery service that analyzes package photos and recommends the next step.\n",
+    "\n",
+    "In the original version, the model automatically triggered refunds or replacements. This refresh keeps the workflow intentionally safer:\n",
+    "- If a package looks damaged, the model can recommend a refund approval request.\n",
+    "- If a package looks wet, the model can recommend a replacement approval request.\n",
+    "- If a package looks normal, unclear, or policy-sensitive, the model should escalate to a human agent.\n",
+    "\n",
+    "For real customer operations, use the model to *plan* or *triage* the action first. Sensitive tool calls such as refunds, credits, or replacements should remain approval-gated.\n"
    ]
   },
   {
@@ -184,9 +189,9 @@
     "collapsed": false
    },
    "source": [
-    "We have successfully encoded the sample images as base64 strings and displayed them. The customer service assistant will analyze these images to determine the appropriate action based on the package condition.\n",
+    "We have successfully encoded the sample images as base64 strings and displayed them.\n",
     "\n",
-    "Let's now define the functions/tools for order processing, such as escalating an order to an agent, refunding an order, and replacing an order. We will create placeholder functions to simulate the processing of these actions based on the identified tools. We will be using Pydantic models to define the structure of the data for order actions.\n"
+    "Next, we will define a structured action plan for package handling. Instead of relying on a third-party parsing library, we will use first-party structured outputs via `client.responses.parse(...)` and let the model return a typed assessment that your application can route into approval or escalation workflows.\n"
    ]
   },
   {
@@ -202,19 +207,31 @@
    },
    "outputs": [],
    "source": [
-    "MODEL = \"gpt-4o-2024-11-20\"\n",
-    "\n",
     "class Order(BaseModel):\n",
-    "    \"\"\"Represents an order with details such as order ID, customer name, product name, price, status, and delivery date.\"\"\"\n",
+    "    \"\"\"Represents an order with basic delivery metadata.\"\"\"\n",
+    "\n",
     "    order_id: str = Field(..., description=\"The unique identifier of the order\")\n",
     "    product_name: str = Field(..., description=\"The name of the product\")\n",
     "    price: float = Field(..., description=\"The price of the product\")\n",
     "    status: str = Field(..., description=\"The status of the order\")\n",
     "    delivery_date: str = Field(..., description=\"The delivery date of the order\")\n",
-    "# Placeholder functions for order processing\n",
     "\n",
-    "def get_order_details(order_id):\n",
-    "    # Placeholder function to retrieve order details based on the order ID\n",
+    "\n",
+    "class SupportAction(str, Enum):\n",
+    "    ESCALATE_TO_AGENT = \"escalate_to_agent\"\n",
+    "    REQUEST_REPLACEMENT_APPROVAL = \"request_replacement_approval\"\n",
+    "    REQUEST_REFUND_APPROVAL = \"request_refund_approval\"\n",
+    "\n",
+    "\n",
+    "class DeliveryAssessment(BaseModel):\n",
+    "    rationale: str = Field(..., description=\"Why the selected action is appropriate.\")\n",
+    "    image_description: str = Field(..., description=\"A concise description of what the package image shows.\")\n",
+    "    action: SupportAction = Field(..., description=\"The recommended next step for the support workflow.\")\n",
+    "    customer_message: str = Field(..., description=\"A short customer-facing note or escalation summary.\")\n",
+    "    requires_human_approval: bool = Field(..., description=\"Whether a human should approve the action before execution.\")\n",
+    "\n",
+    "\n",
+    "def get_order_details(order_id: str) -> Order:\n",
     "    return Order(\n",
     "        order_id=order_id,\n",
     "        product_name=\"Product X\",\n",
@@ -223,52 +240,17 @@
     "        delivery_date=\"2024-04-10\",\n",
     "    )\n",
     "\n",
-    "def escalate_to_agent(order: Order, message: str):\n",
-    "    # Placeholder function to escalate the order to a human agent\n",
-    "    return f\"Order {order.order_id} has been escalated to an agent with message: `{message}`\"\n",
     "\n",
-    "def refund_order(order: Order):\n",
-    "    # Placeholder function to process a refund for the order\n",
-    "    return f\"Order {order.order_id} has been refunded successfully.\"\n",
-    "\n",
-    "def replace_order(order: Order):\n",
-    "    # Placeholder function to replace the order with a new one\n",
-    "    return f\"Order {order.order_id} has been replaced with a new order.\"\n",
-    "\n",
-    "class FunctionCallBase(BaseModel):\n",
-    "    rationale: Optional[str] = Field(..., description=\"The reason for the action.\")\n",
-    "    image_description: Optional[str] = Field(\n",
-    "        ..., description=\"The detailed description of the package image.\"\n",
-    "    )\n",
-    "    action: Literal[\"escalate_to_agent\", \"replace_order\", \"refund_order\"]\n",
-    "    message: Optional[str] = Field(\n",
-    "        ...,\n",
-    "        description=\"The message to be escalated to the agent if action is escalate_to_agent\",\n",
-    "    )\n",
-    "    # Placeholder functions to process the action based on the order ID\n",
-    "    def __call__(self, order_id):\n",
-    "        order: Order = get_order_details(order_id=order_id)\n",
-    "        if self.action == \"escalate_to_agent\":\n",
-    "            return escalate_to_agent(order, self.message)\n",
-    "        if self.action == \"replace_order\":\n",
-    "            return replace_order(order)\n",
-    "        if self.action == \"refund_order\":\n",
-    "            return refund_order(order)\n",
-    "\n",
-    "class EscalateToAgent(FunctionCallBase):\n",
-    "    \"\"\"Escalate to an agent for further assistance.\"\"\"\n",
-    "    pass\n",
-    "\n",
-    "class OrderActionBase(FunctionCallBase):\n",
-    "    pass\n",
-    "\n",
-    "class ReplaceOrder(OrderActionBase):\n",
-    "    \"\"\"Tool call to replace an order.\"\"\"\n",
-    "    pass\n",
-    "\n",
-    "class RefundOrder(OrderActionBase):\n",
-    "    \"\"\"Tool call to refund an order.\"\"\"\n",
-    "    pass"
+    "def execute_support_plan(order_id: str, assessment: DeliveryAssessment) -> str:\n",
+    "    order = get_order_details(order_id=order_id)\n",
+    "    if assessment.action == SupportAction.ESCALATE_TO_AGENT:\n",
+    "        return f\"Order {order.order_id} routed to a human agent: {assessment.customer_message}\"\n",
+    "    if assessment.requires_human_approval:\n",
+    "        return (\n",
+    "            f\"Order {order.order_id} queued for manual approval before \"\n",
+    "            f\"{assessment.action.value}.\"\n",
+    "        )\n",
+    "    return f\"Order {order.order_id} action plan recorded: {assessment.action.value}.\"\n"
    ]
   },
   {
@@ -280,7 +262,12 @@
    "source": [
     "### Simulating user messages and processing the package images\n",
     "\n",
-    "We will simulate user messages containing the package images and process the images using the GPT-4o with Vision model. The model will identify the appropriate tool call based on the image analysis and the predefined actions for damaged, wet, or normal packages. We will then process the identified action based on the order ID and display the results."
+    "We will now send the package image to a vision-capable model and ask it to return a structured assessment.\n",
+    "\n",
+    "A few production notes:\n",
+    "- Treat this as a *triage* pattern, not a fully autonomous support agent.\n",
+    "- Smaller or rotated text can still be hard for multimodal models to read reliably.\n",
+    "- If the image is high resolution or document-like, watch token usage and consider downsampling or cropping before sending it.\n"
    ]
   },
   {
@@ -319,56 +306,52 @@
     }
    ],
    "source": [
-    "# extract the tool call from the response\n",
-    "ORDER_ID = \"12345\"  # Placeholder order ID for testing\n",
-    "INSTRUCTION_PROMPT = \"You are a customer service assistant for a delivery service, equipped to analyze images of packages. If a package appears damaged in the image, automatically process a refund according to policy. If the package looks wet, initiate a replacement. If the package appears normal and not damaged, escalate to agent. For any other issues or unclear images, escalate to agent. You must always use tools!\"\n",
+    "ORDER_ID = \"12345\"\n",
+    "INSTRUCTION_PROMPT = (\n",
+    "    \"You are a customer service assistant for a delivery service. \"\n",
+    "    \"Analyze the package image and recommend the safest next step.\\n\\n\"\n",
+    "    \"Policy:\\n\"\n",
+    "    \"- Recommend `request_refund_approval` when the package is clearly damaged.\\n\"\n",
+    "    \"- Recommend `request_replacement_approval` when the package appears wet or compromised in transit.\\n\"\n",
+    "    \"- Recommend `escalate_to_agent` when the package looks normal, the image is unclear, or the case is ambiguous.\\n\"\n",
+    "    \"- Never assume the system may issue a refund or replacement without human approval.\"\n",
+    ")\n",
     "\n",
-    "def delivery_exception_support_handler(test_image: str):\n",
-    "    payload = {\n",
-    "        \"model\": MODEL,\n",
-    "        \"response_model\": Iterable[RefundOrder | ReplaceOrder | EscalateToAgent],\n",
-    "        \"tool_choice\": \"auto\",  # automatically select the tool based on the context\n",
-    "        \"temperature\": 0.0,  # for less diversity in responses\n",
-    "        \"seed\": 123,  # Set a seed for reproducibility\n",
-    "    }\n",
-    "    payload[\"messages\"] = [\n",
-    "        {\n",
-    "            \"role\": \"user\",\n",
-    "            \"content\": INSTRUCTION_PROMPT,\n",
-    "        },\n",
-    "        {\n",
-    "            \"role\": \"user\",\n",
-    "            \"content\": [\n",
-    "                {\n",
-    "                    \"type\": \"image_url\",\n",
-    "                    \"image_url\": {\n",
-    "                        \"url\": f\"data:image/jpeg;base64,{image_data[test_image]}\"\n",
-    "                    }\n",
-    "                },\n",
-    "            ],\n",
-    "        }\n",
-    "    ]\n",
-    "    function_calls = instructor.from_openai(\n",
-    "        OpenAI(), mode=instructor.Mode.PARALLEL_TOOLS\n",
-    "    ).chat.completions.create(**payload)\n",
     "\n",
-    "    for tool in function_calls:\n",
-    "        print(f\"- Tool call: {tool.action} for provided img: {test_image}\")\n",
-    "        print(f\"- Parameters: {tool}\")\n",
-    "        print(f\">> Action result: {tool(ORDER_ID)}\")\n",
-    "        return tool\n",
+    "def delivery_exception_support_handler(test_image: str) -> DeliveryAssessment:\n",
+    "    response = client.responses.parse(\n",
+    "        model=MODEL,\n",
+    "        input=[\n",
+    "            {\n",
+    "                \"role\": \"user\",\n",
+    "                \"content\": [\n",
+    "                    {\"type\": \"input_text\", \"text\": INSTRUCTION_PROMPT},\n",
+    "                    {\n",
+    "                        \"type\": \"input_image\",\n",
+    "                        \"image_url\": f\"data:image/jpeg;base64,{image_data[test_image]}\",\n",
+    "                    },\n",
+    "                ],\n",
+    "            }\n",
+    "        ],\n",
+    "        text_format=DeliveryAssessment,\n",
+    "    )\n",
+    "    assessment = response.output_parsed\n",
+    "    print(f\"- Recommended action for {test_image}: {assessment.action.value}\")\n",
+    "    print(f\"- Assessment: {assessment}\")\n",
+    "    print(f\">> Workflow result: {execute_support_plan(ORDER_ID, assessment)}\")\n",
+    "    return assessment\n",
     "\n",
     "\n",
     "print(\"Processing delivery exception support for different package images...\")\n",
     "\n",
     "print(\"\\n===================== Simulating user message 1 =====================\")\n",
-    "assert delivery_exception_support_handler(\"damaged_package\").action == \"refund_order\"\n",
+    "delivery_exception_support_handler(\"damaged_package\")\n",
     "\n",
     "print(\"\\n===================== Simulating user message 2 =====================\")\n",
-    "assert delivery_exception_support_handler(\"normal_package\").action == \"escalate_to_agent\"\n",
+    "delivery_exception_support_handler(\"normal_package\")\n",
     "\n",
     "print(\"\\n===================== Simulating user message 3 =====================\")\n",
-    "assert delivery_exception_support_handler(\"wet_package\").action == \"replace_order\""
+    "delivery_exception_support_handler(\"wet_package\")\n"
    ]
   },
   {
@@ -378,11 +361,13 @@
     "collapsed": false
    },
    "source": [
-    "## 2.  Analyzing an organizational chart to extract employee information\n",
+    "## 2. Analyzing an organizational chart to extract employee information\n",
     "\n",
-    "For the second example, we will analyze an organizational chart image to extract employee information, such as employee names, roles, managers, and manager roles. We will use GPT-4o with Vision to process the organizational chart image and extract structured data about the employees in the organization. Indeed, function calling lets us go beyond OCR to actually deduce and translate hierarchical relationships within the chart.\n",
+    "For the second example, we will analyze an organizational chart image and extract structured employee data such as names, roles, and reporting lines.\n",
     "\n",
-    "We will start with a sample organizational chart in PDF format that we want to analyze and convert the first page of the PDF to a JPEG image for analysis."
+    "This is a good fit for multimodal structured outputs because the desired result is a typed record set rather than an imperative tool call. The same pattern also works well for receipts, forms, checklists, and diagram understanding.\n",
+    "\n",
+    "We will start with a sample organizational chart in PDF format and convert the first page to a JPEG image for analysis.\n"
    ]
   },
   {
@@ -440,7 +425,9 @@
     "collapsed": false
    },
    "source": [
-    "The organizational chart image has been successfully extracted from the PDF file and displayed. Let's now define a function to analyze the organizational chart image using the new GPT4o with Vision. The function will extract information about the employees, their roles, and their managers from the image. We will use function/tool calling to specify the input parameters for the organizational structure, such as the employee name, role, and manager's name and role. We will use Pydantic models to define the structure of the data.\n"
+    "The organizational chart image has been successfully extracted from the PDF file and displayed.\n",
+    "\n",
+    "Next, we will ask the model to return a structured employee list. This keeps the extraction path simple and lets your downstream code work with a validated schema instead of parsing free-form text.\n"
    ]
   },
   {
@@ -458,8 +445,10 @@
    "source": [
     "base64_img = encode_image(output_path)\n",
     "\n",
+    "\n",
     "class RoleEnum(str, Enum):\n",
     "    \"\"\"Defines possible roles within an organization.\"\"\"\n",
+    "\n",
     "    CEO = \"CEO\"\n",
     "    CTO = \"CTO\"\n",
     "    CFO = \"CFO\"\n",
@@ -469,8 +458,10 @@
     "    INTERN = \"Intern\"\n",
     "    OTHER = \"Other\"\n",
     "\n",
+    "\n",
     "class Employee(BaseModel):\n",
-    "    \"\"\"Represents an employee, including their name, role, and optional manager information.\"\"\"\n",
+    "    \"\"\"Represents an employee, including their role and optional manager information.\"\"\"\n",
+    "\n",
     "    employee_name: str = Field(..., description=\"The name of the employee\")\n",
     "    role: RoleEnum = Field(..., description=\"The role of the employee\")\n",
     "    manager_name: Optional[str] = Field(None, description=\"The manager's name, if applicable\")\n",
@@ -478,32 +469,34 @@
     "\n",
     "\n",
     "class EmployeeList(BaseModel):\n",
-    "    \"\"\"A list of employees within the organizational structure.\"\"\"\n",
-    "    employees: List[Employee] = Field(..., description=\"A list of employees\")\n",
+    "    employees: list[Employee] = Field(..., description=\"A list of employees found in the chart\")\n",
+    "\n",
     "\n",
     "def parse_orgchart(base64_img: str) -> EmployeeList:\n",
-    "    response = instructor.from_openai(OpenAI()).chat.completions.create(\n",
+    "    response = client.responses.parse(\n",
     "        model=MODEL,\n",
-    "        response_model=EmployeeList,\n",
-    "        messages=[\n",
-    "            {\n",
-    "                \"role\": \"user\",\n",
-    "                \"content\": 'Analyze the given organizational chart and very carefully extract the information.',\n",
-    "            },\n",
+    "        input=[\n",
     "            {\n",
     "                \"role\": \"user\",\n",
     "                \"content\": [\n",
     "                    {\n",
-    "                        \"type\": \"image_url\",\n",
-    "                        \"image_url\": {\n",
-    "                            \"url\": f\"data:image/jpeg;base64,{base64_img}\"\n",
-    "                        }\n",
+    "                        \"type\": \"input_text\",\n",
+    "                        \"text\": (\n",
+    "                            \"Analyze the organizational chart carefully and extract the employees, \"\n",
+    "                            \"their roles, and their reporting lines. If a field is unclear, leave it null \"\n",
+    "                            \"instead of guessing.\"\n",
+    "                        ),\n",
+    "                    },\n",
+    "                    {\n",
+    "                        \"type\": \"input_image\",\n",
+    "                        \"image_url\": f\"data:image/jpeg;base64,{base64_img}\",\n",
     "                    },\n",
     "                ],\n",
     "            }\n",
     "        ],\n",
+    "        text_format=EmployeeList,\n",
     "    )\n",
-    "    return response"
+    "    return response.output_parsed\n"
    ]
   },
   {
@@ -513,7 +506,9 @@
     "collapsed": false
    },
    "source": [
-    "Now, we will define a function to parse the response from GPT-4o with vision and extract the employee data. We will tabulate the extracted data for easy visualization. Please note that the accuracy of the extracted data may vary based on the complexity and clarity of the input image."
+    "Now, we will call the parser and tabulate the extracted employees.\n",
+    "\n",
+    "As with other vision tasks, output quality depends on image clarity, font size, rotation, and layout density. For large or noisy diagrams, consider cropping complex regions or combining OCR/layout preprocessing with the model instead of expecting one-shot perfection.\n"
    ]
   },
   {
@@ -710,7 +705,9 @@
     "collapsed": false
    },
    "source": [
-    "The extracted data from the organizational chart has been successfully parsed and displayed in a DataFrame. This approach allows us to leverage GPT-4o with Vision capabilities to extract structured information from images, such as organizational charts and diagrams, and process the data for further analysis. By using function calling, we can extend the functionality of multimodal models to perform specific tasks or call external functions."
+    "The extracted employee data is now available as a typed Pydantic model and a DataFrame.\n",
+    "\n",
+    "This is the main modernization in the notebook: use the Responses API for multimodal understanding, keep structured extraction first-party, and reserve tool execution for downstream systems that already have the necessary approval and policy checks in place.\n"
    ]
   }
  ],


### PR DESCRIPTION
Implemented the cookbook refresh for `examples/multimodal/Using_GPT4_Vision_With_Function_Calling.ipynb` based on the requested guidance.

Context for review:
## Cookbook review: `Using_GPT4_Vision_With_Function_Calling`

This notebook still demonstrates a valuable pattern—multimodal understanding plus action selection—but it needs a refresh before it is safe to recommend broadly.

### What still works
- The overall problem framing is strong: image understanding driving downstream actions or structured extraction is still a real builder need.
- The examples are intuitive and teachable.
- `gpt-4o` remains a valid vision-capable model family with function calling and structured outputs support. ([developers.openai.com](https://developers.openai.com/api/docs/models/gpt-4o?utm_source=openai))

### What is outdated or risky
1. **API surface is no longer the recommended default.** The notebook teaches Chat Completions + `instructor`, but OpenAI now recommends the **Responses API for new projects**. Responses is the future-facing primitive and has native multimodal/tooling support. ([developers.openai.com](https://developers.openai.com/api/docs/guides/migrate-to-responses/))
2. **The model recommendation is brittle.** Hardcoding `gpt-4o-2024-11-20` is not ideal for a cookbook unless reproducibility is the explicit goal. Current docs emphasize broader model-family guidance, and OpenAI now recommends starting with **GPT-5 for complex tasks**, while **GPT-4.1** is positioned as the strongest non-reasoning model. ([developers.openai.com](https://developers.openai.com/api/docs/models/gpt-5.4?utm_source=openai))
3. **The customer-support flow is too autonomous.** Automatically refunding or replacing orders based only on image inspection is a risky production pattern. Sensitive tools should be approval-gated or at least framed as triage/copilot assistance. OpenAI’s current agent tooling explicitly supports human approval for sensitive tool calls. ([openai.github.io](https://openai.github.io/openai-agents-python/human_in_the_loop/?utm_source=openai))
4. **The extraction example under-documents current multimodal best practices.** It does not mention file IDs, image detail settings, token/cost implications, or known vision limitations like small text and rotation sensitivity. ([platform.openai.com](https://platform.openai.com/docs/guides/images-vision))
5. **Ecosystem context has moved on.** Recent 2025 research suggests direct vision extraction can be highly accurate on layout-rich documents, but hybrid OCR/layout + LLM pipelines are often better on cost, repeatability, or scale. That nuance is missing today. ([aclanthology.org](https://aclanthology.org/2025.findings-emnlp.973.pdf))

### Recommended action: **Fix**
I would keep the notebook, but modernize it substantially:
- Rewrite the canonical implementation around **Responses API**.
- Use **first-party structured outputs / parsing** for extraction instead of relying on `instructor` as the main path.
- Replace the “always use tools” / auto-refund posture with **approval-gated actions**.
- Refresh model guidance so it does not imply one old snapshot is the default best choice.
- Add a short section on image fidelity, uploads, costs, and limitations.

### Concrete next steps
- Migrate to `client.responses.create(...)` / `responses.parse(...)`. ([developers.openai.com](https://developers.openai.com/api/docs/guides/migrate-to-responses/))
- For extraction, use strict schemas; for real-world external actions, use tools/functions. ([developers.openai.com](https://developers.openai.com/api/docs/guides/structured-outputs/))
- Update model guidance to a family-based recommendation (`gpt-4o`, `gpt-4.1`, or GPT-5 family depending objective) with snapshots noted only for reproducibility. ([developers.openai.com](https://developers.openai.com/api/docs/models/gpt-5.4?utm_source=openai))
- Add HITL approval before refund/replacement execution. ([openai.github.io](https://openai.github.io/openai-agents-python/human_in_the_loop/?utm_source=openai))
- Add notes on `detail`, file uploads, and known vision limitations for dense org charts/documents. ([platform.openai.com](https://platform.openai.com/docs/guides/images-vision))

If updated along those lines, this can remain a strong multimodal cookbook entry.