### PR TITLE
docs: fix embeddings notebook typo

### DIFF
--- a/examples/Question_answering_using_embeddings.ipynb
+++ b/examples/Question_answering_using_embeddings.ipynb
@@ -215,7 +215,7 @@
    "id": "1af18d66-d47a-496d-ae5f-4c5d53caa434",
    "metadata": {},
    "source": [
-    "In this case, the model has no knowledge of 2024 and is unable to answer the question. In a similar way, if you ask a question pertaining to a recent political event (that occured in Nov 2024 for example), GPT-4o-mini models will not be able to answer due to its knowledge cut-off date of Oct 2023. "
+    "In this case, the model has no knowledge of 2024 and is unable to answer the question. In a similar way, if you ask a question pertaining to a recent political event (that occurred in Nov 2024 for example), GPT-4o-mini models will not be able to answer due to its knowledge cut-off date of Oct 2023. "
    ]
   },
   {


### PR DESCRIPTION
## Summary\n- Fix a misspelled word in the embeddings question-answering notebook prose: occured -> occurred.\n\n## Validation\n- Confirmed no open PR surfaced for the exact notebook typo search.\n- Parsed examples/Question_answering_using_embeddings.ipynb as JSON with python3 -m json.tool.\n- Targeted content assertion confirmed 'that occured in Nov 2024' is absent and 'that occurred in Nov 2024' is present.\n- git diff --check passed.