### PR TITLE
docs: fix typos across cookbook notebooks

### DIFF
--- a/examples/Using_tool_required_for_customer_service.ipynb
+++ b/examples/Using_tool_required_for_customer_service.ipynb
@@ -94,7 +94,7 @@
     "\n",
     "# Example instructions that the customer service assistant can consult for relevant customer problems\n",
     "INSTRUCTIONS = [ {\"type\": \"fraud\",\n",
-    "                  \"instructions\": \"\"\"• Ask the customer to describe the fraudulent activity, including the the date and items involved in the suspected fraud.\n",
+    "                  \"instructions\": \"\"\"• Ask the customer to describe the fraudulent activity, including the date and items involved in the suspected fraud.\n",
     "• Offer the customer a refund.\n",
     "• Report the fraud to the security team for further investigation.\n",
     "• Thank the customer for contacting support and invite them to reach out with any future queries.\"\"\"},\n",

--- a/examples/chatgpt/gpt_actions_library/gpt_action_googleads_adzviser.ipynb
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_googleads_adzviser.ipynb
@@ -549,7 +549,7 @@
         "          },\n",
         "          \"date_ranges\": {\n",
         "            \"type\": \"array\",\n",
-        "            \"description\": \"A list of date ranges requested from the user. They needs to be calculated seperately with Code Interpreter and Python every single time for accuracy. For example, if the user requests \\\"Google Ads search impression share in May and August\\\", then this array should be [[\\\"2024-05-01\\\", \\\"2024-05-31\\\"], [\\\"2024-08-01\\\", \\\"2024-08-31\\\"]].\",\n",
+        "            \"description\": \"A list of date ranges requested from the user. They needs to be calculated separately with Code Interpreter and Python every single time for accuracy. For example, if the user requests \\\"Google Ads search impression share in May and August\\\", then this array should be [[\\\"2024-05-01\\\", \\\"2024-05-31\\\"], [\\\"2024-08-01\\\", \\\"2024-08-31\\\"]].\",\n",
         "            \"items\": {\n",
         "              \"type\": \"array\",\n",
         "              \"items\": {\n",

--- a/examples/multimodal/Vision_Fine_tuning_on_GPT4o_for_Visual_Question_Answering.ipynb
+++ b/examples/multimodal/Vision_Fine_tuning_on_GPT4o_for_Visual_Question_Answering.ipynb
@@ -1046,7 +1046,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "# seperate by question type\n",
+    "# separate by question type\n",
     "def get_question_type(question):\n",
     "    if question in [\"What is the title of this book?\"]:\n",
     "        return \"Title\"\n",

--- a/examples/partners/temporal_agents_with_knowledge_graphs/temporal_agents.ipynb
+++ b/examples/partners/temporal_agents_with_knowledge_graphs/temporal_agents.ipynb
@@ -5278,7 +5278,7 @@
     "    initial_planner_user_prompt = (\n",
     "        \"Your top equity research team has came to you with a research question they are trying to find the answer to. \"\n",
     "        \"You should use your deep financial expertise to succinctly detail a step-by-step plan for retrieving \"\n",
-    "        \"this information from the the company's knowledge base of earnings call transcripts extracts. \"\n",
+    "        \"this information from the company's knowledge base of earnings call transcripts extracts. \"\n",
     "        \"You should produce a concise set of individual research tasks required to thoroughly address the team's query. \"\n",
     "        \"These tasks should cover all of the key points of the team's research task without overcomplicating it. \\n\\n\"\n",
     "        \"The question the team has is: \\n\\n\"\n",


### PR DESCRIPTION
## Summary

Correct four isolated typographical errors in existing notebooks. The rebase preserved only fixes that are still needed on current `main`; all changes are limited to source text and code comments.

## Changes

- Remove a duplicated word in a customer-service instruction.
- Correct `seperately` to `separately` in a tool description.
- Correct `seperate` to `separate` in a code comment.
- Remove a duplicated word in a system-prompt string.

## Validation

- Rebased onto current `main`; the prior conflict was a sentence already rewritten and corrected upstream.
- `git diff --check` passes.
- Each changed notebook parses as valid JSON with `jq empty`.
- No outputs, metadata, cell order, or executable behavior changed.
- No `registry.yaml` or `authors.yaml` changes are needed because this adds no content.

## Self-review

The final diff changes four source strings across four existing notebooks, with no new dependencies or runtime behavior changes.