### PR TITLE
Fix outdated beta.openai.com URLs in vector database notebooks

### DIFF
--- a/examples/vector_databases/PolarDB/Getting_started_with_PolarDB_and_OpenAI.ipynb
+++ b/examples/vector_databases/PolarDB/Getting_started_with_PolarDB_and_OpenAI.ipynb
@@ -41,7 +41,7 @@
     "\n",
     "1. PolarDB-PG cloud server instance.\n",
     "2. The 'psycopg2' library to interact with the vector database. Any other postgresql client library is ok.\n",
-    "3. An [OpenAI API key](https://beta.openai.com/account/api-keys)."
+    "3. An [OpenAI API key](https://platform.openai.com/account/api-keys)."
    ]
   },
   {
@@ -79,7 +79,7 @@
     "Prepare your OpenAI API key\n",
     "The OpenAI API key is used for vectorization of the documents and queries.\n",
     "\n",
-    "If you don't have an OpenAI API key, you can get one from https://beta.openai.com/account/api-keys.\n",
+    "If you don't have an OpenAI API key, you can get one from https://platform.openai.com/account/api-keys.\n",
     "\n",
     "Once you get your key, please add it to your environment variables as OPENAI_API_KEY.\n",
     "\n",

--- a/examples/vector_databases/analyticdb/Getting_started_with_AnalyticDB_and_OpenAI.ipynb
+++ b/examples/vector_databases/analyticdb/Getting_started_with_AnalyticDB_and_OpenAI.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "1. AnalyticDB cloud server instance.\n",
     "2. The 'psycopg2' library to interact with the vector database. Any other postgresql client library is ok.\n",
-    "3. An [OpenAI API key](https://beta.openai.com/account/api-keys).\n",
+    "3. An [OpenAI API key](https://platform.openai.com/account/api-keys).\n",
     "\n"
    ]
   },
@@ -78,7 +78,7 @@
     "\n",
     "The OpenAI API key is used for vectorization of the documents and queries.\n",
     "\n",
-    "If you don't have an OpenAI API key, you can get one from [https://beta.openai.com/account/api-keys](https://beta.openai.com/account/api-keys).\n",
+    "If you don't have an OpenAI API key, you can get one from [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).\n",
     "\n",
     "Once you get your key, please add it to your environment variables as `OPENAI_API_KEY`."
    ]

--- a/examples/vector_databases/chroma/hyde-with-chroma-and-openai.ipynb
+++ b/examples/vector_databases/chroma/hyde-with-chroma-and-openai.ipynb
@@ -53,7 +53,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use OpenAI's API's throughout this notebook. You can get an API key from [https://beta.openai.com/account/api-keys](https://beta.openai.com/account/api-keys)\n",
+    "We use OpenAI's API's throughout this notebook. You can get an API key from [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys)\n",
     "\n",
     "You can add your API key as an environment variable by executing the command `export OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` in a terminal. Note that you will need to reload the notebook if the environment variable wasn't set yet. Alternatively, you can set it in the notebook, see below. "
    ]

--- a/examples/vector_databases/hologres/Getting_started_with_Hologres_and_OpenAI.ipynb
+++ b/examples/vector_databases/hologres/Getting_started_with_Hologres_and_OpenAI.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "1. Hologres cloud server instance.\n",
     "2. The 'psycopg2-binary' library to interact with the vector database. Any other postgresql client library is ok.\n",
-    "3. An [OpenAI API key](https://beta.openai.com/account/api-keys).\n",
+    "3. An [OpenAI API key](https://platform.openai.com/account/api-keys).\n",
     "\n"
    ]
   },
@@ -83,7 +83,7 @@
     "\n",
     "The OpenAI API key is used for vectorization of the documents and queries.\n",
     "\n",
-    "If you don't have an OpenAI API key, you can get one from [https://beta.openai.com/account/api-keys](https://beta.openai.com/account/api-keys).\n",
+    "If you don't have an OpenAI API key, you can get one from [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).\n",
     "\n",
     "Once you get your key, please add it to your environment variables as `OPENAI_API_KEY`."
    ]

