### PR TITLE
Add runtime containment cookbook for multi-agent workflows

### DIFF
--- a/examples/agents_sdk/runtime_containment_multi_agent.ipynb
+++ b/examples/agents_sdk/runtime_containment_multi_agent.ipynb
@@ -1,0 +1,381 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Runtime Containment for Multi-Agent Workflows\n",
+    "\n",
+    "When you run multiple agents in a loop -- researching, planning, executing -- nothing stops them from blowing through your API budget or looping forever. OpenAI's [guardrails](https://platform.openai.com/docs/guides/agent-builder-safety) handle content safety, but not execution limits: how many calls, how much spend, when to stop.\n",
+    "\n",
+    "This notebook shows how to add runtime containment to a multi-agent workflow built with the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python). We use [veronica-core](https://github.com/amabito/veronica-core) as the containment layer -- you can swap in any library that does budget tracking and circuit breaking.\n",
+    "\n",
+    "We will:\n",
+    "1. Run a multi-agent research workflow **without** containment and watch it overshoot\n",
+    "2. Run the **same** workflow **with** containment and see it halt cleanly\n",
+    "3. Compare cost, call count, and execution time side by side"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1. Install dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install openai-agents veronica-core nest_asyncio -q"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import asyncio\n",
+    "import time\n",
+    "import nest_asyncio\n",
+    "\n",
+    "from agents import Agent, Runner\n",
+    "\n",
+    "nest_asyncio.apply()\n",
+    "\n",
+    "assert os.getenv(\"OPENAI_API_KEY\"), \"Set OPENAI_API_KEY before running this notebook\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "2. Define the agents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "research_agent = Agent(\n",
+    "    name=\"Researcher\",\n",
+    "    instructions=(\n",
+    "        \"You are a research assistant. When given a topic, \"\n",
+    "        \"search for key facts and return a structured summary. \"\n",
+    "        \"If you need more detail, ask follow-up questions.\"\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "writer_agent = Agent(\n",
+    "    name=\"Writer\",\n",
+    "    instructions=(\n",
+    "        \"You are a technical writer. Take research notes and \"\n",
+    "        \"produce a concise, well-structured report. \"\n",
+    "        \"If the notes are incomplete, request more research.\"\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "reviewer_agent = Agent(\n",
+    "    name=\"Reviewer\",\n",
+    "    instructions=(\n",
+    "        \"You are a senior editor. Review the report for accuracy \"\n",
+    "        \"and completeness. If issues are found, send it back to \"\n",
+    "        \"the writer with specific feedback. Be thorough -- check \"\n",
+    "        \"every claim.\"\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Part 1: Without Containment\n",
+    "\n",
+    "We run a research-write-review loop. Each iteration calls all three agents. Without limits, the loop runs until `max_iterations` -- burning through API calls even when the output is already good enough."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "3. Run the uncontained loop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def run_uncontained(topic, max_iterations=6):\n",
+    "    stats = {\"calls\": 0, \"start\": time.time()}\n",
+    "    notes = topic\n",
+    "    report = \"\"\n",
+    "\n",
+    "    for i in range(max_iterations):\n",
+    "        result = await Runner.run(research_agent, notes)\n",
+    "        notes = result.final_output\n",
+    "        stats[\"calls\"] += 1\n",
+    "\n",
+    "        result = await Runner.run(writer_agent, notes)\n",
+    "        report = result.final_output\n",
+    "        stats[\"calls\"] += 1\n",
+    "\n",
+    "        result = await Runner.run(reviewer_agent, report)\n",
+    "        feedback = result.final_output\n",
+    "        stats[\"calls\"] += 1\n",
+    "\n",
+    "        print(f\"Iteration {i+1}: {len(report)} chars, {stats['calls']} total calls\")\n",
+    "        notes = f\"Previous report:\\n{report}\\n\\nReviewer feedback:\\n{feedback}\"\n",
+    "\n",
+    "    stats[\"elapsed\"] = time.time() - stats[\"start\"]\n",
+    "    stats[\"report_len\"] = len(report)\n",
+    "    return stats, report"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uncontained_stats, uncontained_report = asyncio.run(\n",
+    "    run_uncontained(\"Compare WebSocket vs SSE for real-time AI streaming applications\")\n",
+    ")\n",
+    "print(f\"\\nTotal calls: {uncontained_stats['calls']}\")\n",
+    "print(f\"Elapsed: {uncontained_stats['elapsed']:.1f}s\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All 6 iterations ran. The reviewer kept finding things to improve, so the loop never stopped early. In production, this means unbounded cost for every request.\n",
+    "\n",
+    "## Part 2: With Containment\n",
+    "\n",
+    "Now we wrap the same loop with `veronica-core`. Two enforcement mechanisms:\n",
+    "\n",
+    "- **BudgetEnforcer**: tracks spend and halts when the dollar cap is hit\n",
+    "- **CircuitBreaker**: opens after N consecutive failures, skipping the broken agent"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "4. Set up budget and circuit breaker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from veronica_core import BudgetEnforcer, CircuitBreaker, CircuitState\n",
+    "\n",
+    "budget = BudgetEnforcer(limit_usd=0.50)\n",
+    "print(f\"Budget: ${budget.limit_usd:.2f}, spent: ${budget.spent_usd:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "5. Wrap the runner with enforcement"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ContainedRunner:\n",
+    "    def __init__(self, budget, failure_threshold=3):\n",
+    "        self.budget = budget\n",
+    "        self.failure_threshold = failure_threshold\n",
+    "        self.call_count = 0\n",
+    "        self.blocked_calls = []\n",
+    "        self.breakers = {}\n",
+    "\n",
+    "    def _get_breaker(self, name):\n",
+    "        if name not in self.breakers:\n",
+    "            self.breakers[name] = CircuitBreaker(\n",
+    "                failure_threshold=self.failure_threshold,\n",
+    "            )\n",
+    "        return self.breakers[name]\n",
+    "\n",
+    "    async def run(self, agent, input_text):\n",
+    "        name = agent.name\n",
+    "        cb = self._get_breaker(name)\n",
+    "\n",
+    "        # Circuit breaker: skip agents that tripped\n",
+    "        if cb.state == CircuitState.OPEN:\n",
+    "            self.blocked_calls.append((name, \"circuit_open\"))\n",
+    "            return None\n",
+    "\n",
+    "        # Budget: halt if we already blew the cap\n",
+    "        if self.budget.is_exceeded:\n",
+    "            self.blocked_calls.append((name, \"budget_exceeded\"))\n",
+    "            return None\n",
+    "\n",
+    "        try:\n",
+    "            result = await Runner.run(agent, input_text)\n",
+    "            self.call_count += 1\n",
+    "            # spend() records cost after the call completes -- the call\n",
+    "            # that crosses the limit still runs, but the next one is blocked\n",
+    "            self.budget.spend(0.05)  # estimate per call\n",
+    "            cb.record_success()\n",
+    "            return result\n",
+    "        except Exception:\n",
+    "            cb.record_failure()\n",
+    "            self.blocked_calls.append((name, f\"error (failures: {cb.failure_count})\"))\n",
+    "            return None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "6. Run the contained loop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def run_contained(topic, max_iterations=6):\n",
+    "    budget = BudgetEnforcer(limit_usd=0.50)\n",
+    "    runner = ContainedRunner(budget)\n",
+    "    stats = {\"start\": time.time()}\n",
+    "    notes = topic\n",
+    "    report = \"\"\n",
+    "\n",
+    "    for i in range(max_iterations):\n",
+    "        result = await runner.run(research_agent, notes)\n",
+    "        if result is None:\n",
+    "            print(f\"Iteration {i+1}: HALTED (budget or circuit breaker)\")\n",
+    "            break\n",
+    "        notes = result.final_output\n",
+    "\n",
+    "        result = await runner.run(writer_agent, notes)\n",
+    "        if result is None:\n",
+    "            print(f\"Iteration {i+1}: HALTED after research\")\n",
+    "            break\n",
+    "        report = result.final_output\n",
+    "\n",
+    "        result = await runner.run(reviewer_agent, report)\n",
+    "        if result is None:\n",
+    "            print(f\"Iteration {i+1}: HALTED after write\")\n",
+    "            break\n",
+    "        feedback = result.final_output\n",
+    "\n",
+    "        print(f\"Iteration {i+1}: {len(report)} chars, {runner.call_count} calls, ${runner.budget.spent_usd:.2f} spent\")\n",
+    "        notes = f\"Previous report:\\n{report}\\n\\nReviewer feedback:\\n{feedback}\"\n",
+    "\n",
+    "    stats[\"calls\"] = runner.call_count\n",
+    "    stats[\"blocked\"] = len(runner.blocked_calls)\n",
+    "    stats[\"elapsed\"] = time.time() - stats[\"start\"]\n",
+    "    stats[\"spent_usd\"] = runner.budget.spent_usd\n",
+    "    stats[\"report_len\"] = len(report) if report else 0\n",
+    "    return stats, report, runner"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "contained_stats, contained_report, runner = asyncio.run(\n",
+    "    run_contained(\"Compare WebSocket vs SSE for real-time AI streaming applications\")\n",
+    ")\n",
+    "print(f\"\\nTotal calls: {contained_stats['calls']}\")\n",
+    "print(f\"Blocked: {contained_stats['blocked']}\")\n",
+    "print(f\"Spent: ${contained_stats['spent_usd']:.2f} / $0.50 budget\")\n",
+    "print(f\"Elapsed: {contained_stats['elapsed']:.1f}s\")\n",
+    "if runner.blocked_calls:\n",
+    "    print(f\"Block log: {runner.blocked_calls}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The loop stopped after the budget was exhausted. The report from the last complete iteration is still usable -- we just did not burn more API calls polishing it.\n",
+    "\n",
+    "## Part 3: Before/After Comparison"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "7. Compare the two runs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "header = f\"{'Metric':<25} {'Without':<20} {'With':<20}\"\n",
+    "print(header)\n",
+    "print(\"-\" * 65)\n",
+    "rows = [\n",
+    "    (\"LLM calls\", uncontained_stats[\"calls\"], contained_stats[\"calls\"]),\n",
+    "    (\"Blocked calls\", 0, contained_stats[\"blocked\"]),\n",
+    "    (\"Elapsed (s)\", f\"{uncontained_stats['elapsed']:.1f}\", f\"{contained_stats['elapsed']:.1f}\"),\n",
+    "    (\"Report length (chars)\", uncontained_stats[\"report_len\"], contained_stats[\"report_len\"]),\n",
+    "]\n",
+    "for metric, without, with_ in rows:\n",
+    "    print(f\"{metric:<25} {str(without):<20} {str(with_):<20}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "The uncontained loop ran all iterations and made ~18 LLM calls. The contained version stopped when the $0.50 budget was hit and still produced a usable report.\n",
+    "\n",
+    "- **Budget enforcement** prevents runaway cost. Set a dollar cap per request, and the loop halts cleanly instead of silently overspending.\n",
+    "- **Circuit breaking** isolates failing agents. If one agent starts erroring, it gets removed from the loop instead of poisoning every iteration.\n",
+    "- **These are complementary to content guardrails.** OpenAI's built-in guardrails handle what the model *says*. Runtime containment handles what the system *does*."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/registry.yaml
+++ b/registry.yaml
@@ -185,6 +185,17 @@
   tags:
     - agents-sdk
 
+- title: Runtime Containment for Multi-Agent Workflows
+  path: examples/agents_sdk/runtime_containment_multi_agent.ipynb
+  slug: runtime-containment-multi-agent
+  date: 2026-03-15
+  authors:
+    - amabito
+  tags:
+    - agents-sdk
+    - budget
+    - circuit-breaker
+
 - title: Automating Code Quality and Security Fixes with Codex CLI on GitLab
   path: examples/codex/secure_quality_gitlab.md
   slug: secure-quality-gitlab


### PR DESCRIPTION
## Summary

Notebook showing how to add budget enforcement and circuit breaking to a
multi-agent loop built with the Agents SDK. Runs the same 3-agent workflow
with and without containment, then compares call count and execution time.

Tested ContainedRunner logic locally with 9 tests covering budget enforcement,
boundary conditions, circuit breaker open/reset, agent isolation, compound
state (budget + circuit simultaneous), and zero-budget edge case. All passing.

## Motivation

The agents_sdk cookbooks cover orchestration patterns (parallel, handoffs,
memory) but nothing covers runaway loops -- no budget cap, no circuit breaker,
no halt mechanism.

OpenAI's safety docs cover content guardrails. This is about the other half --
execution limits. Uses veronica-core as the containment layer, but any
budget/circuit-breaker library works.

---

## For new content

- [x] I have added a new entry in [registry.yaml](https://github.com/openai/openai-cookbook/blob/main/registry.yaml) (and, optionally, in [authors.yaml](https://github.com/openai/openai-cookbook/blob/main/authors.yaml)) so that my content renders on the cookbook website.
- [x] I have conducted a self-review of my content based on the [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md#rubric):
  - [x] Relevance: This content is related to building with OpenAI technologies and is useful to others.
  - [x] Uniqueness: I have searched for related examples in the OpenAI Cookbook, and verified that my content offers new insights or unique information compared to existing documentation.
  - [x] Spelling and Grammar: I have checked for spelling or grammatical mistakes.
  - [x] Clarity: I have done a final read-through and verified that my submission is well-organized and easy to understand.
  - [x] Correctness: The information I include is correct and all of my code executes successfully.
  - [x] Completeness: I have explained everything fully, including all necessary references and citations.