### PR TITLE
Add cookbook: Building World-Aware Agents with Prediction Market Data

### DIFF
--- a/authors.yaml
+++ b/authors.yaml
@@ -3,6 +3,10 @@
 # You can optionally customize how your information shows up cookbook.openai.com over here.
 # If your information is not present here, it will be pulled from your GitHub profile.
 
+patrickliu0077:
+  name: "Patrick Liu"
+  website: "https://simplefunctions.dev"
+
 zhenweig-cerebras:
   name: "Zhenwei Gao"
   website: "https://www.linkedin.com/in/zhenwei-gao/"

--- a/examples/partners/building_world_aware_agents/building_world_aware_agents.ipynb
+++ b/examples/partners/building_world_aware_agents/building_world_aware_agents.ipynb
@@ -8,9 +8,9 @@
     "\n",
     "LLMs have a knowledge cutoff. Ask your agent \"what's the probability of a US recession?\" and it will either hallucinate a number, hedge, or give you stale data.\n",
     "\n",
-    "This cookbook shows how to build agents that have **real-time world awareness** \u2014 agents that know today's geopolitical risk level, current oil prices, recession probabilities, and Fed rate expectations. Not from web search (which returns narratives), but from **calibrated probability data** backed by real money.\n",
+    "This cookbook shows how to build agents that have **real-time world awareness** — agents that know today's geopolitical risk level, current oil prices, recession probabilities, and Fed rate expectations. Not from web search (which returns narratives), but from **calibrated probability data** backed by real money.\n",
     "\n",
-    "We use [SimpleFunctions](https://simplefunctions.dev/world), which aggregates 9,706 prediction market contracts into an ~800-token world state snapshot. Prediction markets produce calibrated probabilities because participants lose money when they're wrong \u2014 a fundamentally different incentive than news, polls, or LLM reasoning.\n",
+    "We use [SimpleFunctions](https://simplefunctions.dev/world), which aggregates 9,706 prediction market contracts into an ~800-token world state snapshot. Prediction markets produce calibrated probabilities because participants lose money when they're wrong — a fundamentally different incentive than news, polls, or LLM reasoning.\n",
     "\n",
     "**What you'll build:**\n",
     "1. An agent with dynamic world-aware instructions\n",
@@ -45,7 +45,7 @@
     "import os\n",
     "import requests\n",
     "\n",
-    "# No API key needed for the world state endpoint \u2014 it's free and public.\n",
+    "# No API key needed for the world state endpoint — it's free and public.\n",
     "# You only need your OpenAI key for the agent itself.\n",
     "assert os.environ.get(\"OPENAI_API_KEY\"), \"Set OPENAI_API_KEY environment variable\""
    ]
@@ -58,7 +58,7 @@
     "\n",
     "One API call returns ~800 tokens of markdown covering geopolitics, economy, energy, elections, crypto, and tech. The data comes from 9,706 prediction market contracts on Kalshi (CFTC-regulated) and Polymarket.\n",
     "\n",
