### PR TITLE
Fix broken async embedding helpers in embeddings_utils

### DIFF
--- a/examples/utils/embeddings_utils.py
+++ b/examples/utils/embeddings_utils.py
@@ -8,11 +8,12 @@ from sklearn.decomposition import PCA
 from sklearn.manifold import TSNE
 from sklearn.metrics import average_precision_score, precision_recall_curve
 
-from openai import OpenAI
+from openai import AsyncOpenAI, OpenAI
 import numpy as np
 import pandas as pd
 
 client = OpenAI(max_retries=5)
+aclient = AsyncOpenAI(max_retries=5)
 
 
 def get_embedding(text: str, model="text-embedding-3-small", **kwargs) -> List[float]:
@@ -30,9 +31,8 @@ async def aget_embedding(
     # replace newlines, which can negatively affect performance.
     text = text.replace("\n", " ")
 
-    return (await client.embeddings.create(input=[text], model=model, **kwargs))[
-        "data"
-    ][0]["embedding"]
+    response = await aclient.embeddings.create(input=[text], model=model, **kwargs)
+    return response.data[0].embedding
 
 
 def get_embeddings(
@@ -56,7 +56,7 @@ async def aget_embeddings(
     list_of_text = [text.replace("\n", " ") for text in list_of_text]
 
     data = (
-        await client.embeddings.create(input=list_of_text, model=model, **kwargs)
+        await aclient.embeddings.create(input=list_of_text, model=model, **kwargs)
     ).data
     return [d.embedding for d in data]
 


### PR DESCRIPTION
## Bug

`examples/utils/embeddings_utils.py` has two broken async helpers:

1. `aget_embedding` and `aget_embeddings` both `await` a call on the sync `OpenAI` client. `client.embeddings.create(...)` returns a `CreateEmbeddingResponse` (not awaitable), so calling either function raises:
   ```
   TypeError: object CreateEmbeddingResponse can't be used in 'await' expression
   ```
2. `aget_embedding` also subscripts the response as a dict (`response[\"data\"][0][\"embedding\"]`). The v1+ SDK returns a pydantic object, so this raises:
   ```
   TypeError: 'CreateEmbeddingResponse' object is not subscriptable
   ```
   The sibling helpers `get_embedding` / `get_embeddings` / `aget_embeddings` all already use attribute access.

## Fix

- Add an `AsyncOpenAI` client (`aclient`) and use it from the async helpers.
- Use attribute access (`.data[0].embedding`) in `aget_embedding`, matching the sibling helpers.