### PR TITLE
Fix syntax error in Agents SDK example in run-vllm guide

### DIFF
--- a/articles/gpt-oss/run-vllm.md
+++ b/articles/gpt-oss/run-vllm.md
@@ -146,7 +146,7 @@ async def main(model: str, api_key: str):
                 base_url="http://localhost:8000/v1",
                 api_key="EMPTY",
             ),
-        )
+        ),
         tools=[get_weather],
     )
 


### PR DESCRIPTION
The Python code block in the Agents SDK Integration section of `articles/gpt-oss/run-vllm.md` is missing a comma between the `model=OpenAIResponsesModel(...)` argument and the `tools=[get_weather]` argument of the `Agent(...)` constructor.

Running the example as-is raises:

```
SyntaxError: invalid syntax. Perhaps you forgot a comma?
```

This patch adds the missing comma so the example parses and runs. Verified with `ast.parse` on every `py` block in the file after the change.