-    "Anchor contracts \u2014 recession probability, Fed rate path, Iran invasion \u2014 always appear regardless of daily noise. Other contracts are ranked by volume \u00d7 price movement, not raw volatility."
+    "Anchor contracts — recession probability, Fed rate path, Iran invasion — always appear regardless of daily noise. Other contracts are ranked by volume × price movement, not raw volatility."
    ]
   },
   {
@@ -75,7 +75,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice the format: every line is a fact with a number attached. `Iran invasion: 53c (+5c)` means the market prices Iran invasion at 53% probability, up 5 percentage points in 24 hours, with real money behind it. This is what calibrated data looks like \u2014 not \"tensions remain elevated.\""
+    "Notice the format: every line is a fact with a number attached. `Iran invasion: 53c (+5c)` means the market prices Iran invasion at 53% probability, up 5 percentage points in 24 hours, with real money behind it. This is what calibrated data looks like — not \"tensions remain elevated.\""
    ]
   },
   {
@@ -101,7 +101,7 @@
     "    return f\"\"\"You are a macro research analyst with real-time world awareness.\n",
     "\n",
     "Use the data below as ground truth. Cite specific probabilities and prices.\n",
-    "Do not hallucinate numbers \u2014 if it's not in the data, say you don't know.\n",
+    "Do not hallucinate numbers — if it's not in the data, say you don't know.\n",
     "\n",
     "{world}\"\"\"\n",
     "\n",
@@ -119,7 +119,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The agent now cites real numbers \u2014 not because we told it to make up numbers, but because it has actual data to cite."
+    "The agent now cites real numbers — not because we told it to make up numbers, but because it has actual data to cite."
    ]
   },
   {
@@ -130,9 +130,9 @@
     "\n",
     "The world state snapshot is a panoramic view. For specific questions, the agent needs tools to drill deeper:\n",
     "\n",
-    "- **`world_state(focus=...)`** \u2014 same token budget, concentrated on fewer topics (e.g., 10 energy contracts instead of 4)\n",
-    "- **`world_delta(since=...)`** \u2014 only what changed since a timestamp (~30-50 tokens vs 800)\n",
-    "- **`search_markets(query=...)`** \u2014 find specific prediction market contracts"
+    "- **`world_state(focus=...)`** — same token budget, concentrated on fewer topics (e.g., 10 energy contracts instead of 4)\n",
+    "- **`world_delta(since=...)`** — only what changed since a timestamp (~30-50 tokens vs 800)\n",
+    "- **`search_markets(query=...)`** — find specific prediction market contracts"
    ]
   },
   {
@@ -163,7 +163,7 @@
     "@function_tool\n",
     "def world_delta(since: str = \"1h\") -> str:\n",
     "    \"\"\"Get only what changed in the world since the given time.\n",
-    "    Much smaller than full state \u2014 use for periodic refresh during long tasks.\n",
+    "    Much smaller than full state — use for periodic refresh during long tasks.\n",
     "\n",
     "    Args:\n",
     "        since: Time window. Options: 30m, 1h, 6h, 24h.\n",
@@ -206,7 +206,7 @@
    "source": [
     "## Step 4: Multi-Agent with Shared World Context\n",
     "\n",
-    "In multi-agent systems, consistency matters. If the researcher says \"recession at 33%\" and the risk analyst says \"recession at 40%,\" they're not disagreeing \u2014 they're hallucinating different numbers.\n",
+    "In multi-agent systems, consistency matters. If the researcher says \"recession at 33%\" and the risk analyst says \"recession at 40%,\" they're not disagreeing — they're hallucinating different numbers.\n",
     "\n",
     "The fix: fetch the world state once, share it across all agents."
    ]
@@ -216,34 +216,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Fetch once, share across all agents\n",
-    "shared_world = requests.get(\"https://simplefunctions.dev/api/agent/world\").text\n",
-    "\n",
-    "SHARED_CONTEXT = f\"\"\"You have real-time world awareness from prediction markets.\n",
-    "Cite these numbers directly. Do not make up probabilities.\n",
-    "\n",
-    "{shared_world}\"\"\"\n",
-    "\n",
-    "researcher = Agent(\n",
-    "    name=\"researcher\",\n",
-    "    instructions=SHARED_CONTEXT + \"\\nYou are a macro researcher. Analyze geopolitical and economic developments. Hand off to the risk analyst when you identify concerning data.\",\n",
-    "    handoffs=[risk_analyst],\n",
-    "    tools=[world_state, search_markets],\n",
-    ")\n",
-    "\n",
-    "risk_analyst = Agent(\n",
-    "    name=\"risk_analyst\",\n",
-    "    instructions=SHARED_CONTEXT + \"\\nYou are a risk analyst. Assess portfolio implications of the data. Never say 'could' when you have a specific probability.\",\n",
-    "    tools=[world_state],\n",
-    ")\n",
-    "\n",
-    "result = Runner.run_sync(\n",
-    "    researcher,\n",
-    "    \"What should a portfolio manager know about geopolitical risk today?\"\n",
-    ")\n",
-    "print(result.final_output)"
-   ]
+   "source": "# Fetch once, share across all agents\nshared_world = requests.get(\"https://simplefunctions.dev/api/agent/world\").text\n\nSHARED_CONTEXT = f\"\"\"You have real-time world awareness from prediction markets.\nCite these numbers directly. Do not make up probabilities.\n\n{shared_world}\"\"\"\n\nrisk_analyst = Agent(\n    name=\"risk_analyst\",\n    instructions=SHARED_CONTEXT + \"\\nYou are a risk analyst. Assess portfolio implications of the data. Never say 'could' when you have a specific probability.\",\n    tools=[world_state],\n)\n\nresearcher = Agent(\n    name=\"researcher\",\n    instructions=SHARED_CONTEXT + \"\\nYou are a macro researcher. Analyze geopolitical and economic developments. Hand off to the risk analyst when you identify concerning data.\",\n    handoffs=[risk_analyst],\n    tools=[world_state, search_markets],\n)\n\nresult = Runner.run_sync(\n    researcher,\n    \"What should a portfolio manager know about geopolitical risk today?\"\n)\nprint(result.final_output)"
   },
   {
    "cell_type": "markdown",
@@ -286,7 +259,7 @@
     "The world state endpoint requires no API key, is free, and returns data from 9,706 prediction markets updated every 15 minutes.\n",
     "\n",
     "**Links:**\n",
-    "- [World State API](https://simplefunctions.dev/api/agent/world) \u2014 try it now\n",
+    "- [World State API](https://simplefunctions.dev/api/agent/world) — try it now\n",
     "- [Documentation](https://simplefunctions.dev/docs/guide)\n",
     "- [All endpoints](https://simplefunctions.dev/api/tools)"
    ]

