### PR TITLE
fix: extract 1 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/build-website.yaml
+++ b/.github/workflows/build-website.yaml
@@ -11,6 +11,6 @@ jobs:
 
     steps:
       - name: Call Deploy Hook
-        run: curl -X POST ${WEBSITE_DEPLOY_HOOK_URL}
+        run: curl -X POST "${WEBSITE_DEPLOY_HOOK_URL}"
         env:
           WEBSITE_DEPLOY_HOOK_URL: ${{ secrets.WEBSITE_DEPLOY_HOOK_URL }}

--- a/.github/workflows/build-website.yaml
+++ b/.github/workflows/build-website.yaml
@@ -11,4 +11,6 @@ jobs:
 
     steps:
       - name: Call Deploy Hook
-        run: curl -X POST ${{ secrets.WEBSITE_DEPLOY_HOOK_URL }}
+        run: curl -X POST ${WEBSITE_DEPLOY_HOOK_URL}
+        env:
+          WEBSITE_DEPLOY_HOOK_URL: ${{ secrets.WEBSITE_DEPLOY_HOOK_URL }}


### PR DESCRIPTION
> This is a re-submission of #2556, which was closed due to a branch issue on my end. Same fixes, apologies for the noise.

## Security: Harden GitHub Actions workflows

Hey, I found some CI/CD security issues in this repo's GitHub Actions workflows. These are the same vulnerability classes that were exploited in the tj-actions/changed-files supply chain attack. I've been reviewing repos that are affected and submitting fixes where I can.

This PR applies mechanical fixes and flags anything else that needs a manual look. Happy to answer any questions.

### Fixes applied

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-002 | high | `.github/workflows/build-website.yaml` | Extracted 1 unsafe expression(s) to env vars |


### Additional findings (manual review recommended)

No additional findings beyond the fixes applied above.

### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks or reference unpinned third-party actions are vulnerable to code injection and supply chain attacks. These are the same vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-attack-and-its-impact) which compromised CI secrets across thousands of repositories.

### How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **Expression extraction**: Moves `${{ }}` expressions from `run:` blocks into `env:` mappings, preventing shell injection


---

If this PR is not welcome, just close it and I won't send another.