### PR TITLE
feat: Building resilient agents with Kalibr — execution path routing for production

### DIFF
--- a/examples/partners/kalibr_resilient_agents/kalibr_resilient_agents.ipynb
+++ b/examples/partners/kalibr_resilient_agents/kalibr_resilient_agents.ipynb
@@ -3,62 +3,72 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": ["# Building Resilient Agents with Kalibr\n", "\n", "**Partner cookbook — [Kalibr Systems](https://kalibr.systems)**\n", "\n", "---\n", "\n", "## The Problem with Single-Model Agents\n", "\n", "Most OpenAI-powered agents are written like this:\n", "\n", "```python\n", "from openai import OpenAI\n", "client = OpenAI()\n", "response = client.chat.completions.create(model=\"gpt-4o\", messages=[...])\n", "```\n", "\n", "This works in demos. In production:\n", "- Rate limits fire at unpredictable times\n", "- Provider latency spikes during peak load\n", "- Partial outages affect specific model versions\n", "- Your agent silently degrades or errors out\n", "\n", "**What you need:** route away from degraded paths automatically. This notebook shows how with [Kalibr](https://kalibr.systems).\n", "\n", "---\n", "\n", "## What is Kalibr?\n", "\n", "Kalibr captures the outcome of every LLM call (success, failure, quality score 0–1), learns which model+parameter combinations work best for each goal, and routes the next call to the optimal path.\n", "\n", "**Not:** observability (Langfuse/LangSmith), model gateway (LiteLLM/OpenRouter), or a proxy.\n", "\n", "**Classification:** execution path routing based on outcome signals."]
+   "source": ["# Building Resilient Agents with Kalibr\n", "\n", "**Partner cookbook — [Kalibr Systems](https://kalibr.systems)**\n", "\n", "---\n", "\n", "## The Problem with Single-Model Agents\n", "\n", "Most OpenAI-powered agents are written like this:\n", "\n", "```python\n", "from openai import OpenAI\n", "client = OpenAI()\n", "response = client.chat.completions.create(model=\"gpt-4o\", messages=[...])\n", "```\n", "\n", "This works in demos. In production:\n", "- Rate limits fire at unpredictable times\n", "- Provider latency spikes during peak load\n", "- Partial outages affect specific model versions\n", "- Your agent silently degrades or errors out — often with HTTP 200 responses\n", "\n", "**What you actually need:** route away from degraded paths automatically, and route back when they recover.\n", "\n", "---\n", "\n", "## What is Kalibr?\n", "\n", "Kalibr captures the outcome of every LLM call (success, failure, quality score 0–1), learns which model+parameter combinations work best for each goal, and routes the next call to the optimal path — without redeployment.\n", "\n", "**Not:** observability (Langfuse/LangSmith), model gateway (LiteLLM/OpenRouter), or a proxy.\n", "\n", "**Classification:** execution path routing based on outcome signals."]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": ["!pip install kalibr openai anthropic"]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": ["import os\n", "\n", "os.environ[\"OPENAI_API_KEY\"] = \"your-openai-api-key\"\n", "os.environ[\"ANTHROPIC_API_KEY\"] = \"your-anthropic-api-key\"\n", "os.environ[\"KALIBR_API_KEY\"] = \"your-kalibr-api-key\"\n", "os.environ[\"KALIBR_TENANT_ID\"] = \"your-kalibr-tenant-id\""]
+   "source": ["!pip install kalibr openai anthropic -q"]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": ["## Part 1: The Fragile Agent (Before)\n", "\n", "Standard customer support agent hardcoded to GPT-4o."]
+   "source": ["## Setup\n", "\n", "Set your API keys in the environment before running this notebook.\n", "\n", "Required environment variables:\n", "- `OPENAI_API_KEY` — [OpenAI platform](https://platform.openai.com/api-keys)\n", "- `ANTHROPIC_API_KEY` — [Anthropic console](https://console.anthropic.com/) (fallback model)\n", "- `KALIBR_API_KEY` — [Kalibr dashboard](https://dashboard.kalibr.systems) or run `kalibr auth`\n", "- `KALIBR_TENANT_ID` — [Kalibr dashboard](https://dashboard.kalibr.systems)"]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": ["from openai import OpenAI\n", "\n", "client = OpenAI()\n", "\n", "def support_agent_fragile(user_query: str) -> str:\n", "    response = client.chat.completions.create(\n", "        model=\"gpt-4o\",\n", "        messages=[\n", "            {\"role\": \"system\", \"content\": \"You are a helpful customer support agent.\"},\n", "            {\"role\": \"user\", \"content\": user_query}\n", "        ],\n", "        max_tokens=300,\n", "    )\n", "    return response.choices[0].message.content\n", "\n", "result = support_agent_fragile(\"How do I reset my password?\")\n", "print(result)"]
+   "source": ["import os\n", "\n", "# Verify required environment variables are set\n", "required_vars = [\"OPENAI_API_KEY\", \"ANTHROPIC_API_KEY\", \"KALIBR_API_KEY\", \"KALIBR_TENANT_ID\"]\n", "missing = [v for v in required_vars if not os.environ.get(v)]\n", "if missing:\n", "    raise EnvironmentError(\n", "        f\"Missing required environment variables: {missing}\\n\"\n", "        \"Set them before running this notebook. See README for details.\"\n", "    )\n", "print(\"\\u2713 All required environment variables are set\")"]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": ["## Part 2: The Resilient Agent (After)\n", "\n", "Two changes:\n", "1. `import kalibr` — **must be the first import, before OpenAI**\n", "2. Use `Router` instead of bare `OpenAI` client\n", "\n", "The response interface is identical: `response.choices[0].message.content`"]
+   "source": ["---\n", "\n", "## Important: Import Order\n", "\n", "`import kalibr` must come **before** any OpenAI or Anthropic import. It instruments SDK clients at import time via monkey-patching. The cell below sets this up for the entire notebook — both the 'before' and 'after' demos."]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": ["# Restart kernel if openai was already imported above.\n", "# kalibr MUST be the first import.\n", "import kalibr  # noqa — must be first\n", "\n", "from kalibr import Router\n", "\n", "support_router = Router(\n", "    goal=\"customer_support_response\",\n", "    paths=[\"gpt-4o\", \"claude-sonnet-4-20250514\"],\n", "    success_when=lambda output: output is not None and len(output) > 30,\n", ")\n", "\n", "def support_agent_resilient(user_query: str) -> str:\n", "    response = support_router.completion(\n", "        messages=[\n", "            {\"role\": \"system\", \"content\": \"You are a helpful customer support agent.\"},\n", "            {\"role\": \"user\", \"content\": user_query}\n", "        ],\n", "        max_tokens=300,\n", "    )\n", "    return response.choices[0].message.content\n", "\n", "result = support_agent_resilient(\"How do I reset my password?\")\n", "print(result)"]
+   "source": ["# kalibr MUST be first — instruments OpenAI and Anthropic SDK clients at import time\n", "import kalibr  # noqa: F401\n", "\n", "from openai import OpenAI\n", "from kalibr import Router\n", "\n", "print(\"\\u2713 Kalibr instrumentation active\")"]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": ["## Part 3: Outcome Reporting\n", "\n", "For tasks where structural validation isn't enough, report outcomes explicitly."]
+   "source": ["---\n", "\n", "## Part 1: The Fragile Pattern\n", "\n", "This is the standard pattern most agents use. It works — until the model degrades.\n", "\n", "```python\n", "# ❌ Fragile — hardcoded to one model, no fallback\n", "client = OpenAI()\n", "response = client.chat.completions.create(\n", "    model=\"gpt-4o\",\n", "    messages=[{\"role\": \"user\", \"content\": query}],\n", "    max_tokens=300,\n", ")\n", "```\n", "\n", "When GPT-4o has a degradation event (rate limits, latency spikes, partial outage), this agent fails. Recovery requires human intervention: notice the problem, update the code, redeploy.\n", "\n", "**Measured success rate during a 70% GPT-4o degradation event: 16–36%**"]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["---\n", "\n", "## Part 2: The Resilient Pattern (Kalibr)\n", "\n", "Two changes from the fragile pattern:\n", "1. `import kalibr` — already done above (must be first in the process)\n", "2. `Router` instead of bare `OpenAI` client\n", "\n", "The response interface is **identical**: `response.choices[0].message.content`"]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": ["from kalibr import Router\n", "\n", "quality_router = Router(\n", "    goal=\"customer_support_quality\",\n", "    paths=[\"gpt-4o\", \"claude-sonnet-4-20250514\", \"gpt-4o-mini\"],\n", ")\n", "\n", "response = quality_router.completion(\n", "    messages=[\n", "        {\"role\": \"system\", \"content\": \"You are a helpful customer support agent.\"},\n", "        {\"role\": \"user\", \"content\": \"How do I update my billing information?\"}\n", "    ],\n", "    max_tokens=300,\n", ")\n", "output = response.choices[0].message.content\n", "\n", "has_steps = any(w in output.lower() for w in [\"click\", \"go to\", \"select\", \"open\"])\n", "quality_score = 0.9 if has_steps else 0.4\n", "\n", "quality_router.report(success=quality_score >= 0.5, score=quality_score)\n", "print(f\"Quality score: {quality_score}\\nResponse: {output}\")"]
+   "source": ["support_router = Router(\n", "    goal=\"customer_support_response\",\n", "    paths=[\"gpt-4o\", \"claude-sonnet-4-20250514\"],\n", "    success_when=lambda output: output is not None and len(output) > 30,\n", ")\n", "\n", "def support_agent_resilient(user_query: str) -> str:\n", "    \"\"\"\n", "    Customer support agent with Kalibr routing.\n", "\n", "    Kalibr selects the model with the highest success rate for this goal.\n", "    If GPT-4o is degraded, it routes to Claude Sonnet automatically.\n", "    \"\"\"\n", "    response = support_router.completion(\n", "        messages=[\n", "            {\"role\": \"system\", \"content\": \"You are a helpful customer support agent.\"},\n", "            {\"role\": \"user\", \"content\": user_query}\n", "        ],\n", "        max_tokens=300,\n", "    )\n", "    return response.choices[0].message.content\n", "\n", "result = support_agent_resilient(\"How do I reset my password?\")\n", "print(result)"]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": ["## Benchmark Results\n", "\n", "From Kalibr's internal testing during simulated GPT-4o degradation (70% failure rate):\n", "\n", "| Agent Setup | Task Success Rate |\n", "|---|---|\n", "| Hardcoded `gpt-4o` | 16–36% |\n", "| Retry with backoff | 40–55% |\n", "| Kalibr-routed (`gpt-4o` + `claude-sonnet-4-20250514`) | 88–100% |\n", "\n", "## What Changed\n", "\n", "| | Before | After |\n", "|---|---|---|\n", "| Import | `from openai import OpenAI` | `import kalibr` first |\n", "| Client | `OpenAI()` | `Router(goal, paths, success_when)` |\n", "| Completion | `client.chat.completions.create(model=..., ...)` | `router.completion(messages=...)` |\n", "| Fallback | None | Automatic |\n", "| Improvement | Static | Continuous |\n", "\n", "## Links\n", "- [Kalibr docs](https://kalibr.systems/docs)\n", "- [GitHub](https://github.com/kalibr-ai/kalibr-sdk-python)\n", "- [Dashboard](https://dashboard.kalibr.systems)\n", "- [PyPI](https://pypi.org/project/kalibr/)"]
+   "source": ["---\n", "\n", "## Part 3: Outcome Reporting\n", "\n", "For tasks where structural validation isn't enough, report outcomes explicitly.\n", "This gives Kalibr a richer signal — quality score 0–1, not just pass/fail."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": ["quality_router = Router(\n", "    goal=\"customer_support_quality\",\n", "    paths=[\"gpt-4o\", \"claude-sonnet-4-20250514\", \"gpt-4o-mini\"],\n", "    # No success_when — we report manually for finer control\n", ")\n", "\n", "response = quality_router.completion(\n", "    messages=[\n", "        {\"role\": \"system\", \"content\": \"You are a helpful customer support agent.\"},\n", "        {\"role\": \"user\", \"content\": \"How do I update my billing information?\"}\n", "    ],\n", "    max_tokens=300,\n", ")\n", "output = response.choices[0].message.content\n", "\n", "# Your domain-specific quality check\n", "has_steps = any(w in output.lower() for w in [\"click\", \"go to\", \"select\", \"navigate\"])\n", "appropriate_length = 50 < len(output) < 600\n", "quality_score = (int(has_steps) + int(appropriate_length)) / 2.0\n", "\n", "quality_router.report(\n", "    success=quality_score >= 0.5,\n", "    score=quality_score,\n", "    failure_category=None if quality_score >= 0.5 else \"user_unsatisfied\",\n", ")\n", "print(f\"Quality score: {quality_score:.2f}\")\n", "print(f\"Response: {output}\")"]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["---\n", "\n", "## Benchmark Results\n", "\n", "From Kalibr's resilience benchmark during simulated GPT-4o degradation (70% failure rate injected at task 16 of 50):\n", "\n", "| Agent Setup | Task Success Rate During Degradation |\n", "|---|---|\n", "| Hardcoded `gpt-4o` | 16–36% |\n", "| Retry with exponential backoff | 40–55% |\n", "| Kalibr-routed (`gpt-4o` + `claude-sonnet-4-20250514`) | 88–100% |\n", "\n", "Full benchmark methodology: [kalibr.systems/docs/benchmark](https://kalibr.systems/docs/benchmark)\n", "\n", "---\n", "\n", "## What Changed\n", "\n", "| | Fragile Pattern | Kalibr Pattern |\n", "|---|---|---|\n", "| First import | `from openai import OpenAI` | `import kalibr` |\n", "| Client | `OpenAI()` | `Router(goal, paths, success_when)` |\n", "| Call | `client.chat.completions.create(model=..., ...)` | `router.completion(messages=...)` |\n", "| Response | `response.choices[0].message.content` | identical |\n", "| Fallback | None | Automatic |\n", "| Adapts over time | No | Yes — learns from every call |\n", "\n", "---\n", "\n", "## Links\n", "\n", "- [Kalibr docs](https://kalibr.systems/docs)\n", "- [Resilience benchmark](https://kalibr.systems/docs/benchmark)\n", "- [GitHub](https://github.com/kalibr-ai/kalibr-sdk-python)\n", "- [Dashboard](https://dashboard.kalibr.systems)\n", "- [PyPI](https://pypi.org/project/kalibr/)"]
   }
  ],
  "metadata": {

--- a/examples/partners/kalibr_resilient_agents/kalibr_resilient_agents.ipynb
+++ b/examples/partners/kalibr_resilient_agents/kalibr_resilient_agents.ipynb
@@ -1,0 +1,70 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["# Building Resilient Agents with Kalibr\n", "\n", "**Partner cookbook — [Kalibr Systems](https://kalibr.systems)**\n", "\n", "---\n", "\n", "## The Problem with Single-Model Agents\n", "\n", "Most OpenAI-powered agents are written like this:\n", "\n", "```python\n", "from openai import OpenAI\n", "client = OpenAI()\n", "response = client.chat.completions.create(model=\"gpt-4o\", messages=[...])\n", "```\n", "\n", "This works in demos. In production:\n", "- Rate limits fire at unpredictable times\n", "- Provider latency spikes during peak load\n", "- Partial outages affect specific model versions\n", "- Your agent silently degrades or errors out\n", "\n", "**What you need:** route away from degraded paths automatically. This notebook shows how with [Kalibr](https://kalibr.systems).\n", "\n", "---\n", "\n", "## What is Kalibr?\n", "\n", "Kalibr captures the outcome of every LLM call (success, failure, quality score 0–1), learns which model+parameter combinations work best for each goal, and routes the next call to the optimal path.\n", "\n", "**Not:** observability (Langfuse/LangSmith), model gateway (LiteLLM/OpenRouter), or a proxy.\n", "\n", "**Classification:** execution path routing based on outcome signals."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": ["!pip install kalibr openai anthropic"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": ["import os\n", "\n", "os.environ[\"OPENAI_API_KEY\"] = \"your-openai-api-key\"\n", "os.environ[\"ANTHROPIC_API_KEY\"] = \"your-anthropic-api-key\"\n", "os.environ[\"KALIBR_API_KEY\"] = \"your-kalibr-api-key\"\n", "os.environ[\"KALIBR_TENANT_ID\"] = \"your-kalibr-tenant-id\""]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Part 1: The Fragile Agent (Before)\n", "\n", "Standard customer support agent hardcoded to GPT-4o."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": ["from openai import OpenAI\n", "\n", "client = OpenAI()\n", "\n", "def support_agent_fragile(user_query: str) -> str:\n", "    response = client.chat.completions.create(\n", "        model=\"gpt-4o\",\n", "        messages=[\n", "            {\"role\": \"system\", \"content\": \"You are a helpful customer support agent.\"},\n", "            {\"role\": \"user\", \"content\": user_query}\n", "        ],\n", "        max_tokens=300,\n", "    )\n", "    return response.choices[0].message.content\n", "\n", "result = support_agent_fragile(\"How do I reset my password?\")\n", "print(result)"]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Part 2: The Resilient Agent (After)\n", "\n", "Two changes:\n", "1. `import kalibr` — **must be the first import, before OpenAI**\n", "2. Use `Router` instead of bare `OpenAI` client\n", "\n", "The response interface is identical: `response.choices[0].message.content`"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": ["# Restart kernel if openai was already imported above.\n", "# kalibr MUST be the first import.\n", "import kalibr  # noqa — must be first\n", "\n", "from kalibr import Router\n", "\n", "support_router = Router(\n", "    goal=\"customer_support_response\",\n", "    paths=[\"gpt-4o\", \"claude-sonnet-4-20250514\"],\n", "    success_when=lambda output: output is not None and len(output) > 30,\n", ")\n", "\n", "def support_agent_resilient(user_query: str) -> str:\n", "    response = support_router.completion(\n", "        messages=[\n", "            {\"role\": \"system\", \"content\": \"You are a helpful customer support agent.\"},\n", "            {\"role\": \"user\", \"content\": user_query}\n", "        ],\n", "        max_tokens=300,\n", "    )\n", "    return response.choices[0].message.content\n", "\n", "result = support_agent_resilient(\"How do I reset my password?\")\n", "print(result)"]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Part 3: Outcome Reporting\n", "\n", "For tasks where structural validation isn't enough, report outcomes explicitly."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": ["from kalibr import Router\n", "\n", "quality_router = Router(\n", "    goal=\"customer_support_quality\",\n", "    paths=[\"gpt-4o\", \"claude-sonnet-4-20250514\", \"gpt-4o-mini\"],\n", ")\n", "\n", "response = quality_router.completion(\n", "    messages=[\n", "        {\"role\": \"system\", \"content\": \"You are a helpful customer support agent.\"},\n", "        {\"role\": \"user\", \"content\": \"How do I update my billing information?\"}\n", "    ],\n", "    max_tokens=300,\n", ")\n", "output = response.choices[0].message.content\n", "\n", "has_steps = any(w in output.lower() for w in [\"click\", \"go to\", \"select\", \"open\"])\n", "quality_score = 0.9 if has_steps else 0.4\n", "\n", "quality_router.report(success=quality_score >= 0.5, score=quality_score)\n", "print(f\"Quality score: {quality_score}\\nResponse: {output}\")"]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Benchmark Results\n", "\n", "From Kalibr's internal testing during simulated GPT-4o degradation (70% failure rate):\n", "\n", "| Agent Setup | Task Success Rate |\n", "|---|---|\n", "| Hardcoded `gpt-4o` | 16–36% |\n", "| Retry with backoff | 40–55% |\n", "| Kalibr-routed (`gpt-4o` + `claude-sonnet-4-20250514`) | 88–100% |\n", "\n", "## What Changed\n", "\n", "| | Before | After |\n", "|---|---|---|\n", "| Import | `from openai import OpenAI` | `import kalibr` first |\n", "| Client | `OpenAI()` | `Router(goal, paths, success_when)` |\n", "| Completion | `client.chat.completions.create(model=..., ...)` | `router.completion(messages=...)` |\n", "| Fallback | None | Automatic |\n", "| Improvement | Static | Continuous |\n", "\n", "## Links\n", "- [Kalibr docs](https://kalibr.systems/docs)\n", "- [GitHub](https://github.com/kalibr-ai/kalibr-sdk-python)\n", "- [Dashboard](https://dashboard.kalibr.systems)\n", "- [PyPI](https://pypi.org/project/kalibr/)"]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "version": "3.11.0"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/registry.yaml
+++ b/registry.yaml
@@ -3128,3 +3128,18 @@
     - cost
     - responses
     - realtime
+
+- title: Building Resilient Agents with Kalibr
+  path: examples/partners/kalibr_resilient_agents/kalibr_resilient_agents.ipynb
+  slug: kalibr-resilient-agents
+  description: How to use Kalibr execution path routing to keep OpenAI agents running at 88-100% success during provider degradation. Before/after comparison with benchmark results.
+  date: 2026-03-25
+  authors:
+    - devonakelley
+  tags:
+    - agents
+    - reliability
+    - routing
+    - production
+    - partners
+    - resilience


### PR DESCRIPTION
## What this adds

A new partner cookbook notebook: **Building Resilient Agents with Kalibr** — a practical before/after showing how to harden OpenAI-powered agents for production using execution path routing.

## The problem this solves

OpenAI API degradation events are real. Rate limits, partial outages, and latency spikes happen. Most agent tutorials assume the API always works. This notebook shows what happens when it doesnt — and how Kalibr fixes it without code changes or redeployment.

**Measured benchmark results:**
| Agent Setup | Task Success Rate During Degradation |
|---|---|
| Hardcoded `gpt-4o` | 16–36% |
| Retry with backoff | 40–55% |
| Kalibr-routed (`gpt-4o` + `claude-sonnet-4-20250514`) | 88–100% |

## Why it belongs in the Cookbook

The Cookbook has excellent content on rate limit handling (`How_to_handle_rate_limits.ipynb`). This notebook addresses the next layer: *adaptive* reliability — routing away from degraded endpoints automatically, learning which path succeeds per task, without human intervention.

## What Kalibr is

- **Not** observability (Langfuse/LangSmith surface dashboards — Kalibr feeds signals into routing)
- **Not** a model gateway (LiteLLM/OpenRouter route by cost/latency — Kalibr routes by task outcome success)
- **Not** a proxy (model calls go directly to providers)
- **Classification:** execution path routing based on outcome signals

## The change

Two lines:
```python
import kalibr  # first import
from kalibr import Router
router = Router(goal="task", paths=["gpt-4o", "claude-sonnet-4-20250514"], success_when=lambda x: len(x) > 0)
response = router.completion(messages=[...])  # same interface as client.chat.completions.create
```

Docs: https://kalibr.systems/docs | PyPI: https://pypi.org/project/kalibr/