### PR TITLE
refactor(gpt-5): remove duplicate pydantic imports in apply_patch.py

### DIFF
--- a/examples/gpt-5/apply_patch.py
+++ b/examples/gpt-5/apply_patch.py
@@ -48,9 +48,6 @@ def assemble_changes(orig: dict[str, Optional[str]], dest: dict[str, Optional[st
     return commit
 
 
-from pydantic import BaseModel, Field
-
-
 class Chunk(BaseModel):
     orig_index: int = -1  # line index of the first line in the original file
     del_lines: list[str] = Field(default_factory=list)

--- a/examples/gpt-5/apply_patch.py
+++ b/examples/gpt-5/apply_patch.py
@@ -65,9 +65,6 @@ class Patch(BaseModel):
     actions: dict[str, PatchAction] = Field(default_factory=dict)
 
 
-from pydantic import BaseModel, Field
-
-
 class Parser(BaseModel):
     current_files: dict[str, str] = Field(default_factory=dict)
     lines: list[str] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
`examples/gpt-5/apply_patch.py` re-imports `from pydantic import BaseModel, Field` two extra times (before `class Chunk` and before `class Parser`), in addition to the original import at the top of the file. Python silently accepts the duplicates, but they add noise and look like an artifact of stitching multiple code blocks into one module. This PR removes the two redundant imports.

## Changes
- Remove duplicate `from pydantic import BaseModel, Field` before `class Chunk`
- Remove duplicate `from pydantic import BaseModel, Field` before `class Parser`

Net change: −6 lines, no behavioural impact. PEP 8 two-blank-line spacing between top-level definitions is preserved.

## Test plan
- [x] `python -c "import ast; ast.parse(open('examples/gpt-5/apply_patch.py').read())"` parses cleanly.
- [x] All `BaseModel` / `Field` references in the file are still satisfied by the line-4 import.
- [x] No other files import from `apply_patch.py` in a way affected by the removed lines (`grep -r "from .* import .*apply_patch"` confirms).