### PR TITLE
Add structured outputs with validate-and-retry using agentcast

### DIFF
--- a/authors.yaml
+++ b/authors.yaml
@@ -587,3 +587,8 @@ sophiaqin-openai:
   name: "Sophia Qin"
   website: "https://github.com/sophiaqin-openai"
   avatar: "https://avatars.githubusercontent.com/u/205098674?v=4"
+
+MukundaKatta:
+  name: "Mukunda Katta"
+  website: "https://github.com/MukundaKatta"
+  avatar: "https://github.com/MukundaKatta.png"

--- a/examples/Structured_outputs_with_validate_and_retry_using_agentcast.ipynb
+++ b/examples/Structured_outputs_with_validate_and_retry_using_agentcast.ipynb
@@ -1,0 +1,362 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7cb61ae6",
+   "metadata": {},
+   "source": [
+    "# Structured outputs with validate-and-retry, using agentcast\n",
+    "\n",
+    "OpenAI's [Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs) feature is the right answer when you can use it: pass a JSON Schema (or Pydantic model), get back JSON that exactly matches it. No retries needed.\n",
+    "\n",
+    "But there are real cases where Structured Outputs alone isn't enough:\n",
+    "\n",
+    "1. **Validation rules JSON Schema can't express.** \"The list of category weights must sum to 1.0\". \"`end_date` must be after `start_date`\". \"At least one of `email` or `phone` must be present\". You need code, not a schema.\n",
+    "2. **Models or providers that don't support strict mode.** Older OpenAI models, fine-tunes, third-party endpoints behind the OpenAI-compatible API, local models. The output looks like JSON ninety percent of the time and you want a clean retry loop for the other ten.\n",
+    "3. **You want validation + retry as a reusable layer** that doesn't care which LLM you're calling.\n",
+    "\n",
+    "[`agentcast`](https://pypi.org/project/agentcast-py/) is a small (~200 LOC, MIT, zero runtime deps) library that wraps any LLM call with: extract JSON → validate → on failure, append the error as feedback and retry. BYO-LLM, BYO-validator. This notebook shows how to drop it in alongside the OpenAI Python SDK."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18fc780c",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0684f80c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q openai agentcast-py pydantic python-dotenv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ebda678",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "# agentcast: validate-and-retry wrapper for any LLM call\n",
+    "from agentcast import CastError, cast, extract_json\n",
+    "from agentcast import adapters as cast_adapters\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "from pydantic import BaseModel, Field, model_validator\n",
+    "\n",
+    "load_dotenv()\n",
+    "client = OpenAI()\n",
+    "MODEL = \"gpt-4o-mini\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e94c646",
+   "metadata": {},
+   "source": [
+    "## Example 1: a Pydantic model with a custom invariant\n",
+    "\n",
+    "We want to extract a product description into a typed shape, plus enforce a rule that JSON Schema can't say on its own: the per-category sentiment scores must sum to 1.0."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1573b1fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class CategorySentiment(BaseModel):\n",
+    "    label: str\n",
+    "    score: float = Field(ge=0.0, le=1.0)\n",
+    "\n",
+    "\n",
+    "class ProductReview(BaseModel):\n",
+    "    product_name: str\n",
+    "    overall_rating: int = Field(ge=1, le=5)\n",
+    "    summary: str\n",
+    "    sentiment_breakdown: list[CategorySentiment]\n",
+    "\n",
+    "    @model_validator(mode=\"after\")\n",
+    "    def _scores_sum_to_one(self):\n",
+    "        total = sum(c.score for c in self.sentiment_breakdown)\n",
+    "        if abs(total - 1.0) > 1e-3:\n",
+    "            raise ValueError(\n",
+    "                f\"sentiment_breakdown scores must sum to 1.0 (got {total:.3f}). \"\n",
+    "                f\"Re-normalize the per-category scores so they total 1.0.\"\n",
+    "            )\n",
+    "        return self\n",
+    "\n",
+    "\n",
+    "REVIEW_TEXT = \"\"\"\n",
+    "The new SoundPod 3 has fantastic battery life — I get a full week on a single\n",
+    "charge — and the noise cancellation is the best I've used at this price. The\n",
+    "ear cups feel a little plasticky and the bundled cable is too short, but those\n",
+    "are small gripes. Sound quality is rich and balanced. I'd give it 4 out of 5.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6d2bdfc",
+   "metadata": {},
+   "source": [
+    "## A plain OpenAI call: works on the happy path\n",
+    "\n",
+    "This is the baseline. With `gpt-4o-mini` and a clear instruction, you'll usually get valid JSON back. But \"usually\" is doing a lot of work — the moment a model adds a markdown fence, an apology, or a sentiment breakdown that sums to 0.97, your downstream code breaks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2fc35e46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def call_openai(messages):\n",
+    "    \"\"\"Tiny adapter: messages in, string out. The shape agentcast expects.\"\"\"\n",
+    "    completion = client.chat.completions.create(\n",
+    "        model=MODEL,\n",
+    "        messages=messages,\n",
+    "        temperature=0.2,\n",
+    "    )\n",
+    "    return completion.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "002026bf",
+   "metadata": {},
+   "source": [
+    "## Use agentcast to validate + retry\n",
+    "\n",
+    "`cast()` calls your LLM, runs `extract_json` on the response (which handles fenced blocks and prose-wrapped JSON), then runs your validator. On failure it appends the error to the message history as feedback and retries up to `max_retries` times. The Pydantic adapter turns a `BaseModel` into the validator shape `cast()` wants."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2fba953f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "\n",
+    "\n",
+    "async def extract_review():\n",
+    "    review = await cast(\n",
+    "        llm=call_openai,\n",
+    "        validate=cast_adapters.pydantic(ProductReview),\n",
+    "        prompt=(\n",
+    "            \"Extract a structured product review from the text below. \"\n",
+    "            \"Include a sentiment_breakdown list with categories like \"\n",
+    "            \"battery, sound_quality, build_quality, value — each with a score \"\n",
+    "            \"in [0, 1]. The scores MUST sum to exactly 1.0.\\n\\n\"\n",
+    "            f\"REVIEW:\\n{REVIEW_TEXT}\"\n",
+    "        ),\n",
+    "        max_retries=2,\n",
+    "    )\n",
+    "    return review\n",
+    "\n",
+    "\n",
+    "review = asyncio.run(extract_review())\n",
+    "print(json.dumps(review, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26316403",
+   "metadata": {},
+   "source": [
+    "## Example 2: see the retry loop fire\n",
+    "\n",
+    "To see the retry behavior end-to-end, swap in a stub LLM that produces a deliberately broken first response and a valid second response. The validation error from attempt 1 is appended to the conversation as feedback before attempt 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da57061b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Build a stub LLM that returns a different response each call.\n",
+    "class FakeLLM:\n",
+    "    def __init__(self, responses):\n",
+    "        self._responses = list(responses)\n",
+    "        self.calls = []\n",
+    "\n",
+    "    def __call__(self, messages):\n",
+    "        self.calls.append(messages)\n",
+    "        return self._responses.pop(0)\n",
+    "\n",
+    "\n",
+    "# First response: scores sum to 0.85 (invalid). Second: corrected.\n",
+    "fake = FakeLLM(\n",
+    "    [\n",
+    "        json.dumps(\n",
+    "            {\n",
+    "                \"product_name\": \"SoundPod 3\",\n",
+    "                \"overall_rating\": 4,\n",
+    "                \"summary\": \"Great battery, plasticky build.\",\n",
+    "                \"sentiment_breakdown\": [\n",
+    "                    {\"label\": \"battery\", \"score\": 0.5},\n",
+    "                    {\"label\": \"sound_quality\", \"score\": 0.25},\n",
+    "                    {\"label\": \"build_quality\", \"score\": 0.10},\n",
+    "                ],\n",
+    "            }\n",
+    "        ),\n",
+    "        json.dumps(\n",
+    "            {\n",
+    "                \"product_name\": \"SoundPod 3\",\n",
+    "                \"overall_rating\": 4,\n",
+    "                \"summary\": \"Great battery, plasticky build.\",\n",
+    "                \"sentiment_breakdown\": [\n",
+    "                    {\"label\": \"battery\", \"score\": 0.45},\n",
+    "                    {\"label\": \"sound_quality\", \"score\": 0.30},\n",
+    "                    {\"label\": \"build_quality\", \"score\": 0.15},\n",
+    "                    {\"label\": \"value\", \"score\": 0.10},\n",
+    "                ],\n",
+    "            }\n",
+    "        ),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "\n",
+    "async def with_retry_visibility():\n",
+    "    return await cast(\n",
+    "        llm=fake,\n",
+    "        validate=cast_adapters.pydantic(ProductReview),\n",
+    "        prompt=\"Extract the structured review.\",\n",
+    "        on_attempt=lambda info: print(\n",
+    "            f\"  attempt {info['attempt']}: error = {info['error'][:80]}...\"\n",
+    "            if info[\"error\"]\n",
+    "            else f\"  attempt {info['attempt']}: ok\"\n",
+    "        ),\n",
+    "        max_retries=2,\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "result = asyncio.run(with_retry_visibility())\n",
+    "print()\n",
+    "print(\"final:\", json.dumps(result, indent=2))\n",
+    "print(f\"\\ntotal LLM calls made: {len(fake.calls)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd9814a7",
+   "metadata": {},
+   "source": [
+    "## Example 3: the failure mode — exhausted retries\n",
+    "\n",
+    "If validation never passes, `cast()` raises `CastError` with the full attempt history attached. You can log it, alert on it, or return a graceful fallback to your user."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e29b1d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "always_broken = FakeLLM(\n",
+    "    [\n",
+    "        '{\"product_name\": \"X\", \"overall_rating\": 99, \"summary\": \"\", \"sentiment_breakdown\": []}',\n",
+    "        '{\"product_name\": \"X\", \"overall_rating\": 99, \"summary\": \"\", \"sentiment_breakdown\": []}',\n",
+    "        '{\"product_name\": \"X\", \"overall_rating\": 99, \"summary\": \"\", \"sentiment_breakdown\": []}',\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "try:\n",
+    "    asyncio.run(\n",
+    "        cast(\n",
+    "            llm=always_broken,\n",
+    "            validate=cast_adapters.pydantic(ProductReview),\n",
+    "            prompt=\"Extract the structured review.\",\n",
+    "            max_retries=2,\n",
+    "        )\n",
+    "    )\n",
+    "except CastError as e:\n",
+    "    print(f\"raised CastError: {e}\")\n",
+    "    print(f\"\\n{len(e.attempts)} attempt(s) recorded\")\n",
+    "    for i, attempt in enumerate(e.attempts, 1):\n",
+    "        print(f\"  attempt {i}: {attempt['error'][:100]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97a9b254",
+   "metadata": {},
+   "source": [
+    "## Example 4: extract_json on its own\n",
+    "\n",
+    "Sometimes you don't need the full retry loop — just \"pull JSON out of this LLM string, ignore the prose around it.\" `extract_json` handles fenced ` ```json ... ``` ` blocks, language-less fences, top-level arrays, inline JSON in prose, and refusals (returns `None`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f2bf3a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "samples = [\n",
+    "    '{\"answer\": 42}',\n",
+    "    'Sure! Here is the answer:\\n\\n```json\\n{\"name\": \"Widget\", \"price\": 29.99}\\n```\\n\\nLet me know if you need anything else.',\n",
+    "    \"I'm sorry, I cannot answer that.\",\n",
+    "    'The result is { \"valid\": true, \"score\": 0.87 }. Please verify.',\n",
+    "    '[{\"k\": 1}, {\"k\": 2}]',\n",
+    "]\n",
+    "\n",
+    "for s in samples:\n",
+    "    extracted = extract_json(s)\n",
+    "    print(f\"{s[:50]!r:55}  ->  {extracted}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38e7ade5",
+   "metadata": {},
+   "source": [
+    "## When to use this vs. native Structured Outputs\n",
+    "\n",
+    "| Situation | Recommendation |\n",
+    "|---|---|\n",
+    "| Latest OpenAI model + plain JSON shape | **Native Structured Outputs** — strict mode is simpler and avoids the retry round-trip. |\n",
+    "| You need validation rules JSON Schema can't express | `agentcast` with a Pydantic `model_validator` (Example 1 above). |\n",
+    "| You're calling an older model, a fine-tune, or a non-OpenAI provider that doesn't support strict mode | `agentcast` — works against any `messages -> string` callable. |\n",
+    "| You want one validation layer that's portable across providers | `agentcast` — same code regardless of which LLM is behind `llm=`. |\n",
+    "\n",
+    "The two compose well. Use native Structured Outputs for the JSON shape, then wrap the call in `cast()` with a validator that only checks your business invariants. The model gets schema enforcement for free, and your code gets clean retries when the invariant fails.\n",
+    "\n",
+    "## Further reading\n",
+    "\n",
+    "- [`agentcast` source + docs](https://github.com/MukundaKatta/AgentCastPy)\n",
+    "- [The agent reliability stack](https://mukundakatta.github.io/agent-stack/) — `agentcast` is one of five small libraries (fit, guard, snap, vet, cast) that fix the boring parts of long-running agents.\n",
+    "- [Companion dataset](https://huggingface.co/datasets/mukunda1729/llm-output-extraction-cases) — 20 messy LLM outputs with expected JSON, useful for testing your own extractor against."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/registry.yaml
+++ b/registry.yaml
@@ -3182,7 +3182,7 @@
 - title: ChatGPT Enterprise Prompting Guide
   path: examples/chatgpt/chatgpt_prompt_guide/chatgpt_prompt_guide.md
   slug: chatgpt_prompt_engineering
-  description: Cookbook for writing better prompts for everyday work in ChatGPT Enterprise.  
+  description: Cookbook for writing better prompts for everyday work in ChatGPT Enterprise.
   date: 2026-04-27
   authors:
     - sophiaqin-openai
@@ -3190,3 +3190,20 @@
   tags:
     - chatgpt
     - prompt-engineering
+
+- title: Structured outputs with validate-and-retry using agentcast
+  path: examples/Structured_outputs_with_validate_and_retry_using_agentcast.ipynb
+  slug: structured-outputs-with-validate-and-retry-using-agentcast
+  description: Use agentcast to wrap any LLM call with validate-and-retry. Useful when
+    JSON Schema can't express your invariant (e.g. category scores must sum to 1.0),
+    when calling models that don't support strict mode, or when you want one validation
+    layer that's portable across providers. Includes a Pydantic example with a custom
+    model_validator and a stub LLM that demonstrates the retry loop end-to-end.
+  date: 2026-04-27
+  authors:
+    - MukundaKatta
+  tags:
+    - structured-outputs
+    - pydantic
+    - validation
+    - agents


### PR DESCRIPTION
## Summary

Adds an `examples/` notebook showing how to use [`agentcast`](https://pypi.org/project/agentcast-py/) as a portable validate-and-retry layer alongside the OpenAI Python SDK.

Native Structured Outputs is the right answer when you can use it. This notebook covers the cases where it's not enough on its own:

1. **Validation rules JSON Schema can't express** (e.g. "category scores must sum to 1.0"). Demoed with a Pydantic `model_validator`.
2. **Models or providers that don't support strict mode** (older OpenAI models, fine-tunes, third-party endpoints behind the OpenAI-compatible API, local models).
3. **A single validation layer that's portable across providers** — same code, swap the `llm=` callable.

`agentcast` is MIT, pure Python, zero runtime deps.

## Notebook walkthrough

1. Define a Pydantic `ProductReview` model with a custom invariant.
2. Run end-to-end against the real OpenAI API.
3. Use a stub LLM to demo the retry loop without burning tokens (deliberately broken first response → corrected second response).
4. Show the exhausted-retries failure mode (`CastError` + full `attempts` history).
5. Use `extract_json` on its own for cases that just need JSON extraction without the full loop.

## Files

- New: `examples/Structured_outputs_with_validate_and_retry_using_agentcast.ipynb`
- `registry.yaml`: new entry tagged `structured-outputs`, `pydantic`, `validation`, `agents`, dated 2026-04-27
- `authors.yaml`: add `MukundaKatta`

## Test plan

- [x] `ruff check + format` clean on the notebook
- [x] All non-LLM cells smoke-tested locally against `agentcast-py>=0.1.0`
- [x] No secrets in notebook; uses `dotenv.load_dotenv()` + `OpenAI()` default env reading
- [x] Execution counts cleared per AGENTS.md