--- a/examples/partners/building_world_aware_agents/building_world_aware_agents.ipynb
+++ b/examples/partners/building_world_aware_agents/building_world_aware_agents.ipynb
@@ -1,0 +1,308 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Building World-Aware Agents with the OpenAI Agents SDK\n",
+    "\n",
+    "LLMs have a knowledge cutoff. Ask your agent \"what's the probability of a US recession?\" and it will either hallucinate a number, hedge, or give you stale data.\n",
+    "\n",
+    "This cookbook shows how to build agents that have **real-time world awareness** — agents that know today's geopolitical risk level, current oil prices, recession probabilities, and Fed rate expectations. Not from web search (which returns narratives), but from **calibrated probability data** backed by real money.\n",
+    "\n",
+    "We use [SimpleFunctions](https://simplefunctions.dev/world), which aggregates 9,706 prediction market contracts into an ~800-token world state snapshot. Prediction markets produce calibrated probabilities because participants lose money when they're wrong — a fundamentally different incentive than news, polls, or LLM reasoning.\n",
+    "\n",
+    "**What you'll build:**\n",
+    "1. An agent with dynamic world-aware instructions\n",
+    "2. Tools for focused topic drilling and incremental updates\n",
+    "3. A multi-agent system where all agents share the same world context"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Install dependencies and set your OpenAI API key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install openai-agents requests -q"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import requests\n",
+    "\n",
+    "# No API key needed for the world state endpoint — it's free and public.\n",
+    "# You only need your OpenAI key for the agent itself.\n",
+    "assert os.environ.get(\"OPENAI_API_KEY\"), \"Set OPENAI_API_KEY environment variable\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Fetch the World State\n",
+    "\n",
+    "One API call returns ~800 tokens of markdown covering geopolitics, economy, energy, elections, crypto, and tech. The data comes from 9,706 prediction market contracts on Kalshi (CFTC-regulated) and Polymarket.\n",
+    "\n",
+    "Anchor contracts — recession probability, Fed rate path, Iran invasion — always appear regardless of daily noise. Other contracts are ranked by volume × price movement, not raw volatility."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "world = requests.get(\"https://simplefunctions.dev/api/agent/world\").text\n",
+    "print(world)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice the format: every line is a fact with a number attached. `Iran invasion: 53c (+5c)` means the market prices Iran invasion at 53% probability, up 5 percentage points in 24 hours, with real money behind it. This is what calibrated data looks like — not \"tensions remain elevated.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: World-Aware Agent with Dynamic Instructions\n",
+    "\n",
+    "The Agents SDK's `instructions` parameter accepts a callable. We use this to fetch fresh world state before each agent run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from agents import Agent, Runner\n",
+    "\n",
+    "\n",
+    "def get_instructions():\n",
+    "    world = requests.get(\"https://simplefunctions.dev/api/agent/world\").text\n",
+    "    return f\"\"\"You are a macro research analyst with real-time world awareness.\n",
+    "\n",
+    "Use the data below as ground truth. Cite specific probabilities and prices.\n",
+    "Do not hallucinate numbers — if it's not in the data, say you don't know.\n",
+    "\n",
+    "{world}\"\"\"\n",
+    "\n",
+    "\n",
+    "analyst = Agent(\n",
+    "    name=\"world_aware_analyst\",\n",
+    "    instructions=get_instructions,\n",
+    ")\n",
+    "\n",
+    "result = Runner.run_sync(analyst, \"What's the current geopolitical risk level and how does it affect energy markets?\")\n",
+    "print(result.final_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The agent now cites real numbers — not because we told it to make up numbers, but because it has actual data to cite."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Adding Depth Tools\n",
+    "\n",
+    "The world state snapshot is a panoramic view. For specific questions, the agent needs tools to drill deeper:\n",
+    "\n",
+    "- **`world_state(focus=...)`** — same token budget, concentrated on fewer topics (e.g., 10 energy contracts instead of 4)\n",
+    "- **`world_delta(since=...)`** — only what changed since a timestamp (~30-50 tokens vs 800)\n",
+    "- **`search_markets(query=...)`** — find specific prediction market contracts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from agents import function_tool\n",
+    "\n",
+    "\n",
+    "@function_tool\n",
+    "def world_state(focus: str = \"\") -> str:\n",
+    "    \"\"\"Get current world state from prediction markets.\n",
+    "\n",
+    "    Args:\n",
+    "        focus: Comma-separated topics for deeper coverage.\n",
+    "               Options: geopolitics, economy, energy, elections, crypto, tech.\n",
+    "               Empty string returns all topics.\n",
+    "    \"\"\"\n",
+    "    url = \"https://simplefunctions.dev/api/agent/world\"\n",
+    "    if focus:\n",
+    "        url += f\"?focus={focus}\"\n",
+    "    return requests.get(url).text\n",
+    "\n",
+    "\n",
+    "@function_tool\n",
+    "def world_delta(since: str = \"1h\") -> str:\n",
+    "    \"\"\"Get only what changed in the world since the given time.\n",
+    "    Much smaller than full state — use for periodic refresh during long tasks.\n",
+    "\n",
+    "    Args:\n",
+    "        since: Time window. Options: 30m, 1h, 6h, 24h.\n",
+    "    \"\"\"\n",
+    "    return requests.get(\n",
+    "        f\"https://simplefunctions.dev/api/agent/world/delta?since={since}\"\n",
+    "    ).text\n",
+    "\n",
+    "\n",
+    "@function_tool\n",
+    "def search_markets(query: str) -> str:\n",
+    "    \"\"\"Search prediction markets for specific contracts.\n",
+    "    Returns prices, volumes, and spreads from Kalshi and Polymarket.\n",
+    "\n",
+    "    Args:\n",
+    "        query: Natural language search query, e.g. 'iran oil' or 'fed rate cut'.\n",
+    "    \"\"\"\n",
+    "    resp = requests.get(\n",
+    "        f\"https://simplefunctions.dev/api/public/scan?q={query}\"\n",
+    "    )\n",
+    "    return json.dumps(resp.json(), indent=2)\n",
+    "\n",
+    "\n",
+    "analyst_with_tools = Agent(\n",
+    "    name=\"deep_analyst\",\n",
+    "    instructions=get_instructions,\n",
+    "    tools=[world_state, world_delta, search_markets],\n",
+    ")\n",
+    "\n",
+    "result = Runner.run_sync(\n",
+    "    analyst_with_tools,\n",
+    "    \"I need a deep dive on Iran risk and its impact on oil. Search for specific contracts.\"\n",
+    ")\n",
+    "print(result.final_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Multi-Agent with Shared World Context\n",
+    "\n",
+    "In multi-agent systems, consistency matters. If the researcher says \"recession at 33%\" and the risk analyst says \"recession at 40%,\" they're not disagreeing — they're hallucinating different numbers.\n",
+    "\n",
+    "The fix: fetch the world state once, share it across all agents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fetch once, share across all agents\n",
+    "shared_world = requests.get(\"https://simplefunctions.dev/api/agent/world\").text\n",
+    "\n",
+    "SHARED_CONTEXT = f\"\"\"You have real-time world awareness from prediction markets.\n",
+    "Cite these numbers directly. Do not make up probabilities.\n",
+    "\n",
+    "{shared_world}\"\"\"\n",
+    "\n",
+    "researcher = Agent(\n",
+    "    name=\"researcher\",\n",
+    "    instructions=SHARED_CONTEXT + \"\\nYou are a macro researcher. Analyze geopolitical and economic developments. Hand off to the risk analyst when you identify concerning data.\",\n",
+    "    handoffs=[\"risk_analyst\"],\n",
+    "    tools=[world_state, search_markets],\n",
+    ")\n",
+    "\n",
+    "risk_analyst = Agent(\n",
+    "    name=\"risk_analyst\",\n",
+    "    instructions=SHARED_CONTEXT + \"\\nYou are a risk analyst. Assess portfolio implications of the data. Never say 'could' when you have a specific probability.\",\n",
+    "    tools=[world_state],\n",
+    ")\n",
+    "\n",
+    "result = Runner.run_sync(\n",
+    "    researcher,\n",
+    "    \"What should a portfolio manager know about geopolitical risk today?\"\n",
+    ")\n",
+    "print(result.final_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Both agents see the same Iran invasion probability, the same recession odds, the same oil price. When the researcher identifies a risk and hands off to the risk analyst, the numbers are consistent."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Why Prediction Markets Instead of Web Search?\n",
+    "\n",
+    "| | Web Search | News API | Prediction Markets |\n",
+    "|---|---|---|---|\n",
+    "| **Output** | Narrative text | Headlines | Calibrated probabilities |\n",
+    "| **Token cost** | 2,000-5,000 | 500-1,000 | ~800 for everything |\n",
+    "| **Latency** | 2-5 seconds | 500ms | ~200ms (cached) |\n",
+    "| **Signal** | Needs parsing | No judgment | Numbers with money behind them |\n",
+    "| **Calibration** | None | None | Participants lose money when wrong |\n",
+    "\n",
+    "A prediction market price of 53 cents on \"Iran invasion\" encodes the aggregate judgment of everyone with money at risk on that question. A news headline encodes what an editor thought would get clicks. These are fundamentally different information sources."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "| Pattern | When to use | Token cost |\n",
+    "|---|---|---|\n",
+    "| `instructions=get_instructions` | Agent needs fresh world state each run | ~800 |\n",
+    "| `world_state(focus=\"energy,geo\")` | Agent needs deeper coverage of specific topics | ~800 (concentrated) |\n",
+    "| `world_delta(since=\"1h\")` | Long-running agent needs periodic refresh | ~30-50 |\n",
+    "| `search_markets(query)` | Agent needs specific contract data | Varies |\n",
+    "| Shared `SHARED_CONTEXT` | Multi-agent consistency | ~800 (shared) |\n",
+    "\n",
+    "The world state endpoint requires no API key, is free, and returns data from 9,706 prediction markets updated every 15 minutes.\n",
+    "\n",
+    "**Links:**\n",
+    "- [World State API](https://simplefunctions.dev/api/agent/world) — try it now\n",
+    "- [Documentation](https://simplefunctions.dev/docs/guide)\n",
+    "- [All endpoints](https://simplefunctions.dev/api/tools)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/partners/building_world_aware_agents/building_world_aware_agents.ipynb
+++ b/examples/partners/building_world_aware_agents/building_world_aware_agents.ipynb
@@ -8,9 +8,9 @@
     "\n",
     "LLMs have a knowledge cutoff. Ask your agent \"what's the probability of a US recession?\" and it will either hallucinate a number, hedge, or give you stale data.\n",
     "\n",
