### PR TITLE
[codex] add goals in codex cookbook

### DIFF
--- a/authors.yaml
+++ b/authors.yaml
@@ -236,7 +236,7 @@ aaronwilkowitz-openai:
 stefanofabbri-oai:
   name: "Stefano Fabbri"
   website: "https://www.linkedin.com/in/stefano-fabbri-633a1895/"
-  avatar: "https://static.licdn.com/aero-v1/sc/h/bgaqk7x4ntjz0wg67d8u723eb"
+  avatar: "https://media.licdn.com/dms/image/v2/C5603AQGekzEY9dhxXA/profile-displayphoto-shrink_400_400/profile-displayphoto-shrink_400_400/0/1639500546853?e=1779926400&v=beta&t=siVg-MLpr70UfpUYhcEg86sxqcKSOU-jC7V4iT4FtK0"
 
 charuj:
   name: "Charu Jaiswal"

--- a/authors.yaml
+++ b/authors.yaml
@@ -233,6 +233,11 @@ aaronwilkowitz-openai:
   website: "https://www.linkedin.com/in/aaronwilkowitz/"
   avatar: "https://avatars.githubusercontent.com/u/157151487"
 
+stefanofabbri-oai:
+  name: "Stefano Fabbri"
+  website: "https://www.linkedin.com/in/stefano-fabbri-633a1895/"
+  avatar: "https://static.licdn.com/aero-v1/sc/h/bgaqk7x4ntjz0wg67d8u723eb"
+
 charuj:
   name: "Charu Jaiswal"
   website: "https://www.linkedin.com/in/charu-j-8a866471"

--- a/registry.yaml
+++ b/registry.yaml
@@ -19,6 +19,19 @@
     - structured-outputs
     - evals
 
+- title: Using Goals in Codex
+  path: examples/codex/using_goals_in_codex.ipynb
+  slug: using-goals-in-codex
+  description: Use Goals in Codex to keep long-running work moving toward a persistent, evidence-checked outcome across turns.
+  date: 2026-05-09
+  authors:
+    - rajpathak-openai
+    - stefanofabbri-oai
+  tags:
+    - codex
+    - agents
+    - planning
+
 - title: Building workspace agents in ChatGPT to complete repeatable, end-to-end work
   path: articles/chatgpt-agents-sales-meeting-prep.md
   slug: chatgpt-agents-sales-meeting-prep

--- a/registry.yaml
+++ b/registry.yaml
@@ -29,6 +29,7 @@
     - stefanofabbri-oai
   tags:
     - codex
+    - goals
     - agents
     - planning
 


### PR DESCRIPTION
## Summary

Add a new Codex cookbook on using Goals for long-running work, including:
- a new notebook under `examples/codex/`
- registry metadata so the cookbook renders on the website
- author metadata for Stefano Fabbri

## Motivation

Goals are a new Codex workflow for persistent, evidence-checked objectives. This cookbook gives users a practical guide to when Goals help, how to write high-quality Goals, and how to apply them to both engineering and research work.

## Validation

- validated the notebook with `nbformat`
- rendered the notebook to HTML with `jupyter nbconvert`
- parsed `registry.yaml` and `authors.yaml` and verified the referenced author slugs exist

## For new content

- [x] I have added a new entry in `registry.yaml` (and, optionally, in `authors.yaml`) so that my content renders on the cookbook website.
- [x] I have conducted a self-review of my content based on the contribution guidelines.
