### PR TITLE
fix(apply_patch): remove debug print and move imports to file top

### DIFF
--- a/examples/gpt-5/apply_patch.py
+++ b/examples/gpt-5/apply_patch.py
@@ -1,5 +1,6 @@
+import os
 from enum import Enum
-from typing import Optional
+from typing import Callable, Optional
 
 from pydantic import BaseModel, Field
 
@@ -221,7 +222,6 @@ class Parser(BaseModel):
 
 def find_context_core(lines: list[str], context: list[str], start: int) -> tuple[int, int]:
     if not context:
-        print("context is empty")
         return start, 0
 
     # Prefer identical
@@ -407,10 +407,6 @@ def patch_to_commit(patch: Patch, orig: dict[str, str]) -> Commit:
 
 class DiffError(ValueError):
     pass
-
-
-import os
-from typing import Callable
 
 
 def load_files(paths: list[str], open_fn: Callable) -> dict[str, str]:


### PR DESCRIPTION
## Summary

Two cleanup fixes in `examples/gpt-5/apply_patch.py`:

### 1. Remove leaked debug `print()`

`find_context_core` (line ~224) had `print("context is empty")` left over from development. This statement fires on every call where `context=[]` — a valid edge case that occurs when a patch section has no surrounding context lines — and writes noise to stdout in any script that imports this module.

**Before:**
```python
def find_context_core(lines, context, start):
    if not context:
        print("context is empty")
        return start, 0
```

**After:**
```python
def find_context_core(lines, context, start):
    if not context:
        return start, 0
```

### 2. Move mid-file imports to the top-of-file import block

`import os` and `from typing import Callable` appeared after all class definitions (~line 412), violating [PEP 8 E402](https://peps.python.org/pep-0008/#imports). Moving them to the top of the file with the other stdlib/typing imports fixes static analysis warnings and improves readability. No behavior changes.

## Testing

The `apply_patch.py` module has no dedicated test suite, but the changes are mechanical: a print statement removal and an import hoist. Both `os` and `Callable` are still imported at module load time.