### PR TITLE
Add Dewey managed RAG pipeline example

### DIFF
--- a/examples/dewey_rag_pipeline.ipynb
+++ b/examples/dewey_rag_pipeline.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Building a RAG pipeline from scratch requires wiring together many moving parts: a document parser, a chunking strategy, an embedding model, a vector database, a keyword search index, and a retrieval layer that reconciles them. Each piece has configuration to tune, infrastructure to host, and failure modes to handle.\n",
     "\n",
-    "**[Dewey](https://meetdewey.com)** is a managed document backend that handles this entire pipeline behind a single REST API. You upload a document and Dewey takes care of conversion, section extraction, chunking, embedding, and hybrid retrieval — leaving you to focus on the application layer.\n",
+    "**[Dewey](https://meetdewey.com)** is a managed document backend that handles this entire pipeline behind a single REST API. You upload a document and Dewey takes care of conversion, section extraction, chunking, embedding, and hybrid retrieval \u2014 leaving you to focus on the application layer.\n",
     "\n",
     "In this notebook you will:\n",
     "\n",
@@ -63,7 +63,7 @@
    "source": [
     "## 1. Create a collection and upload documents\n",
     "\n",
-    "A **collection** is Dewey's top-level namespace — analogous to a table in a database or an index in a search engine. All documents, sections, and chunks live inside a collection, and retrieval is always scoped to one.\n",
+    "A **collection** is Dewey's top-level namespace \u2014 analogous to a table in a database or an index in a search engine. All documents, sections, and chunks live inside a collection, and retrieval is always scoped to one.\n",
     "\n",
     "We'll upload three foundational AI papers from ArXiv as PDFs."
    ]
@@ -112,7 +112,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Dewey processes documents asynchronously. The pipeline runs conversion → section extraction → chunking → embedding in the background. We poll until all documents reach `ready` status."
+    "Dewey processes documents asynchronously. The pipeline runs conversion \u2192 section extraction \u2192 chunking \u2192 embedding in the background. We poll until all documents reach `ready` status."
    ]
   },
   {
@@ -133,7 +133,7 @@
     "            if doc.status != \"ready\":\n",
     "                still_pending.add(doc_id)\n",
     "        if still_pending:\n",
-    "            print(f\"  waiting — {len(still_pending)}/{len(doc_ids)} still processing...\")\n",
+    "            print(f\"  waiting \u2014 {len(still_pending)}/{len(doc_ids)} still processing...\")\n",
     "            time.sleep(poll_interval)\n",
     "        pending = still_pending\n",
     "    print(\"All documents ready.\")\n",
@@ -147,7 +147,7 @@
    "source": [
     "### Inspect the document structure\n",
     "\n",
-    "Dewey parses each document's heading hierarchy into **sections** — a first-class API primitive. Sections with generic titles (\"Introduction\", \"Chapter 3\") automatically receive AI-generated summaries so they remain findable."
+    "Dewey parses each document's heading hierarchy into **sections** \u2014 a first-class API primitive. Sections with generic titles (\"Introduction\", \"Chapter 3\") automatically receive AI-generated summaries so they remain findable."
    ]
   },
   {
@@ -161,7 +161,7 @@
     "print(f\"Sections in '{PAPERS[0][0]}':\")\n",
     "for s in sections[:10]:\n",
     "    indent = \"  \" * (s.level - 1)\n",
-    "    summary_preview = f\" — {s.summary[:80]}...\" if s.summary else \"\"\n",
+    "    summary_preview = f\" \u2014 {s.summary[:80]}...\" if s.summary else \"\"\n",
     "    print(f\"  {indent}[L{s.level}] {s.title}{summary_preview}\")"
    ]
   },
@@ -173,7 +173,7 @@
     "\n",
     "Dewey's retrieval endpoint runs **hybrid search**: dense vector similarity (via text-embedding-3-small by default) combined with BM25 keyword search, merged using Reciprocal Rank Fusion (RRF). This catches both semantic matches and exact-term matches that pure vector search misses.\n",
     "\n",
