### PR TITLE
docs(contributing): fix typo in heading

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing the the cookbook
+# Contributing to the cookbook
 
 The OpenAI Cookbook is a collection of useful patterns and examples of working with the OpenAI platform, provided as a community resource.
 


### PR DESCRIPTION
## Summary
- The H1 of `CONTRIBUTING.md` read "Contributing the the cookbook" — duplicate "the" with a missing preposition.
- Changed to "Contributing to the cookbook".

## Test plan
- [x] Heading renders correctly when previewed as Markdown.
- [x] No other occurrences of the same typo elsewhere in the repo (`grep -r "the the cookbook"` returns no matches).