### PR TITLE
docs(imagegen-evals): clarify required-assets path

### DIFF
--- a/examples/evals/imagegen_evals/README.md
+++ b/examples/evals/imagegen_evals/README.md
@@ -47,7 +47,8 @@ Editing cases:
 
 ## Required assets (editing harness)
 
-The editing harness expects these files in `images/`:
+The editing harness reads required assets from the repository's top-level
+`images/` directory (resolved relative to the repo root, not this folder):
 
 - `images/base_woman.png`
 - `images/jacket.png`


### PR DESCRIPTION
## Summary
The "Required assets (editing harness)" section of `examples/evals/imagegen_evals/README.md` reads:

> The editing harness expects these files in `images/`:

This phrasing reads as a folder **inside** `examples/evals/imagegen_evals/`, but the harness script actually resolves the location relative to the repository root:

https://github.com/openai/openai-cookbook/blob/main/examples/evals/imagegen_evals/editing_harness/run_imagegen_evals.py#L255-L260

```python
repo_root = ROOT_DIR.parents[2]
images_dir = repo_root / "images"

vto_person_path = images_dir / "base_woman.png"
vto_garment_path = images_dir / "jacket.png"
logo_input_path = images_dir / "logo_generation_1.png"
```

The required PNGs already live at the repo's top-level `images/` directory, so the harness works correctly — but a reader of the README is steered to the wrong place. This PR updates the wording to make the location explicit.

## Changes
- `examples/evals/imagegen_evals/README.md`: rewrite the assets-location sentence to clarify that `images/` is the repository's top-level directory, not a folder inside `imagegen_evals/`.

## Test plan
- [x] `git grep "expects these files in" examples/evals/imagegen_evals` confirms only the one occurrence was updated.
- [x] No code changes; harness behaviour unchanged.