### PR TITLE
docs: add missing `https://` scheme to bare-domain markdown links

### DIFF
--- a/examples/evaluation/Getting_Started_with_OpenAI_Evals.ipynb
+++ b/examples/evaluation/Getting_Started_with_OpenAI_Evals.ipynb
@@ -359,7 +359,7 @@
    "source": [
     "## Running an evaluation\n",
     "\n",
-    "We can run this eval using the `oaieval` CLI. To get setup, install the library: `pip install .` (if you are running the [OpenAI Evals library](github.com/openai/evals) locally) or `pip install oaieval` if you are running an existing eval.\n",
+    "We can run this eval using the `oaieval` CLI. To get setup, install the library: `pip install .` (if you are running the [OpenAI Evals library](https://github.com/openai/evals) locally) or `pip install oaieval` if you are running an existing eval.\n",
     "\n",
     "Then, run the eval using the CLI: `oaieval gpt-3.5-turbo spider-sql`\n",
     "\n",

--- a/examples/fine-tuned_qa/ft_retrieval_augmented_generation_qdrant.ipynb
+++ b/examples/fine-tuned_qa/ft_retrieval_augmented_generation_qdrant.ipynb
@@ -538,7 +538,7 @@
     "\n",
     "### 4.2 Fine-Tune OpenAI Model\n",
     "\n",
-    "If you're new to OpenAI Model Fine-Tuning, please refer to the [How to finetune Chat models](https://github.com/openai/openai-cookbook/blob/448a0595b84ced3bebc9a1568b625e748f9c1d60/examples/How_to_finetune_chat_models.ipynb) notebook. You can also refer to the [OpenAI Fine-Tuning Docs](platform.openai.com/docs/guides/fine-tuning/use-a-fine-tuned-model) for more details."
+    "If you're new to OpenAI Model Fine-Tuning, please refer to the [How to finetune Chat models](https://github.com/openai/openai-cookbook/blob/448a0595b84ced3bebc9a1568b625e748f9c1d60/examples/How_to_finetune_chat_models.ipynb) notebook. You can also refer to the [OpenAI Fine-Tuning Docs](https://platform.openai.com/docs/guides/fine-tuning/use-a-fine-tuned-model) for more details."
    ]
   },
   {

--- a/examples/partners/self_evolving_agents/autonomous_agent_retraining.ipynb
+++ b/examples/partners/self_evolving_agents/autonomous_agent_retraining.ipynb
@@ -1874,7 +1874,7 @@
    "source": [
     "## Contributors\n",
     "\n",
-    "This cookbook is based on a joint collaboration between [Bain](www.bain.com) and [OpenAI](openai.com). \n",
+    "This cookbook is based on a joint collaboration between [Bain](https://www.bain.com) and [OpenAI](https://openai.com). \n",
     "\n",
     "[Calvin Maguranis](https://www.linkedin.com/in/calvin-maguranis-b9956045/)  \n",
     "[Fanny Perraudeau](https://www.linkedin.com/in/fanny-sabran-perraudeau-494b7573/)   \n",


### PR DESCRIPTION
## Summary

Three notebooks contain markdown links written as `[text](www.example.com)` or `[text](github.com/...)` instead of `[text](https://...)`. Without a scheme, GitHub and Jupyter renderers treat the URL as a relative path and the link 404s.

Fixed (markdown cells only — output cells untouched):

| File | Before | After |
|---|---|---|
| `examples/fine-tuned_qa/ft_retrieval_augmented_generation_qdrant.ipynb` | `[OpenAI Fine-Tuning Docs](platform.openai.com/docs/guides/fine-tuning/use-a-fine-tuned-model)` | `[…](https://platform.openai.com/…)` |
| `examples/partners/self_evolving_agents/autonomous_agent_retraining.ipynb` | `[Bain](www.bain.com)`, `[OpenAI](openai.com)` | `[…](https://www.bain.com)`, `[…](https://openai.com)` |
| `examples/evaluation/Getting_Started_with_OpenAI_Evals.ipynb` | `[OpenAI Evals library](github.com/openai/evals)` | `[…](https://github.com/openai/evals)` |

Diff is exactly **3 lines changed** total. No code cells, no execution output cells, no notebook metadata.

## Verification

- Each notebook still parses as JSON (`json.loads` succeeds).
- Diff confined to the three markdown cells listed above.
- Other markdown links in these notebooks already use `https://` and were left alone.