--- a/examples/vector_databases/myscale/Getting_started_with_MyScale_and_OpenAI.ipynb
+++ b/examples/vector_databases/myscale/Getting_started_with_MyScale_and_OpenAI.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "1. A MyScale cluster deployed by following the [quickstart guide](https://docs.myscale.com/en/quickstart/).\n",
     "2. The 'clickhouse-connect' library to interact with MyScale.\n",
-    "3. An [OpenAI API key](https://beta.openai.com/account/api-keys) for vectorization of queries."
+    "3. An [OpenAI API key](https://platform.openai.com/account/api-keys) for vectorization of queries."
    ]
   },
   {

--- a/examples/vector_databases/qdrant/Getting_started_with_Qdrant_and_OpenAI.ipynb
+++ b/examples/vector_databases/qdrant/Getting_started_with_Qdrant_and_OpenAI.ipynb
@@ -132,7 +132,7 @@
     "\n",
     "The OpenAI API key is used for vectorization of the documents and queries.\n",
     "\n",
-    "If you don't have an OpenAI API key, you can get one from [https://beta.openai.com/account/api-keys](https://beta.openai.com/account/api-keys).\n",
+    "If you don't have an OpenAI API key, you can get one from [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).\n",
     "\n",
     "Once you get your key, please add it to your environment variables as `OPENAI_API_KEY` by running following command:"
    ]

--- a/examples/vector_databases/qdrant/QA_with_Langchain_Qdrant_and_OpenAI.ipynb
+++ b/examples/vector_databases/qdrant/QA_with_Langchain_Qdrant_and_OpenAI.ipynb
@@ -29,7 +29,7 @@
     "1. Qdrant server instance. In our case a local Docker container.\n",
     "2. The [qdrant-client](https://github.com/qdrant/qdrant_client) library to interact with the vector database.\n",
     "3. [Langchain](https://github.com/hwchase17/langchain) as a framework.\n",
-    "3. An [OpenAI API key](https://beta.openai.com/account/api-keys).\n",
+    "3. An [OpenAI API key](https://platform.openai.com/account/api-keys).\n",
     "\n",
     "### Start Qdrant server\n",
     "\n",
@@ -120,7 +120,7 @@
     "\n",
     "The OpenAI API key is used for vectorization of the documents and queries.\n",
     "\n",
-    "If you don't have an OpenAI API key, you can get one from [https://beta.openai.com/account/api-keys](https://beta.openai.com/account/api-keys).\n",
+    "If you don't have an OpenAI API key, you can get one from [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).\n",
     "\n",
     "Once you get your key, please add it to your environment variables as `OPENAI_API_KEY` by running following command:"
    ]

--- a/examples/vector_databases/redis/getting-started-with-redis-and-openai.ipynb
+++ b/examples/vector_databases/redis/getting-started-with-redis-and-openai.ipynb
@@ -43,7 +43,7 @@
     "* start a Redis database with RediSearch (redis-stack)\n",
     "* install libraries\n",
     "    * [Redis-py](https://github.com/redis/redis-py)\n",
-    "* get your [OpenAI API key](https://beta.openai.com/account/api-keys)\n",
+    "* get your [OpenAI API key](https://platform.openai.com/account/api-keys)\n",
     "\n",
     "===========================================================\n",
     "\n",
@@ -92,7 +92,7 @@
     "\n",
     "The `OpenAI API key` is used for vectorization of query data.\n",
     "\n",
-    "If you don't have an OpenAI API key, you can get one from [https://beta.openai.com/account/api-keys](https://beta.openai.com/account/api-keys).\n",
+    "If you don't have an OpenAI API key, you can get one from [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).\n",
     "\n",
     "Once you get your key, please add it to your environment variables as `OPENAI_API_KEY` by using following command:"
    ]

--- a/examples/vector_databases/redis/redis-hybrid-query-examples.ipynb
+++ b/examples/vector_databases/redis/redis-hybrid-query-examples.ipynb
@@ -24,7 +24,7 @@
     "* start a Redis database with RediSearch (redis-stack)\n",
     "* install libraries\n",
     "    * [Redis-py](https://github.com/redis/redis-py)\n",
-    "* get your [OpenAI API key](https://beta.openai.com/account/api-keys)\n",
+    "* get your [OpenAI API key](https://platform.openai.com/account/api-keys)\n",
     "\n",
     "===========================================================\n",
     "\n",
