### PR TITLE
fix: guard against IndexError on empty choices list in agent fixture clients

### DIFF
--- a/examples/agents_sdk/sandboxed-code-migration/repo_fixtures/case_summary_service/case_summary_service/client.py
+++ b/examples/agents_sdk/sandboxed-code-migration/repo_fixtures/case_summary_service/case_summary_service/client.py
@@ -14,4 +14,6 @@ def complete_summary_prompt(
         messages=messages,
         temperature=0,
     )
+    if not completion.choices:
+        raise ValueError("No choices returned from the API")
     return completion.choices[0].message.content

--- a/examples/agents_sdk/sandboxed-code-migration/repo_fixtures/support_reply_service/customer_support_bot/client.py
+++ b/examples/agents_sdk/sandboxed-code-migration/repo_fixtures/support_reply_service/customer_support_bot/client.py
@@ -14,4 +14,6 @@ def complete_support_prompt(
         messages=messages,
         temperature=0,
     )
+    if not completion.choices:
+        raise ValueError("No choices returned from the API")
     return completion.choices[0].message.content


### PR DESCRIPTION
## Problem

Two `client.py` helper files in the sandboxed-code-migration fixtures return `completion.choices[0].message.content` without checking whether the API returned any choices. A bare `IndexError` is raised when:

- the LLM applies a **content-policy filter** and returns `choices=[]`
- a **token limit** is hit before the first choice is generated  
- the API returns a non-standard error body

Since both functions are typed `-> str`, the fix raises `ValueError` with a clear message so callers know to handle the no-choices case explicitly, rather than getting an opaque `IndexError`.

## Files changed

| File | Line | Fix |
|------|------|-----|
| `case_summary_service/case_summary_service/client.py` | 17 | raise `ValueError` when `completion.choices` is empty |
| `support_reply_service/customer_support_bot/client.py` | 17 | same |

Minimal diff — no logic change on the happy path.

---
*Found by [pact](https://github.com/qizwiz/pact) static analysis — `llm_response_unguarded` mode.*