### PR TITLE
Update agent improvement loop publication date

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -3248,7 +3248,7 @@
   path: examples/agents_sdk/agent_improvement_loop.ipynb
   slug: agent-improvement-loop
   description: Build a trace-driven improvement loop that turns human and model feedback into Promptfoo evals, HALO-ranked harness changes, and a Codex handoff.
-  date: 2026-05-01
+  date: 2026-05-12
   authors:
     - PASFIELD-OAI
   tags:


### PR DESCRIPTION
## Summary

Updates the registry date for **Build an Agent Improvement Loop with Traces, Evals, and Codex** from `2026-05-01` to `2026-05-12` so the published Cookbook page reflects the intended publication date.

## What changed

- Updated the `registry.yaml` `date` field for `agent-improvement-loop` to `2026-05-12`

## How to test

- Confirm `registry.yaml` contains `date: 2026-05-12` for the `agent-improvement-loop` entry
- After site refresh, verify the page header updates on:
  - https://developers.openai.com/cookbook/examples/agents_sdk/agent_improvement_loop
