### PR TITLE
docs: fix typo in CONTRIBUTING.md heading ('the the' -> 'to the')

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing the the cookbook
+# Contributing to the cookbook
 
 The OpenAI Cookbook is a collection of useful patterns and examples of working with the OpenAI platform, provided as a community resource.
 


### PR DESCRIPTION
## Summary

Fix a one-word typo in the `CONTRIBUTING.md` heading. The file currently opens with:

> # Contributing the the cookbook

It should read:

> # Contributing to the cookbook

## Motivation

`CONTRIBUTING.md` is the first thing prospective contributors see when they look at how to add to the cookbook, so the typo is visible on GitHub's contributing-doc surface and on any page that renders the file. The fix is one character beyond a pure no-op — purely editorial, no behavior or example output changes.

## Diff

```diff
-# Contributing the the cookbook
+# Contributing to the cookbook
```

## Checklist

This is a docs-only typo fix, so the new-content rubric in the PR template does not strictly apply, but for completeness:

- [x] Self-reviewed the change
- [x] Spelling and grammar verified (the fix itself addresses the issue)
- [x] No code or example output affected
- [x] No `registry.yaml` / `authors.yaml` entries needed (not new content)