### PR TITLE
docs(fine-tuned_qa): fix broken fine-tuning guide link

### DIFF
--- a/examples/fine-tuned_qa/ft_retrieval_augmented_generation_qdrant.ipynb
+++ b/examples/fine-tuned_qa/ft_retrieval_augmented_generation_qdrant.ipynb
@@ -488,7 +488,7 @@
    "source": [
     "## 4. Fine-tuning and Answering using Fine-tuned model\n",
     "\n",
-    "For the complete fine-tuning process, please refer to the [OpenAI Fine-Tuning Docs](https://platform.openai.com/docs/guides/fine-tuning/use-a-fine-tuned-model).\n",
+    "For the complete fine-tuning process, please refer to the [OpenAI Fine-Tuning Docs](https://developers.openai.com/api/docs/guides/model-optimization).\n",
     "\n",
     "### 4.1 Prepare the Fine-Tuning Data\n",
     "\n",


### PR DESCRIPTION
Closes #2320.

Section 4 of the Qdrant fine-tuning notebook links to `platform.openai.com/docs/guides/fine-tuning/use-a-fine-tuned-model`, which returns 404 — that deep link no longer exists. This points it at `developers.openai.com/api/docs/guides/model-optimization`, the same page #2864 moved the notebook's other fine-tuning link to.

One line in one markdown cell. No code cells, no outputs, no other links touched.
