### PR TITLE
docs: fix typos across example notebooks

### DIFF
--- a/examples/Leveraging_model_distillation_to_fine-tune_a_model.ipynb
+++ b/examples/Leveraging_model_distillation_to_fine-tune_a_model.ipynb
@@ -67,7 +67,7 @@
     "\n",
     "We're looking at a classification problem where we'd like to guess the grape variety based on all other criterias available, including description, subregion and province that we'll include in the prompt. It gives a lot of information to the model, you're free to also remove some information that can help significantly the model such as the region in which it was produced to see if it does a good job at finding the grape.\n",
     "\n",
-    "Let's filter the grape varieties that have less than 5 occurences in reviews.\n",
+    "Let's filter the grape varieties that have less than 5 occurrences in reviews.\n",
     "\n",
     "Let's proceed with a subset of 500 random rows from this dataset."
    ]

--- a/examples/Named_Entity_Recognition_to_enrich_text.ipynb
+++ b/examples/Named_Entity_Recognition_to_enrich_text.ipynb
@@ -79,7 +79,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook works with the latest OpeanAI models `gpt-3.5-turbo-0613` and `gpt-4-0613`."
+    "This notebook works with the latest OpenAI models `gpt-3.5-turbo-0613` and `gpt-4-0613`."
    ]
   },
   {

--- a/examples/Question_answering_using_embeddings.ipynb
+++ b/examples/Question_answering_using_embeddings.ipynb
@@ -215,7 +215,7 @@
    "id": "1af18d66-d47a-496d-ae5f-4c5d53caa434",
    "metadata": {},
    "source": [
-    "In this case, the model has no knowledge of 2024 and is unable to answer the question. In a similar way, if you ask a question pertaining to a recent political event (that occured in Nov 2024 for example), GPT-4o-mini models will not be able to answer due to its knowledge cut-off date of Oct 2023. "
+    "In this case, the model has no knowledge of 2024 and is unable to answer the question. In a similar way, if you ask a question pertaining to a recent political event (that occurred in Nov 2024 for example), GPT-4o-mini models will not be able to answer due to its knowledge cut-off date of Oct 2023. "
    ]
   },
   {

--- a/examples/agents_sdk/app_assistant_voice_agents.ipynb
+++ b/examples/agents_sdk/app_assistant_voice_agents.ipynb
@@ -22,7 +22,7 @@
     "- **Knowledge Agent** - utilises the file search tooling of the Responses API to retrieve information from an OpenAI managed vector database\n",
     "- **Account Agent** - uses function calling to provide the ability to trigger custom actions via API\n",
     "\n",
-    "Finally, we'll convert this workflow into a live voice assistant using the AgentsSDK's Voice funtionality, capturing microphone input, performing speech‑to‑text, routing through our agents, and responding with text‑to‑speech."
+    "Finally, we'll convert this workflow into a live voice assistant using the AgentsSDK's Voice functionality, capturing microphone input, performing speech‑to‑text, routing through our agents, and responding with text‑to‑speech."
    ]
   },
   {

--- a/examples/chatgpt/gpt_actions_library/gpt_action_googleads_adzviser.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_googleads_adzviser.ipynb
@@ -549,7 +549,7 @@
         "          },\n",
         "          \"date_ranges\": {\n",
         "            \"type\": \"array\",\n",
-        "            \"description\": \"A list of date ranges requested from the user. They needs to be calculated seperately with Code Interpreter and Python every single time for accuracy. For example, if the user requests \\\"Google Ads search impression share in May and August\\\", then this array should be [[\\\"2024-05-01\\\", \\\"2024-05-31\\\"], [\\\"2024-08-01\\\", \\\"2024-08-31\\\"]].\",\n",
+        "            \"description\": \"A list of date ranges requested from the user. They need to be calculated separately with Code Interpreter and Python every single time for accuracy. For example, if the user requests \\\"Google Ads search impression share in May and August\\\", then this array should be [[\\\"2024-05-01\\\", \\\"2024-05-31\\\"], [\\\"2024-08-01\\\", \\\"2024-08-31\\\"]].\",\n",
         "            \"items\": {\n",
         "              \"type\": \"array\",\n",
         "              \"items\": {\n",

--- a/examples/evaluation/Evaluate_RAG_with_LlamaIndex.ipynb
+++ b/examples/evaluation/Evaluate_RAG_with_LlamaIndex.ipynb
@@ -645,7 +645,7 @@
       "source": [
         "We will use `gpt-3.5-turbo` for generating response for a given query and `gpt-4` for evaluation.\n",
         "\n",
-        "Let's create service_context seperately for `gpt-3.5-turbo` and `gpt-4`."
+        "Let's create service_context separately for `gpt-3.5-turbo` and `gpt-4`."
       ]
     },
     {

--- a/examples/multimodal/Vision_Fine_tuning_on_GPT4o_for_Visual_Question_Answering.ipynb
+++ b/examples/multimodal/Vision_Fine_tuning_on_GPT4o_for_Visual_Question_Answering.ipynb
@@ -1046,7 +1046,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "# seperate by question type\n",
+    "# separate by question type\n",
     "def get_question_type(question):\n",
     "    if question in [\"What is the title of this book?\"]:\n",
     "        return \"Title\"\n",

--- a/examples/object_oriented_agentic_approach/Secure_code_interpreter_tool_for_LLM_agents.ipynb
+++ b/examples/object_oriented_agentic_approach/Secure_code_interpreter_tool_for_LLM_agents.ipynb
@@ -254,7 +254,7 @@
     "- Uses gpt-4o model.\n",
     "\n",
     "2.\t**Agent 2: Python Code Generator and Executor (with Dynamically Generated Tool Calling and Code Execution)**\n",
-    "- Recieve the file content's context from Agent 1.\n",
+    "- Receive the file content's context from Agent 1.\n",
     "- Instructions to generate a Python script to answer the user's question.\n",
     "- Has access to the code interpreter within the Docker container, which is used to execute Python code.\n",
     "- Has access only to the file system inside the Docker container (not the host).\n",


### PR DESCRIPTION
## Summary

Fix small spelling and grammar typos in markdown cells, code comments, and one tool description string across eight example notebooks.

## Affected files (one word per file)

| File | Fix |
|---|---|
| `examples/Named_Entity_Recognition_to_enrich_text.ipynb` | `OpeanAI` → `OpenAI` (markdown) |
| `examples/agents_sdk/app_assistant_voice_agents.ipynb` | `funtionality` → `functionality` (markdown) |
| `examples/object_oriented_agentic_approach/Secure_code_interpreter_tool_for_LLM_agents.ipynb` | `Recieve` → `Receive` (markdown) |
| `examples/Question_answering_using_embeddings.ipynb` | `occured` → `occurred` (markdown) |
| `examples/Leveraging_model_distillation_to_fine-tune_a_model.ipynb` | `occurences` → `occurrences` (markdown) |
| `examples/evaluation/Evaluate_RAG_with_LlamaIndex.ipynb` | `seperately` → `separately` (markdown) |
| `examples/multimodal/Vision_Fine_tuning_on_GPT4o_for_Visual_Question_Answering.ipynb` | `seperate` → `separate` (Python comment) |
| `examples/chatgpt/gpt_actions_library/gpt_action_googleads_adzviser.ipynb` | `They needs to be calculated seperately` → `They need to be calculated separately` (tool description string; also fixes subject-verb agreement) |

## Motivation

`AGENTS.md` lists "typos, broken links, and inconsistent formatting" as priority-0 review items. These are small but visible issues in published cookbook pages.

## Checklist

- [x] No code or output cells changed
- [x] All eight notebooks remain valid JSON
- [x] `python .github/scripts/check_notebooks.py` passes locally for all changed notebooks
- [x] No `registry.yaml` or `authors.yaml` changes needed
- [x] Self-review complete