@@ -100,7 +100,7 @@
     "\n",
     "The `OpenAI API key` is used for vectorization of query data.\n",
     "\n",
-    "If you don't have an OpenAI API key, you can get one from [https://beta.openai.com/account/api-keys](https://beta.openai.com/account/api-keys).\n",
+    "If you don't have an OpenAI API key, you can get one from [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).\n",
     "\n",
     "Once you get your key, please add it to your environment variables as `OPENAI_API_KEY` by using following command:"
    ]

--- a/examples/vector_databases/tair/Getting_started_with_Tair_and_OpenAI.ipynb
+++ b/examples/vector_databases/tair/Getting_started_with_Tair_and_OpenAI.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "1. Tair cloud server instance.\n",
     "2. The 'tair' library to interact with the tair database.\n",
-    "3. An [OpenAI API key](https://beta.openai.com/account/api-keys).\n",
+    "3. An [OpenAI API key](https://platform.openai.com/account/api-keys).\n",
     "\n"
    ]
   },
@@ -109,7 +109,7 @@
     "\n",
     "The OpenAI API key is used for vectorization of the documents and queries.\n",
     "\n",
-    "If you don't have an OpenAI API key, you can get one from [https://beta.openai.com/account/api-keys](https://beta.openai.com/account/api-keys).\n",
+    "If you don't have an OpenAI API key, you can get one from [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).\n",
     "\n",
     "Once you get your key, please add it by getpass."
    ]

--- a/examples/vector_databases/weaviate/generative-search-with-weaviate-and-openai.ipynb
+++ b/examples/vector_databases/weaviate/generative-search-with-weaviate-and-openai.ipynb
@@ -30,7 +30,7 @@
     "* completed [Getting Started cookbook](./getting-started-with-weaviate-and-openai.ipynb),\n",
     "* crated a `Weaviate` instance,\n",
     "* imported data into your `Weaviate` instance,\n",
-    "* you have an [OpenAI API key](https://beta.openai.com/account/api-keys)"
+    "* you have an [OpenAI API key](https://platform.openai.com/account/api-keys)"
    ]
   },
   {
@@ -43,7 +43,7 @@
     "\n",
     "The `OpenAI API key` is used for vectorization of your data at import, and for running queries.\n",
     "\n",
-    "If you don't have an OpenAI API key, you can get one from [https://beta.openai.com/account/api-keys](https://beta.openai.com/account/api-keys).\n",
+    "If you don't have an OpenAI API key, you can get one from [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).\n",
     "\n",
     "Once you get your key, please add it to your environment variables as `OPENAI_API_KEY`."
    ]

--- a/examples/vector_databases/weaviate/getting-started-with-weaviate-and-openai.ipynb
+++ b/examples/vector_databases/weaviate/getting-started-with-weaviate-and-openai.ipynb
@@ -95,7 +95,7 @@
     "    * `weaviate-client`\n",
     "    * `datasets`\n",
     "    * `apache-beam`\n",
-    "* get your [OpenAI API key](https://beta.openai.com/account/api-keys)\n",
+    "* get your [OpenAI API key](https://platform.openai.com/account/api-keys)\n",
     "\n",
     "===========================================================\n",
     "### Create a Weaviate instance\n",
@@ -172,7 +172,7 @@
     "\n",
     "The `OpenAI API key` is used for vectorization of your data at import, and for running queries.\n",
     "\n",
-    "If you don't have an OpenAI API key, you can get one from [https://beta.openai.com/account/api-keys](https://beta.openai.com/account/api-keys).\n",
+    "If you don't have an OpenAI API key, you can get one from [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).\n",
     "\n",
     "Once you get your key, please add it to your environment variables as `OPENAI_API_KEY`."
    ]

--- a/examples/vector_databases/weaviate/hybrid-search-with-weaviate-and-openai.ipynb
+++ b/examples/vector_databases/weaviate/hybrid-search-with-weaviate-and-openai.ipynb
@@ -95,7 +95,7 @@
     "    * `weaviate-client`\n",
     "    * `datasets`\n",
     "    * `apache-beam`\n",
-    "* get your [OpenAI API key](https://beta.openai.com/account/api-keys)\n",
+    "* get your [OpenAI API key](https://platform.openai.com/account/api-keys)\n",
     "\n",
     "===========================================================\n",
     "### Create a Weaviate instance\n",