-    "Each result carries citation metadata — filename, section title, and section level — so you always know where a chunk came from."
+    "Each result carries citation metadata \u2014 filename, section title, and section level \u2014 so you always know where a chunk came from."
    ]
   },
   {
@@ -187,7 +187,7 @@
     "\n",
     "print(f\"Top results for: '{query}'\\n\")\n",
     "for i, r in enumerate(results, 1):\n",
-    "    print(f\"  [{i}] score={r.score:.4f}  {r.document.filename} › {r.section.title}\")\n",
+    "    print(f\"  [{i}] score={r.score:.4f}  {r.document.filename} \u203a {r.section.title}\")\n",
     "    print(f\"      {r.chunk.content[:200].strip()}...\")\n",
     "    print()"
    ]
@@ -198,9 +198,9 @@
    "source": [
     "## 3. Section-aware retrieval\n",
     "\n",
-    "In addition to chunk-level retrieval, Dewey exposes a **section scan** endpoint that searches section titles and summaries — not chunk content. This is useful when you want to identify which parts of a document are relevant before fetching their full text.\n",
+    "In addition to chunk-level retrieval, Dewey exposes a **section scan** endpoint that searches section titles and summaries \u2014 not chunk content. This is useful when you want to identify which parts of a document are relevant before fetching their full text.\n",
     "\n",
-    "The mental model: **scan sections cheaply → fetch chunks only where needed**. This is especially valuable for large documents where loading every chunk into an LLM context is expensive."
+    "The mental model: **scan sections cheaply \u2192 fetch chunks only where needed**. This is especially valuable for large documents where loading every chunk into an LLM context is expensive."
    ]
   },
   {
@@ -216,9 +216,9 @@
     "    top_k=5,\n",
     ")\n",
     "\n",
-    "print(\"Relevant sections (titles + summaries only — no chunk content loaded yet):\\n\")\n",
+    "print(\"Relevant sections (titles + summaries only \u2014 no chunk content loaded yet):\\n\")\n",
     "for r in scan_results:\n",
-    "    print(f\"  {r.filename} › {r.title}  ({r.chunk_count} chunks)\")\n",
+    "    print(f\"  {r.filename} \u203a {r.title}  ({r.chunk_count} chunks)\")\n",
     "    if r.summary:\n",
     "        print(f\"    {r.summary[:150]}...\")\n",
     "    print()"
@@ -245,7 +245,7 @@
    "source": [
     "## 4. Agentic research with streaming\n",
     "\n",
-    "Dewey's `/research` endpoint runs a multi-step agentic loop: it searches, reads relevant sections, reasons across documents, and produces a grounded answer with full source citations. This is the equivalent of a research analyst skimming your document library — not just a single retrieval call.\n",
+    "Dewey's `/research` endpoint runs a multi-step agentic loop: it searches, reads relevant sections, reasons across documents, and produces a grounded answer with full source citations. This is the equivalent of a research analyst skimming your document library \u2014 not just a single retrieval call.\n",
     "\n",
     "The response streams over Server-Sent Events. Four depth levels trade cost for thoroughness:\n",
     "\n",
@@ -288,7 +288,7 @@
     "print(\"\\n\" + \"=\" * 80)\n",
     "print(f\"\\nSources ({len(sources)}):\")\n",
     "for s in sources:\n",
-    "    print(f\"  {s.filename} › {s.section_title}\")"
+    "    print(f\"  {s.filename} \u203a {s.section_title}\")"
    ]
   },
   {
@@ -297,7 +297,7 @@
    "source": [
     "## 5. Bring your own OpenAI key (BYOK)\n",
     "\n",
-    "By default, Dewey uses a managed OpenAI key and charges credits per research request. If you configure your own OpenAI key, Dewey routes all generation calls through it directly — no markup, and credit metering is bypassed entirely.\n",
+    "By default, Dewey uses a managed OpenAI key and charges credits per research request. If you configure your own OpenAI key, Dewey routes all generation calls through it directly \u2014 no markup, and credit metering is bypassed entirely.\n",
     "\n",
     "This makes sense once you want cost transparency and control, or when you want to use `deep` or `exhaustive` depth."
    ]
@@ -307,7 +307,25 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# To register your OpenAI key with Dewey, you need your project ID.\n# Find it in the Dewey dashboard or via the API:\n#\n#   provider_key = dewey.provider_keys.create(\n#       project_id=\"<your-project-id>\",\n#       provider=\"openai\",\n#       key=OPENAI_API_KEY,\n#       name=\"my-openai-key\",\n#   )\n#\n# Once registered, all research requests using this project's API key will route\n# through your OpenAI account. You pay OpenAI directly at cost.\n\nprint(\"To configure BYOK, uncomment and run the provider_key registration block above.\")\nprint(\"Once your key is registered, deep/exhaustive depths are unlocked and credit\")\nprint(\"metering is bypassed — Dewey routes generation through your OpenAI account.\")"
+   "source": [
+    "# To register your OpenAI key with Dewey, you need your project ID.\n",
+    "# Find it in the Dewey dashboard or via the API:\n",
+    "#\n",
+    "#   provider_key = dewey.provider_keys.create(\n",
+    "#       project_id=\"<your-project-id>\",\n",
+    "#       provider=\"openai\",\n",
+    "#       key=OPENAI_API_KEY,\n",
+    "#       name=\"my-openai-key\",\n",
+    "#   )\n",
+    "#\n",
+    "# Once registered, all research requests using this project's API key will route\n",
+    "# through your OpenAI account. You pay OpenAI directly at cost.\n",
+    "\n",
+    "print(\"BYOK is not yet configured \u2014 generation will use Dewey's managed key and consume credits.\")\n",
+    "print(\"To enable BYOK: fill in your project ID above, uncomment the provider_key.create(...)\")\n",
+    "print(\"block, and run this cell. Once registered, deep/exhaustive depths are unlocked\")\n",
+    "print(\"and credit metering is bypassed for this project.\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -317,7 +335,7 @@
     "\n",
     "You can also use Dewey purely as a retrieval backend and drive generation yourself with the OpenAI SDK. This gives you full control over prompting, model selection, and conversation management.\n",
     "\n",
-    "The pattern: **Dewey handles retrieval → OpenAI handles generation**."
+    "The pattern: **Dewey handles retrieval \u2192 OpenAI handles generation**."
    ]
   },
   {
@@ -342,7 +360,7 @@
     "    context_parts = []\n",
     "    for r in results:\n",
     "        context_parts.append(\n",
-    "            f\"[Source: {r.document.filename} › {r.section.title}]\\n{r.chunk.content}\"\n",
+    "            f\"[Source: {r.document.filename} \u203a {r.section.title}]\\n{r.chunk.content}\"\n",
     "        )\n",
     "    context = \"\\n\\n---\\n\\n\".join(context_parts)\n",
     "\n",
@@ -408,7 +426,7 @@
     "\n",
     "In this notebook you used Dewey to:\n",
     "\n",
-    "- **Ingest** PDF documents into a managed pipeline (convert → section → chunk → embed)\n",
+    "- **Ingest** PDF documents into a managed pipeline (convert \u2192 section \u2192 chunk \u2192 embed)\n",
     "- **Search** with hybrid BM25 + vector retrieval that returns chunk-level results with full citation metadata\n",
     "- **Navigate** document structure using section scan before committing to full chunk retrieval\n",
     "- **Research** across multiple documents with a streaming agentic loop that produces grounded, cited answers\n",

--- a/examples/dewey_rag_pipeline.ipynb
+++ b/examples/dewey_rag_pipeline.ipynb
@@ -1,0 +1,434 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Production Document Q&A with Dewey's Managed RAG Backend\n",
+    "\n",
+    "Building a RAG pipeline from scratch requires wiring together many moving parts: a document parser, a chunking strategy, an embedding model, a vector database, a keyword search index, and a retrieval layer that reconciles them. Each piece has configuration to tune, infrastructure to host, and failure modes to handle.\n",
+    "\n",
+    "**[Dewey](https://meetdewey.com)** is a managed document backend that handles this entire pipeline behind a single REST API. You upload a document and Dewey takes care of conversion, section extraction, chunking, embedding, and hybrid retrieval — leaving you to focus on the application layer.\n",
+    "\n",
+    "In this notebook you will:\n",
+    "\n",
+    "1. Upload a set of AI research papers to a Dewey collection\n",
+    "2. Run hybrid semantic + keyword search over them\n",
+    "3. Use section-aware retrieval to navigate document structure\n",
+    "4. Stream a grounded, cited answer from Dewey's agentic research endpoint\n",
+    "5. Build a simple RAG chat loop using the OpenAI Python SDK\n",
+    "\n",
+    "**Prerequisites**: A Dewey API key (free at [meetdewey.com](https://meetdewey.com)) and an OpenAI API key."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "%pip install meetdewey openai requests --quiet"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import time\n",
+    "import textwrap\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import requests\n",
+    "from dewey import DeweyClient\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "DEWEY_API_KEY = os.environ.get(\"DEWEY_API_KEY\", \"dwy_live_...\")\n",
+    "OPENAI_API_KEY = os.environ.get(\"OPENAI_API_KEY\", \"sk-...\")\n",
+    "\n",
+    "dewey = DeweyClient(api_key=DEWEY_API_KEY)\n",
+    "oai = OpenAI(api_key=OPENAI_API_KEY)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Create a collection and upload documents\n",
+    "\n",
+    "A **collection** is Dewey's top-level namespace — analogous to a table in a database or an index in a search engine. All documents, sections, and chunks live inside a collection, and retrieval is always scoped to one.\n",
+    "\n",
+    "We'll upload three foundational AI papers from ArXiv as PDFs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a collection\n",
+    "collection = dewey.collections.create(\"AI Research Papers\")\n",
+    "print(f\"Collection created: {collection.id}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Papers to upload: (filename, ArXiv PDF URL)\n",
+    "PAPERS = [\n",
+    "    (\"attention-is-all-you-need.pdf\",   \"https://arxiv.org/pdf/1706.03762\"),\n",
+    "    (\"gpt3-language-models.pdf\",         \"https://arxiv.org/pdf/2005.14165\"),\n",
+    "    (\"rag-knowledge-intensive-nlp.pdf\",  \"https://arxiv.org/pdf/2005.11401\"),\n",
+    "]\n",
+    "\n",
+    "doc_ids = []\n",
+    "for filename, url in PAPERS:\n",
+    "    print(f\"Uploading {filename}...\", end=\" \")\n",
+    "    pdf_bytes = requests.get(url, timeout=30).content\n",
+    "    doc = dewey.documents.upload(\n",
+    "        collection.id,\n",
+    "        pdf_bytes,\n",
+    "        filename=filename,\n",
+    "        content_type=\"application/pdf\",\n",
+    "    )\n",
+    "    doc_ids.append(doc.id)\n",
+    "    print(f\"id={doc.id}\")\n",
+    "\n",
+    "print(f\"\\nUploaded {len(doc_ids)} documents.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Dewey processes documents asynchronously. The pipeline runs conversion → section extraction → chunking → embedding in the background. We poll until all documents reach `ready` status."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def wait_for_ready(collection_id: str, doc_ids: list[str], poll_interval: float = 5.0) -> None:\n",
+    "    \"\"\"Block until all documents in doc_ids reach 'ready' or 'error' status.\"\"\"\n",
+    "    pending = set(doc_ids)\n",
+    "    while pending:\n",
+    "        still_pending = set()\n",
+    "        for doc_id in pending:\n",
+    "            doc = dewey.documents.get(collection_id, doc_id)\n",
+    "            if doc.status == \"error\":\n",
+    "                raise RuntimeError(f\"{doc.filename} failed: {doc.error_message}\")\n",
+    "            if doc.status != \"ready\":\n",
+    "                still_pending.add(doc_id)\n",
+    "        if still_pending:\n",
+    "            print(f\"  waiting — {len(still_pending)}/{len(doc_ids)} still processing...\")\n",
+    "            time.sleep(poll_interval)\n",
+    "        pending = still_pending\n",
+    "    print(\"All documents ready.\")\n",
+    "\n",
+    "wait_for_ready(collection.id, doc_ids)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Inspect the document structure\n",
+    "\n",
+    "Dewey parses each document's heading hierarchy into **sections** — a first-class API primitive. Sections with generic titles (\"Introduction\", \"Chapter 3\") automatically receive AI-generated summaries so they remain findable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List the top-level sections for the first document\n",
+    "sections = dewey.sections.list(collection.id, doc_ids[0])\n",
+    "print(f\"Sections in '{PAPERS[0][0]}':\")\n",
+    "for s in sections[:10]:\n",
+    "    indent = \"  \" * (s.level - 1)\n",
+    "    summary_preview = f\" — {s.summary[:80]}...\" if s.summary else \"\"\n",
+    "    print(f\"  {indent}[L{s.level}] {s.title}{summary_preview}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Hybrid search\n",
+    "\n",
+    "Dewey's retrieval endpoint runs **hybrid search**: dense vector similarity (via text-embedding-3-small by default) combined with BM25 keyword search, merged using Reciprocal Rank Fusion (RRF). This catches both semantic matches and exact-term matches that pure vector search misses.\n",
+    "\n",
+    "Each result carries citation metadata — filename, section title, and section level — so you always know where a chunk came from."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"How does the attention mechanism scale with sequence length?\"\n",
+    "results = dewey.retrieval.query(collection.id, query, limit=5)\n",
+    "\n",
+    "print(f\"Top results for: '{query}'\\n\")\n",
+    "for i, r in enumerate(results, 1):\n",
+    "    print(f\"  [{i}] score={r.score:.4f}  {r.document.filename} › {r.section.title}\")\n",
+    "    print(f\"      {r.chunk.content[:200].strip()}...\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Section-aware retrieval\n",
+    "\n",
+    "In addition to chunk-level retrieval, Dewey exposes a **section scan** endpoint that searches section titles and summaries — not chunk content. This is useful when you want to identify which parts of a document are relevant before fetching their full text.\n",
+    "\n",
+    "The mental model: **scan sections cheaply → fetch chunks only where needed**. This is especially valuable for large documents where loading every chunk into an LLM context is expensive."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Scan section titles and summaries first\n",
+    "scan_results = dewey.sections.scan(\n",
+    "    collection.id,\n",
+    "    query=\"multi-head attention architecture\",\n",
+    "    top_k=5,\n",
+    ")\n",
+    "\n",
+    "print(\"Relevant sections (titles + summaries only — no chunk content loaded yet):\\n\")\n",
+    "for r in scan_results:\n",
+    "    print(f\"  {r.filename} › {r.title}  ({r.chunk_count} chunks)\")\n",
+    "    if r.summary:\n",
+    "        print(f\"    {r.summary[:150]}...\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fetch the full content of the most relevant section\n",
+    "top_section_id = scan_results[0].section_id\n",
+    "section = dewey.sections.get(top_section_id)\n",
+    "\n",
+    "print(f\"Full content of '{section.title}' ({len(section.content)} chars):\\n\")\n",
+    "print(textwrap.fill(section.content[:800], width=90))\n",
+    "print(\"...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Agentic research with streaming\n",
+    "\n",
+    "Dewey's `/research` endpoint runs a multi-step agentic loop: it searches, reads relevant sections, reasons across documents, and produces a grounded answer with full source citations. This is the equivalent of a research analyst skimming your document library — not just a single retrieval call.\n",
+    "\n",
+    "The response streams over Server-Sent Events. Four depth levels trade cost for thoroughness:\n",
+    "\n",
+    "| Depth | Credits | Use case |\n",
+    "|---|---|---|\n",
+    "| `quick` | 0.5 | Fast factual lookups |\n",
+    "| `balanced` | 1 | General Q&A (default) |\n",
+    "| `deep` | 3 | Multi-document synthesis |\n",
+    "| `exhaustive` | 8 | Comprehensive research |\n",
+    "\n",
+    "`deep` and `exhaustive` require a configured provider key (see section 5)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "question = (\n",
+    "    \"Compare how the Transformer architecture and RAG each address the limitations \"\n",
+    "    \"of earlier sequence-to-sequence models. What problems does each solve?\"\n",
+    ")\n",
+    "\n",
+    "print(f\"Question: {question}\\n\")\n",
+    "print(\"=\" * 80)\n",
+    "\n",
+    "answer_parts = []\n",
+    "sources = []\n",
+    "\n",
+    "for event in dewey.research.stream(collection.id, question, depth=\"balanced\"):\n",
+    "    if event.type == \"tool_call\":\n",
+    "        print(f\"  [searching] {event.query}\", flush=True)\n",
+    "    elif event.type == \"chunk\":\n",
+    "        print(event.content, end=\"\", flush=True)\n",
+    "        answer_parts.append(event.content)\n",
+    "    elif event.type == \"done\":\n",
+    "        sources = event.sources\n",
+    "\n",
+    "print(\"\\n\" + \"=\" * 80)\n",
+    "print(f\"\\nSources ({len(sources)}):\")\n",
+    "for s in sources:\n",
+    "    print(f\"  {s.filename} › {s.section_title}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Bring your own OpenAI key (BYOK)\n",
+    "\n",
+    "By default, Dewey uses a managed OpenAI key and charges credits per research request. If you configure your own OpenAI key, Dewey routes all generation calls through it directly — no markup, and credit metering is bypassed entirely.\n",
+    "\n",
+    "This makes sense once you want cost transparency and control, or when you want to use `deep` or `exhaustive` depth."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# To register your OpenAI key with Dewey, you need your project ID.\n# Find it in the Dewey dashboard or via the API:\n#\n#   provider_key = dewey.provider_keys.create(\n#       project_id=\"<your-project-id>\",\n#       provider=\"openai\",\n#       key=OPENAI_API_KEY,\n#       name=\"my-openai-key\",\n#   )\n#\n# Once registered, all research requests using this project's API key will route\n# through your OpenAI account. You pay OpenAI directly at cost.\n\nprint(\"To configure BYOK, uncomment and run the provider_key registration block above.\")\nprint(\"Once your key is registered, deep/exhaustive depths are unlocked and credit\")\nprint(\"metering is bypassed — Dewey routes generation through your OpenAI account.\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Building a RAG chat loop with the OpenAI SDK\n",
+    "\n",
+    "You can also use Dewey purely as a retrieval backend and drive generation yourself with the OpenAI SDK. This gives you full control over prompting, model selection, and conversation management.\n",
+    "\n",
+    "The pattern: **Dewey handles retrieval → OpenAI handles generation**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SYSTEM_PROMPT = \"\"\"\\\n",
+    "You are a research assistant with access to a library of AI papers.\n",
+    "Answer questions using only the provided context. Always cite your sources\n",
+    "by referencing the document filename and section title.\n",
+    "If the context does not contain enough information, say so.\"\"\"\n",
+    "\n",
+    "\n",
+    "def rag_answer(question: str, k: int = 6) -> str:\n",
+    "    \"\"\"Retrieve relevant chunks from Dewey and generate an answer with OpenAI.\"\"\"\n",
+    "    # 1. Retrieve\n",
+    "    results = dewey.retrieval.query(collection.id, question, limit=k)\n",
+    "\n",
+    "    # 2. Build context block\n",
+    "    context_parts = []\n",
+    "    for r in results:\n",
+    "        context_parts.append(\n",
+    "            f\"[Source: {r.document.filename} › {r.section.title}]\\n{r.chunk.content}\"\n",
+    "        )\n",
+    "    context = \"\\n\\n---\\n\\n\".join(context_parts)\n",
+    "\n",
+    "    # 3. Generate\n",
+    "    response = oai.chat.completions.create(\n",
+    "        model=\"gpt-4o-mini\",\n",
+    "        messages=[\n",
+    "            {\"role\": \"system\", \"content\": SYSTEM_PROMPT},\n",
+    "            {\n",
+    "                \"role\": \"user\",\n",
+    "                \"content\": f\"Context:\\n{context}\\n\\nQuestion: {question}\",\n",
+    "            },\n",
+    "        ],\n",
+    "    )\n",
+    "    return response.choices[0].message.content\n",
+    "\n",
+    "\n",
+    "# Try it\n",
+    "answer = rag_answer(\"What is the role of positional encoding in the Transformer?\")\n",
+    "print(textwrap.fill(answer, width=90))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simple multi-turn chat loop\n",
+    "# Uncomment and run to interact in the notebook\n",
+    "\n",
+    "# while True:\n",
+    "#     q = input(\"\\nYou: \").strip()\n",
+    "#     if q.lower() in {\"exit\", \"quit\", \"q\"}:\n",
+    "#         break\n",
+    "#     answer = rag_answer(q)\n",
+    "#     print(f\"\\nAssistant: {answer}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the collection and all its documents when you're done\n",
+    "dewey.collections.delete(collection.id)\n",
+    "print(f\"Collection {collection.id} deleted.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook you used Dewey to:\n",
+    "\n",
+    "- **Ingest** PDF documents into a managed pipeline (convert → section → chunk → embed)\n",
+    "- **Search** with hybrid BM25 + vector retrieval that returns chunk-level results with full citation metadata\n",
+    "- **Navigate** document structure using section scan before committing to full chunk retrieval\n",
+    "- **Research** across multiple documents with a streaming agentic loop that produces grounded, cited answers\n",
+    "- **Integrate** Dewey's retrieval layer into an OpenAI-powered RAG chat loop\n",
+    "\n",
+    "The full REST API and Python/TypeScript SDKs are documented at [meetdewey.com/docs](https://meetdewey.com/docs). A free tier is available with no credit card required."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/registry.yaml
+++ b/registry.yaml
@@ -4,6 +4,21 @@
 # should build pages for, and indicates metadata such as tags, creation date and
 # authors for each page.
 
+- title: Production Document Q&A with Dewey's Managed RAG Backend
+  path: examples/dewey_rag_pipeline.ipynb
+  slug: dewey-rag-pipeline
+  description: Build a production RAG pipeline using Dewey's managed document backend — upload PDFs, run hybrid search, stream agentic research, and integrate with the OpenAI SDK.
+  date: 2026-04-03
+  authors:
+    - lambdabaa
+  tags:
+    - rag
+    - retrieval
+    - search
+    - embeddings
+    - agents
+    - partners
+
 - title: Getting the Most out of GPT-5.4 for Vision and Document Understanding
   path: examples/multimodal/document_and_multimodal_understanding_tips.ipynb
   slug: vision-understanding


### PR DESCRIPTION
## Summary

Adds a notebook demonstrating how to build production document Q&A using [Dewey](https://meetdewey.com) as a managed RAG backend alongside the OpenAI Python SDK.

Dewey handles the full ingestion pipeline (PDF conversion, section extraction, chunking, embedding) behind a single API, letting developers focus on the application layer rather than infrastructure assembly.

The notebook covers:

- Uploading PDFs (three foundational AI papers from ArXiv) to a Dewey collection
- Waiting for async ingestion and inspecting the extracted section hierarchy
- Hybrid BM25 + vector search (RRF) with chunk-level citation metadata
- Section-aware retrieval: scan section titles/summaries cheaply before loading full chunk content
- Streaming agentic research endpoint with tool-call trace and source attribution
- BYOK (bring your own OpenAI key) for direct cost transparency
- A RAG chat loop using Dewey retrieval + OpenAI `gpt-4o-mini` generation

## Notebook location

`examples/dewey_rag_pipeline.ipynb`

## Dependencies

- `meetdewey` — Dewey Python SDK
- `openai` — OpenAI Python SDK
- `requests` — for downloading ArXiv PDFs (stdlib-only alternative available)

Both are installed via `%pip install` at the top of the notebook.