### PR TITLE
Fix broken fine-tuning docs links in RAG notebook

### DIFF
--- a/examples/fine-tuned_qa/ft_retrieval_augmented_generation_qdrant.ipynb
+++ b/examples/fine-tuned_qa/ft_retrieval_augmented_generation_qdrant.ipynb
@@ -488,7 +488,7 @@
    "source": [
     "## 4. Fine-tuning and Answering using Fine-tuned model\n",
     "\n",
-    "For the complete fine-tuning process, please refer to the [OpenAI Fine-Tuning Docs](https://platform.openai.com/docs/guides/fine-tuning/use-a-fine-tuned-model).\n",
+    "For the complete fine-tuning process, please refer to the [OpenAI Fine-Tuning Docs](https://platform.openai.com/docs/guides/fine-tuning).\n",
     "\n",
     "### 4.1 Prepare the Fine-Tuning Data\n",
     "\n",
@@ -538,7 +538,7 @@
     "\n",
     "### 4.2 Fine-Tune OpenAI Model\n",
     "\n",
-    "If you're new to OpenAI Model Fine-Tuning, please refer to the [How to finetune Chat models](https://github.com/openai/openai-cookbook/blob/448a0595b84ced3bebc9a1568b625e748f9c1d60/examples/How_to_finetune_chat_models.ipynb) notebook. You can also refer to the [OpenAI Fine-Tuning Docs](platform.openai.com/docs/guides/fine-tuning/use-a-fine-tuned-model) for more details."
+    "If you're new to OpenAI Model Fine-Tuning, please refer to the [How to finetune Chat models](https://github.com/openai/openai-cookbook/blob/448a0595b84ced3bebc9a1568b625e748f9c1d60/examples/How_to_finetune_chat_models.ipynb) notebook. You can also refer to the [OpenAI Fine-Tuning Docs](https://platform.openai.com/docs/guides/fine-tuning) for more details."
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Fixes broken links to OpenAI Fine-Tuning documentation in `examples/fine-tuned_qa/ft_retrieval_augmented_generation_qdrant.ipynb`
- The `/use-a-fine-tuned-model` anchor no longer exists on the OpenAI platform docs page, so both URLs now point to `https://platform.openai.com/docs/guides/fine-tuning`
- Also fixes a missing `https://` protocol prefix on one of the URLs (cell 20 had a bare `platform.openai.com/...` link)

Fixes #2320

## Test plan
- [ ] Verify that the updated links (`https://platform.openai.com/docs/guides/fine-tuning`) resolve correctly in a browser
- [ ] Confirm no other links in the notebook are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)