### PR TITLE
[codex] Add teen safety policy pack section

### DIFF
--- a/articles/gpt-oss-safeguard-guide.md
+++ b/articles/gpt-oss-safeguard-guide.md
@@ -277,6 +277,128 @@ Before rolling out a new or revised policy, run it through gpt-oss-safeguard to 
 
 gpt-oss-safeguard’s bring-your-own-policy design allows policy teams to A/B test alternative definitions directly in production without model retraining.
 
+## Off-the-shelf Teen Safety Policies
+
+While safety classifiers like gpt-oss-safeguard can detect harmful content, they depend on clear definitions of what that content is. In practice, one of the biggest challenges developers face is defining policies that accurately capture teen-specific risks and can be consistently applied in real systems.
+
+To address this challenge, OpenAI has released the [teen-safety-policy-pack](https://github.com/openai/teen-safety-policy-pack), a set of safety policies tailored to common risks faced by teens and informed by careful review of existing research on teens' unique developmental differences. These policies are structured as prompts that can be directly used with [gpt-oss-safeguard](https://github.com/openai/gpt-oss-safeguard) and other reasoning models, enabling developers to apply consistent safety standards across their systems more easily.
+
+The initial release includes policies covering:
+
+- Graphic violent content
+- Graphic sexual content
+- Harmful body ideals and behaviors
+- Dangerous activities and challenges
+- Romantic or violent roleplay
+- Age-restricted goods and services
+
+These policies can be used for real-time content filtering, as well as offline analysis of user-generated content.
+
+### Example Dangerous Content Policy
+
+```markdown
+# Dangerous Content Policy (#DC)
+
+## Goal
+
+Identify dangerous activity content that is not appropriate for teenagers. Classify each example as `VALID` (allowed) or `INVALID` (dangerous content) using this policy.
+
+This policy focuses on activities that could cause physical harm if attempted, especially viral challenges, risky stunts, unsafe experimentation, and dangerous at-home procedures.
+
+The assistant must not encourage, prompt, instruct, simulate, or facilitate teen participation in dangerous activities, stunts, or challenges. This includes glorifying the activity, providing instructions, realistic simulations, or linking to materials needed to attempt the challenge when user intent is present.
+
+## Definitions
+
+- **Dangerous activities or challenges**: Activities, stunts, or online challenges that could realistically cause physical injury, poisoning, suffocation, overdose, burns, falls, or other serious harm if attempted by a teenager.
+- Examples include risky viral trends such as substance misuse challenges, choking challenges, extreme stunts, and unsafe experimentation.
+- **Facilitation**: Providing instructions, tactics, materials, preparation steps, or optimization that would enable someone to attempt a dangerous activity.
+- **Glorification**: Portraying a dangerous activity as exciting, admirable, funny, or desirable in ways that could encourage imitation.
+- **Realistic simulation**: Detailed descriptions or narrative walkthroughs of performing a dangerous activity that functionally model how to do it.
+
+## Allowed Content (DC0 - Non-dangerous or Safety-oriented)
+
+Content that discourages risk, provides safety guidance, or discusses challenges critically or educationally without enough detail to mimic.
+
+Examples:
+
+- **DC0.a Media literacy**: "Why do viral internet challenges sometimes lead to injuries?"; "Viral internet challenges can lead to injuries because they often prioritize attention and shock value over safety."
+- **DC0.b Safety framing**: "Why is the Benadryl Challenge dangerous?"; "The Benadryl Challenge is dangerous because it involves taking more medication than recommended, which can cause serious health effects. Medications should only be used as directed."
+- **DC0.c Refusal or discouragement**: "That challenge can be very dangerous and isn't something I can help with."
+- **DC0.d News reporting without replicable detail**: "Summarize the news about injuries caused by viral TikTok challenges."; "Recent reports have highlighted multiple cases where teens were injured after attempting viral TikTok challenges. Health officials and educators have raised concerns about the risks."
+- **DC0.e Safety advice**: "If someone took too much medication, they should contact poison control or seek medical help."
+
+Output: `VALID`
+
+## Promotion or Glorification of Dangerous Challenges (DC1 - Promotion)
+
+Content that celebrates, encourages, or positively frames participation in dangerous activities without giving explicit instructions.
+
+Examples:
+
+- **DC1.a Glorification**: "The blackout challenge is wild, people pass out and wake up laughing."
+- **DC1.b Encouragement**: "You should totally try the Benadryl challenge, it's trending everywhere."
+- **DC1.c Social pressure**: "Everyone at school is doing it, don't be the only one who's scared."
+- **DC1.d Competitive framing**: "See how long you can hold your breath before you pass out. Compare with your friends."
+
+Output: `INVALID`
+
+## Facilitating Dangerous Activities (DC2 - Facilitation or instruction)
+
+Content that enables or instructs someone to perform dangerous challenges or stunts.
+
+Examples:
+
+- **DC2.a Instructions**: "Take 10 Benadryl tablets and wait for the hallucinations to start."
+- **DC2.b Preparation guidance**: "To do the blackout challenge safely, sit down first and breathe rapidly."
+- **DC2.c Optimization**: "The trick to the choking challenge is cutting off oxygen just long enough to pass out."
+- **DC2.d Material sourcing**: "You can buy Benadryl cheaply at this pharmacy before trying the challenge."
+- **DC2.e Realistic simulation**: "First you hold your breath, then your friend presses on your chest until you pass out."
+- **DC2.f Challenge escalation**: "Make it more extreme." or "How do I last longer?"
+
+Output: `INVALID`
+
+## Dangerous At-Home Procedures (DC3 - Facilitation or instruction)
+
+Content that enables or instructs teenagers to perform medical, cosmetic, or body-modification procedures at home without professional supervision.
+
+These activities may appear common online but can cause infection, nerve damage, bleeding, poisoning, burns, or other serious harm when attempted by minors without trained supervision.
+
+Examples:
+
+- **DC3.a DIY piercing instructions**: "You can pierce your ear at home by sterilizing a needle and pushing it through the lobe."
+- **DC3.b Preparation guidance**: "To pierce your nose yourself, numb it with ice and mark the spot before inserting the needle."
+- **DC3.c Optimization tips**: "Use a hollow needle instead of a safety pin so the piercing heals faster."
+- **DC3.d Material sourcing**: "Buy a piercing kit online and do the piercing yourself in the bathroom mirror."
+- **DC3.e Other at-home procedures**: "You can remove a mole yourself with dental floss or a razor blade."
+
+Output: `INVALID`
+
+## Label Format
+
+Each item gets one label indicating the presence and type of dangerous content.
+
+- `DC0`: Allowed or safety-oriented discussion.
+- `DC1`: Promotion or glorification.
+- `DC2`: Facilitation, instruction, sourcing, or realistic simulation of dangerous activities.
+- `DC3`: Dangerous at-home procedures.
+
+Examples:
+
+- "Why is the Benadryl challenge dangerous?" -> `DC0`
+- "The choking challenge is hilarious to watch." -> `DC1`
+- "Take a bunch of Benadryl pills to hallucinate." -> `DC2`
+- "Where can I buy Benadryl to try the challenge?" -> `DC2`
+- "Where can I buy Benadryl?" -> `DC0`
+- "It's technically possible to pierce an ear with a needle, but here are the safety-first steps you must follow." -> `DC3`
+
+## Ambiguity and Escalation
+
+- If the user shows clear intent to attempt a dangerous challenge, treat enabling responses as `DC2`.
+- If a response celebrates or encourages participation without instructions, classify it as `DC1`.
+- If the content overlaps with self-harm, substance misuse, or criminal activity, escalate to the relevant policy domain.
+- Educational or safety-focused discussion of dangerous trends remains `DC0`.
+```
+
 ## Integrating gpt-oss-safeguard with ROOST’s Tools
 
 ### Osprey


### PR DESCRIPTION
## Summary
- add a new "Off-the-shelf Teen Safety Policies" section to the gpt-oss-safeguard guide before the ROOST section
- link to the `teen-safety-policy-pack` repo and summarize the initial policy areas
- format the dangerous content sample as a fenced `markdown` policy block based on the linked source doc

## Why
Ludovic requested this cookbook update in Slack and provided the source copy in the linked Google Doc.

## Validation
- `git diff --check -- articles/gpt-oss-safeguard-guide.md`