### PR TITLE
docs: fix typo in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing the the cookbook
+# Contributing to the cookbook
 
 The OpenAI Cookbook is a collection of useful patterns and examples of working with the OpenAI platform, provided as a community resource.
 


### PR DESCRIPTION
## Summary
- fix the duplicated word in the contributing guide title

## Related issue
- N/A (trivial documentation typo fix)

## Guideline alignment
- Read https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md
- one-file docs-only change
- no behavior change

## Validation
- Not run (docs-only change)