@@ -172,7 +172,7 @@
     "\n",
     "The `OpenAI API key` is used for vectorization of your data at import, and for running queries.\n",
     "\n",
-    "If you don't have an OpenAI API key, you can get one from [https://beta.openai.com/account/api-keys](https://beta.openai.com/account/api-keys).\n",
+    "If you don't have an OpenAI API key, you can get one from [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).\n",
     "\n",
     "Once you get your key, please add it to your environment variables as `OPENAI_API_KEY`."
    ]

--- a/examples/vector_databases/weaviate/question-answering-with-weaviate-and-openai.ipynb
+++ b/examples/vector_databases/weaviate/question-answering-with-weaviate-and-openai.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "This notebook is prepared for a scenario where:\n",
     "* Your data is not vectorized\n",
-    "* You want to run Q&A ([learn more](https://weaviate.io/developers/weaviate/modules/reader-generator-modules/qna-openai)) on your data based on the [OpenAI completions](https://beta.openai.com/docs/api-reference/completions) endpoint.\n",
+    "* You want to run Q&A ([learn more](https://weaviate.io/developers/weaviate/modules/reader-generator-modules/qna-openai)) on your data based on the [OpenAI completions](https://platform.openai.com/docs/api-reference/completions) endpoint.\n",
     "* You want to use Weaviate with the OpenAI module ([text2vec-openai](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai)), to generate vector embeddings for you.\n",
     "\n",
     "This notebook takes you through a simple flow to set up a Weaviate instance, connect to it (with OpenAI API key), configure data schema, import data (which will automatically generate vector embeddings for your data), and run question answering.\n",
@@ -94,7 +94,7 @@
     "    * `weaviate-client`\n",
     "    * `datasets`\n",
     "    * `apache-beam`\n",
-    "* get your [OpenAI API key](https://beta.openai.com/account/api-keys)\n",
+    "* get your [OpenAI API key](https://platform.openai.com/account/api-keys)\n",
     "\n",
     "===========================================================\n",
     "### Create a Weaviate instance\n",
@@ -171,7 +171,7 @@
     "\n",
     "The `OpenAI API key` is used for vectorization of your data at import, and for queries.\n",
     "\n",
-    "If you don't have an OpenAI API key, you can get one from [https://beta.openai.com/account/api-keys](https://beta.openai.com/account/api-keys).\n",
+    "If you don't have an OpenAI API key, you can get one from [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).\n",
     "\n",
     "Once you get your key, please add it to your environment variables as `OPENAI_API_KEY`."
    ]


### PR DESCRIPTION
## Summary
- Replace all deprecated `beta.openai.com` links with the current `platform.openai.com` equivalents across 14 vector database example notebooks
- Covers notebooks for Weaviate (4 files), Qdrant (2), Redis (2), Tair, AnalyticDB, PolarDB, Hologres, MyScale, and Chroma
- Most occurrences are API key links (`/account/api-keys`) and API reference links that currently redirect or 404

## Files changed (14 notebooks)
- `examples/vector_databases/weaviate/` — 4 notebooks (getting-started, generative-search, hybrid-search, question-answering)
- `examples/vector_databases/qdrant/` — 2 notebooks (Getting_started, QA_with_Langchain)
- `examples/vector_databases/redis/` — 2 notebooks (getting-started, hybrid-query)
- `examples/vector_databases/tair/Getting_started_with_Tair_and_OpenAI.ipynb`
- `examples/vector_databases/analyticdb/Getting_started_with_AnalyticDB_and_OpenAI.ipynb`
- `examples/vector_databases/PolarDB/Getting_started_with_PolarDB_and_OpenAI.ipynb`
- `examples/vector_databases/hologres/Getting_started_with_Hologres_and_OpenAI.ipynb`
- `examples/vector_databases/myscale/Getting_started_with_MyScale_and_OpenAI.ipynb`
- `examples/vector_databases/chroma/hyde-with-chroma-and-openai.ipynb`

## Test plan
- [ ] Verify each updated URL resolves to the correct page on platform.openai.com
- [ ] Confirm no other content was changed (only URL domain replacement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)