### PR TITLE
Add maxreid-openai to authors.yaml (5 referenced pages)

### DIFF
--- a/authors.yaml
+++ b/authors.yaml
@@ -612,3 +612,8 @@ anshgupta-oai:
   name: "Ansh Gupta"
   website: "https://github.com/anshgupta-oai"
   avatar: "https://avatars.githubusercontent.com/u/269039830?v=4"
+
+maxreid-openai:
+  name: "Max Reid"
+  website: "https://github.com/maxreid-openai"
+  avatar: "https://avatars.githubusercontent.com/u/164893837?v=4"

--- a/authors.yaml
+++ b/authors.yaml
@@ -642,3 +642,8 @@ deepakjain108:
   name: "Deepak Jain"
   website: "https://github.com/deepakjain108"
   avatar: "https://avatars.githubusercontent.com/u/301830121?v=4"
+
+maxreid-openai:
+  name: "Max Reid"
+  website: "https://github.com/maxreid-openai"
+  avatar: "https://avatars.githubusercontent.com/u/164893837?v=4"


### PR DESCRIPTION
Adds a missing entry to `authors.yaml` for `maxreid-openai`, which is referenced by 5 cookbook pages in `registry.yaml` but has no corresponding profile defined.

References (oldest to newest):

- `examples/chatgpt/gpt_actions_library/gpt_action_sharepoint_doc.ipynb` (2024-05-24)
- `examples/chatgpt/gpt_actions_library/gpt_action_sharepoint_text.ipynb` (2024-05-24)
- `examples/chatgpt/gpt_actions_library/gpt_middleware_azure_function.ipynb` (2024-05-24)
- `examples/chatgpt/rag-quickstart/azure/Azure_AI_Search_with_Azure_Functions_and_GPT_Actions_in_ChatGPT.ipynb` (2024-07-08)
- `examples/chatgpt/rag-quickstart/gcp/Getting_started_with_bigquery_vector_search_and_openai.ipynb` (2024-08-02)

Profile data sourced from the public GitHub API for the `maxreid-openai` user (Max Reid). Validated against `.github/authors_schema.json`.

Same pattern as #2702 (the `alfozan` fix). I'm scoping each PR to a single author so each one is trivially reviewable. Happy to bundle the remaining GitHub-login-shaped slugs (`atroyn`, `ankrgyl`, `kristapratico`, `logankilpatrick`, `ash0ts`, etc.) into one combined PR instead if that's preferred — let me know.