-    "This cookbook shows how to build agents that have **real-time world awareness** — agents that know today's geopolitical risk level, current oil prices, recession probabilities, and Fed rate expectations. Not from web search (which returns narratives), but from **calibrated probability data** backed by real money.\n",
+    "This cookbook shows how to build agents that have **real-time world awareness** \u2014 agents that know today's geopolitical risk level, current oil prices, recession probabilities, and Fed rate expectations. Not from web search (which returns narratives), but from **calibrated probability data** backed by real money.\n",
     "\n",
-    "We use [SimpleFunctions](https://simplefunctions.dev/world), which aggregates 9,706 prediction market contracts into an ~800-token world state snapshot. Prediction markets produce calibrated probabilities because participants lose money when they're wrong — a fundamentally different incentive than news, polls, or LLM reasoning.\n",
+    "We use [SimpleFunctions](https://simplefunctions.dev/world), which aggregates 9,706 prediction market contracts into an ~800-token world state snapshot. Prediction markets produce calibrated probabilities because participants lose money when they're wrong \u2014 a fundamentally different incentive than news, polls, or LLM reasoning.\n",
     "\n",
     "**What you'll build:**\n",
     "1. An agent with dynamic world-aware instructions\n",
@@ -45,7 +45,7 @@
     "import os\n",
     "import requests\n",
     "\n",
