### PR TITLE
examples(SingleStoreDB): migrate notebook to openai>=1.0 client API

### DIFF
--- a/examples/vector_databases/SingleStoreDB/OpenAI_wikipedia_semantic_search.ipynb
+++ b/examples/vector_databases/SingleStoreDB/OpenAI_wikipedia_semantic_search.ipynb
@@ -70,7 +70,7 @@
     }
    ],
    "source": [
-    "client = OpenAI(api_key='OPENAI API KEY')\n\nresponse = client.chat.completions.create(\n  model=GPT_MODEL,\n  messages=[\n        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n        {\"role\": \"user\", \"content\": \"Who won the gold medal for curling in Olymics 2022?\"},\n    ]\n)\n\nprint(response.choices[0].message.content)\n"
+    "# Uses OPENAI_API_KEY from your environment.\nclient = OpenAI()\n\nresponse = client.chat.completions.create(\n  model=GPT_MODEL,\n  messages=[\n        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n        {\"role\": \"user\", \"content\": \"Who won the gold medal for curling in Olymics 2022?\"},\n    ]\n)\n\nprint(response.choices[0].message.content)\n"
    ]
   },
   {
@@ -452,7 +452,7 @@
       "(\"There were three curling events at the 2022 Winter Olympics: men's, women's, \"\n",
       " 'and mixed doubles. The gold medalists for each event are:\\n'\n",
       " '\\n'\n",
-      " \"- Men's: Sweden (Niklas Edin, Oskar Eriksson, Rasmus Wran\u00e5, Christoffer \"\n",
+      " \"- Men's: Sweden (Niklas Edin, Oskar Eriksson, Rasmus Wranå, Christoffer \"\n",
       " 'Sundgren, Daniel Magnusson)\\n'\n",
       " \"- Women's: Great Britain (Eve Muirhead, Vicky Wright, Jennifer Dodds, Hailey \"\n",
       " 'Duff, Mili Smith)\\n'\n",

--- a/examples/vector_databases/SingleStoreDB/OpenAI_wikipedia_semantic_search.ipynb
+++ b/examples/vector_databases/SingleStoreDB/OpenAI_wikipedia_semantic_search.ipynb
@@ -44,10 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import openai\n",
-    "\n",
-    "EMBEDDING_MODEL = \"text-embedding-3-small\"\n",
-    "GPT_MODEL = \"gpt-3.5-turbo\"\n"
+    "from openai import OpenAI\n\nEMBEDDING_MODEL = \"text-embedding-3-small\"\nGPT_MODEL = \"gpt-3.5-turbo\"\n"
    ]
   },
   {
@@ -73,17 +70,7 @@
     }
    ],
    "source": [
-    "openai.api_key = 'OPENAI API KEY'\n",
-    "\n",
-    "response = openai.ChatCompletion.create(\n",
-    "  model=GPT_MODEL,\n",
-    "  messages=[\n",
-    "        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n",
-    "        {\"role\": \"user\", \"content\": \"Who won the gold medal for curling in Olymics 2022?\"},\n",
-    "    ]\n",
-    ")\n",
-    "\n",
-    "print(response['choices'][0]['message']['content'])\n"
+    "client = OpenAI(api_key='OPENAI API KEY')\n\nresponse = client.chat.completions.create(\n  model=GPT_MODEL,\n  messages=[\n        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n        {\"role\": \"user\", \"content\": \"Who won the gold medal for curling in Olymics 2022?\"},\n    ]\n)\n\nprint(response.choices[0].message.content)\n"
    ]
   },
   {
@@ -441,59 +428,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import tiktoken\n",
-    "\n",
-    "def num_tokens(text: str, model: str = GPT_MODEL) -> int:\n",
-    "    \"\"\"Return the number of tokens in a string.\"\"\"\n",
-    "    encoding = tiktoken.encoding_for_model(model)\n",
-    "    return len(encoding.encode(text))\n",
-    "\n",
-    "\n",
-    "def query_message(\n",
-    "    query: str,\n",
-    "    df: pd.DataFrame,\n",
-    "    model: str,\n",
-    "    token_budget: int\n",
-    ") -> str:\n",
-    "    \"\"\"Return a message for GPT, with relevant source texts pulled from SingleStoreDB.\"\"\"\n",
-    "    strings, relatednesses = strings_ranked_by_relatedness(query, df, \"winter_olympics_2022\")\n",
-    "    introduction = 'Use the below articles on the 2022 Winter Olympics to answer the subsequent question. If the answer cannot be found in the articles, write \"I could not find an answer.\"'\n",
-    "    question = f\"\\n\\nQuestion: {query}\"\n",
-    "    message = introduction\n",
-    "    for string in strings:\n",
-    "        next_article = f'\\n\\nWikipedia article section:\\n\"\"\"\\n{string}\\n\"\"\"'\n",
-    "        if (\n",
-    "            num_tokens(message + next_article + question, model=model)\n",
-    "            > token_budget\n",
-    "        ):\n",
-    "            break\n",
-    "        else:\n",
-    "            message += next_article\n",
-    "    return message + question\n",
-    "\n",
-    "\n",
-    "def ask(\n",
-    "    query: str,\n",
-    "    df: pd.DataFrame = df,\n",
-    "    model: str = GPT_MODEL,\n",
-    "    token_budget: int = 4096 - 500,\n",
-    "    print_message: bool = False,\n",
-    ") -> str:\n",
-    "    \"\"\"Answers a query using GPT and a table of relevant texts and embeddings in SingleStoreDB.\"\"\"\n",
-    "    message = query_message(query, df, model=model, token_budget=token_budget)\n",
-    "    if print_message:\n",
-    "        print(message)\n",
-    "    messages = [\n",
-    "        {\"role\": \"system\", \"content\": \"You answer questions about the 2022 Winter Olympics.\"},\n",
-    "        {\"role\": \"user\", \"content\": message},\n",
-    "    ]\n",
-    "    response = openai.ChatCompletion.create(\n",
-    "        model=model,\n",
-    "        messages=messages,\n",
-    "        temperature=0\n",
-    "    )\n",
-    "    response_message = response[\"choices\"][0][\"message\"][\"content\"]\n",
-    "    return response_message\n"
+    "import tiktoken\n\ndef num_tokens(text: str, model: str = GPT_MODEL) -> int:\n    \"\"\"Return the number of tokens in a string.\"\"\"\n    encoding = tiktoken.encoding_for_model(model)\n    return len(encoding.encode(text))\n\n\ndef query_message(\n    query: str,\n    df: pd.DataFrame,\n    model: str,\n    token_budget: int\n) -> str:\n    \"\"\"Return a message for GPT, with relevant source texts pulled from SingleStoreDB.\"\"\"\n    strings, relatednesses = strings_ranked_by_relatedness(query, df, \"winter_olympics_2022\")\n    introduction = 'Use the below articles on the 2022 Winter Olympics to answer the subsequent question. If the answer cannot be found in the articles, write \"I could not find an answer.\"'\n    question = f\"\\n\\nQuestion: {query}\"\n    message = introduction\n    for string in strings:\n        next_article = f'\\n\\nWikipedia article section:\\n\"\"\"\\n{string}\\n\"\"\"'\n        if (\n            num_tokens(message + next_article + question, model=model)\n            > token_budget\n        ):\n            break\n        else:\n            message += next_article\n    return message + question\n\n\ndef ask(\n    query: str,\n    df: pd.DataFrame = df,\n    model: str = GPT_MODEL,\n    token_budget: int = 4096 - 500,\n    print_message: bool = False,\n) -> str:\n    \"\"\"Answers a query using GPT and a table of relevant texts and embeddings in SingleStoreDB.\"\"\"\n    message = query_message(query, df, model=model, token_budget=token_budget)\n    if print_message:\n        print(message)\n    messages = [\n        {\"role\": \"system\", \"content\": \"You answer questions about the 2022 Winter Olympics.\"},\n        {\"role\": \"user\", \"content\": message},\n    ]\n    response = client.chat.completions.create(\n        model=model,\n        messages=messages,\n        temperature=0\n    )\n    response_message = response.choices[0].message.content\n    return response_message\n"
    ]
   },
   {
@@ -517,7 +452,7 @@
       "(\"There were three curling events at the 2022 Winter Olympics: men's, women's, \"\n",
       " 'and mixed doubles. The gold medalists for each event are:\\n'\n",
       " '\\n'\n",
-      " \"- Men's: Sweden (Niklas Edin, Oskar Eriksson, Rasmus Wranå, Christoffer \"\n",
+      " \"- Men's: Sweden (Niklas Edin, Oskar Eriksson, Rasmus Wran\u00e5, Christoffer \"\n",
       " 'Sundgren, Daniel Magnusson)\\n'\n",
       " \"- Women's: Great Britain (Eve Muirhead, Vicky Wright, Jennifer Dodds, Hailey \"\n",
       " 'Duff, Mili Smith)\\n'\n",


### PR DESCRIPTION
## Summary

`examples/vector_databases/SingleStoreDB/OpenAI_wikipedia_semantic_search.ipynb` still uses the pre-v1 OpenAI Python SDK API (`openai.ChatCompletion.create`, `openai.api_key = ...`, `response["choices"][0]["message"]["content"]`). The pre-v1 API was removed in `openai>=1.0.0`, so this notebook fails immediately for any user who installs the current SDK:

```text
AttributeError: module 'openai' has no attribute 'ChatCompletion'
```

This PR migrates the affected cells to the v1+ client API. No behavioral changes — same model (`gpt-3.5-turbo`), same prompts, same temperature.

## Changes

```diff
-import openai
+from openai import OpenAI

 EMBEDDING_MODEL = "text-embedding-3-small"
 GPT_MODEL = "gpt-3.5-turbo"
```

```diff
-openai.api_key = 'OPENAI API KEY'
-
-response = openai.ChatCompletion.create(
+# Uses OPENAI_API_KEY from your environment.
+client = OpenAI()
+
+response = client.chat.completions.create(
   model=GPT_MODEL,
   messages=[...]
 )
-print(response['choices'][0]['message']['content'])
+print(response.choices[0].message.content)
```

```diff
 # inside ask()
-    response = openai.ChatCompletion.create(
+    response = client.chat.completions.create(
         model=model, messages=messages, temperature=0
     )
-    response_message = response["choices"][0]["message"]["content"]
+    response_message = response.choices[0].message.content
```

The embeddings helper used elsewhere in this notebook is already on the v1+ API, so the rest of the flow works as soon as the chat calls are migrated.

## Test plan

- [x] Notebook JSON validates and re-renders cleanly.
- [x] No remaining `openai.ChatCompletion.create`, `openai.api_key = `, or dict-style `response[...]` access in any code cell.
- [x] Uses the same model and parameters as before — purely an SDK-surface migration.
