### PR TITLE
Add alfozan to authors.yaml (referenced by #2658)

### DIFF
--- a/authors.yaml
+++ b/authors.yaml
@@ -612,3 +612,8 @@ anshgupta-oai:
   name: "Ansh Gupta"
   website: "https://github.com/anshgupta-oai"
   avatar: "https://avatars.githubusercontent.com/u/269039830?v=4"
+
+alfozan:
+  name: "Abdulrahman Alfozan"
+  website: "https://github.com/alfozan"
+  avatar: "https://avatars.githubusercontent.com/u/979984?v=4"

--- a/authors.yaml
+++ b/authors.yaml
@@ -642,3 +642,8 @@ deepakjain108:
   name: "Deepak Jain"
   website: "https://github.com/deepakjain108"
   avatar: "https://avatars.githubusercontent.com/u/301830121?v=4"
+
+alfozan:
+  name: "Abdulrahman Alfozan"
+  website: "https://github.com/alfozan"
+  avatar: "https://avatars.githubusercontent.com/u/979984?v=4"


### PR DESCRIPTION
﻿Adds a missing entry to authors.yaml for `alfozan`, who is registered as an author in registry.yaml (introduced in #2658, 'Agents SDK: Add deployment manager example') but has no corresponding profile in authors.yaml.

Without this entry the cookbook website cannot render Abdulrahman's byline / avatar on the deployment manager example page.

Profile data sourced from the public GitHub API for the `alfozan` user. Validated against `.github/authors_schema.json`.

While auditing this I noticed there are ~60 other slugs referenced in registry.yaml that are not defined in authors.yaml (most are full-name slugs for partner authors; a handful are GitHub logins like this one). Happy to do follow-up PRs for the GitHub-login gaps if maintainers prefer one-author-per-PR cadence — leaving this PR scoped to the most recent gap so it is easy to review.