-    "# No API key needed for the world state endpoint — it's free and public.\n",
+    "# No API key needed for the world state endpoint \u2014 it's free and public.\n",
     "# You only need your OpenAI key for the agent itself.\n",
     "assert os.environ.get(\"OPENAI_API_KEY\"), \"Set OPENAI_API_KEY environment variable\""
    ]
@@ -58,7 +58,7 @@
     "\n",
     "One API call returns ~800 tokens of markdown covering geopolitics, economy, energy, elections, crypto, and tech. The data comes from 9,706 prediction market contracts on Kalshi (CFTC-regulated) and Polymarket.\n",
     "\n",
-    "Anchor contracts — recession probability, Fed rate path, Iran invasion — always appear regardless of daily noise. Other contracts are ranked by volume × price movement, not raw volatility."
+    "Anchor contracts \u2014 recession probability, Fed rate path, Iran invasion \u2014 always appear regardless of daily noise. Other contracts are ranked by volume \u00d7 price movement, not raw volatility."
    ]
   },
   {
@@ -75,7 +75,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice the format: every line is a fact with a number attached. `Iran invasion: 53c (+5c)` means the market prices Iran invasion at 53% probability, up 5 percentage points in 24 hours, with real money behind it. This is what calibrated data looks like — not \"tensions remain elevated.\""
+    "Notice the format: every line is a fact with a number attached. `Iran invasion: 53c (+5c)` means the market prices Iran invasion at 53% probability, up 5 percentage points in 24 hours, with real money behind it. This is what calibrated data looks like \u2014 not \"tensions remain elevated.\""
    ]
   },
   {
@@ -101,7 +101,7 @@
     "    return f\"\"\"You are a macro research analyst with real-time world awareness.\n",
     "\n",
     "Use the data below as ground truth. Cite specific probabilities and prices.\n",
-    "Do not hallucinate numbers — if it's not in the data, say you don't know.\n",
+    "Do not hallucinate numbers \u2014 if it's not in the data, say you don't know.\n",
     "\n",
     "{world}\"\"\"\n",
     "\n",
@@ -119,7 +119,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The agent now cites real numbers — not because we told it to make up numbers, but because it has actual data to cite."
+    "The agent now cites real numbers \u2014 not because we told it to make up numbers, but because it has actual data to cite."
    ]
   },
   {
@@ -130,9 +130,9 @@
     "\n",
     "The world state snapshot is a panoramic view. For specific questions, the agent needs tools to drill deeper:\n",
     "\n",
-    "- **`world_state(focus=...)`** — same token budget, concentrated on fewer topics (e.g., 10 energy contracts instead of 4)\n",
-    "- **`world_delta(since=...)`** — only what changed since a timestamp (~30-50 tokens vs 800)\n",
-    "- **`search_markets(query=...)`** — find specific prediction market contracts"
+    "- **`world_state(focus=...)`** \u2014 same token budget, concentrated on fewer topics (e.g., 10 energy contracts instead of 4)\n",
+    "- **`world_delta(since=...)`** \u2014 only what changed since a timestamp (~30-50 tokens vs 800)\n",
+    "- **`search_markets(query=...)`** \u2014 find specific prediction market contracts"
    ]
   },
   {
@@ -163,7 +163,7 @@
     "@function_tool\n",
     "def world_delta(since: str = \"1h\") -> str:\n",
     "    \"\"\"Get only what changed in the world since the given time.\n",
-    "    Much smaller than full state — use for periodic refresh during long tasks.\n",
+    "    Much smaller than full state \u2014 use for periodic refresh during long tasks.\n",
     "\n",
     "    Args:\n",
     "        since: Time window. Options: 30m, 1h, 6h, 24h.\n",
@@ -206,7 +206,7 @@
    "source": [
     "## Step 4: Multi-Agent with Shared World Context\n",
     "\n",
-    "In multi-agent systems, consistency matters. If the researcher says \"recession at 33%\" and the risk analyst says \"recession at 40%,\" they're not disagreeing — they're hallucinating different numbers.\n",
+    "In multi-agent systems, consistency matters. If the researcher says \"recession at 33%\" and the risk analyst says \"recession at 40%,\" they're not disagreeing \u2014 they're hallucinating different numbers.\n",
     "\n",
     "The fix: fetch the world state once, share it across all agents."
    ]
@@ -228,7 +228,7 @@
     "researcher = Agent(\n",
     "    name=\"researcher\",\n",
     "    instructions=SHARED_CONTEXT + \"\\nYou are a macro researcher. Analyze geopolitical and economic developments. Hand off to the risk analyst when you identify concerning data.\",\n",
-    "    handoffs=[\"risk_analyst\"],\n",
+    "    handoffs=[risk_analyst],\n",
     "    tools=[world_state, search_markets],\n",
     ")\n",
     "\n",
@@ -286,7 +286,7 @@
     "The world state endpoint requires no API key, is free, and returns data from 9,706 prediction markets updated every 15 minutes.\n",
     "\n",
     "**Links:**\n",
-    "- [World State API](https://simplefunctions.dev/api/agent/world) — try it now\n",
+    "- [World State API](https://simplefunctions.dev/api/agent/world) \u2014 try it now\n",
     "- [Documentation](https://simplefunctions.dev/docs/guide)\n",
     "- [All endpoints](https://simplefunctions.dev/api/tools)"
    ]

--- a/examples/partners/building_world_aware_agents/requirements.txt
+++ b/examples/partners/building_world_aware_agents/requirements.txt
@@ -1,0 +1,3 @@
+openai>=1.60.0
+openai-agents>=0.1.0
+requests>=2.31.0

--- a/registry.yaml
+++ b/registry.yaml
@@ -3128,3 +3128,16 @@
     - cost
     - responses
     - realtime
+
+- title: Building World-Aware Agents — Real-Time Context from Prediction Markets
+  path: examples/partners/building_world_aware_agents/building_world_aware_agents.ipynb
+  slug: building-world-aware-agents
+  description: Give agents real-time world awareness using calibrated prediction market data. Covers dynamic instructions, focused topic drilling, incremental updates, and multi-agent consistency.
+  date: 2026-04-02
+  authors:
+    - patrickliu0077
+  tags:
+    - agents
+    - agents-sdk
+    - partners
+    - function-calling


### PR DESCRIPTION
## Summary

Adds a cookbook showing how to build agents that have real-time world awareness using calibrated prediction market data. The cookbook uses the OpenAI Agents SDK and demonstrates:

1. **Dynamic instructions** — agent fetches fresh world state (~800 tokens) before each run
2. **Depth tools** — focused topic drilling (`?focus=energy,geo`) and incremental updates (`/delta?since=1h` for ~30-50 tokens)
3. **Multi-agent consistency** — shared world context so all agents cite the same probabilities

The data source ([SimpleFunctions](https://simplefunctions.dev/world)) aggregates 9,706 prediction market contracts from Kalshi (CFTC-regulated) and Polymarket into a markdown snapshot optimized for LLM context windows. No API key needed — the endpoint is free and public.

## Motivation

A recurring problem in agent development: LLMs have a knowledge cutoff and don't know what's happening today. Web search returns narratives ("tensions remain elevated"), not data. This cookbook shows a different approach — injecting calibrated probabilities backed by real money into the agent's context.

The prediction market insight: a price of 53c on "Iran invasion" encodes the aggregate judgment of everyone with money at risk on that question. This is fundamentally more useful for agent reasoning than news headlines or search results.

## Checklist

- [x] I've added an entry to `registry.yaml`
- [x] I've added an entry to `authors.yaml`
- [x] I've included a `requirements.txt`

## Self-review

- **Relevance**: 4 — Uses OpenAI Agents SDK (function_tool, Agent, Runner, handoffs)
- **Uniqueness**: 4 — No existing cookbook covers real-time world state injection for agents
- **Spelling/Grammar**: 4
- **Clarity**: 4 — Step-by-step with runnable code
- **Correctness**: 4 — All code cells execute (endpoints are live and public)
- **Completeness**: 4 — Covers single agent, tools, and multi-agent patterns