### PR TITLE
examples(redis): migrate vector database notebooks to openai>=1.0 client API

### DIFF
--- a/examples/vector_databases/redis/Using_Redis_for_embeddings_search.ipynb
+++ b/examples/vector_databases/redis/Using_Redis_for_embeddings_search.ipynb
@@ -56,32 +56,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "5be94df6",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import openai\n",
-    "\n",
-    "from typing import List, Iterator\n",
-    "import pandas as pd\n",
-    "import numpy as np\n",
-    "import os\n",
-    "import wget\n",
-    "from ast import literal_eval\n",
-    "\n",
-    "# Redis client library for Python\n",
-    "import redis\n",
-    "\n",
-    "# I've set this to our new embeddings model, this can be changed to the embedding model of your choice\n",
-    "EMBEDDING_MODEL = \"text-embedding-3-small\"\n",
-    "\n",
-    "# Ignore unclosed SSL socket warnings - optional in case you get these errors\n",
-    "import warnings\n",
-    "\n",
-    "warnings.filterwarnings(action=\"ignore\", message=\"unclosed\", category=ResourceWarning)\n",
-    "warnings.filterwarnings(\"ignore\", category=DeprecationWarning) "
-   ]
+   "source": "from openai import OpenAI\n\nfrom typing import List, Iterator\nimport pandas as pd\nimport numpy as np\nimport os\nimport wget\nfrom ast import literal_eval\n\n# Redis client library for Python\nimport redis\n\n# I've set this to our new embeddings model, this can be changed to the embedding model of your choice\nEMBEDDING_MODEL = \"text-embedding-3-small\"\n\n# Ignore unclosed SSL socket warnings - optional in case you get these errors\n# Uses OPENAI_API_KEY from your environment.\nclient = OpenAI()\n\nimport warnings\n\nwarnings.filterwarnings(action=\"ignore\", message=\"unclosed\", category=ResourceWarning)\nwarnings.filterwarnings(\"ignore\", category=DeprecationWarning) "
   },
   {
    "cell_type": "markdown",
@@ -567,73 +546,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "508d1f89",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def search_redis(\n",
-    "    redis_client: redis.Redis,\n",
-    "    user_query: str,\n",
-    "    index_name: str = \"embeddings-index\",\n",
-    "    vector_field: str = \"title_vector\",\n",
-    "    return_fields: list = [\"title\", \"url\", \"text\", \"vector_score\"],\n",
-    "    hybrid_fields = \"*\",\n",
-    "    k: int = 20,\n",
-    ") -> List[dict]:\n",
-    "\n",
-    "    # Creates embedding vector from user query\n",
-    "    embedded_query = openai.Embedding.create(input=user_query,\n",
-    "                                            model=EMBEDDING_MODEL,\n",
-    "                                            )[\"data\"][0]['embedding']\n",
-    "\n",
-    "    # Prepare the Query\n",
-    "    base_query = f'{hybrid_fields}=>[KNN {k} @{vector_field} $vector AS vector_score]'\n",
-    "    query = (\n",
-    "        Query(base_query)\n",
-    "         .return_fields(*return_fields)\n",
-    "         .sort_by(\"vector_score\")\n",
-    "         .paging(0, k)\n",
-    "         .dialect(2)\n",
-    "    )\n",
-    "    params_dict = {\"vector\": np.array(embedded_query).astype(dtype=np.float32).tobytes()}\n",
-    "\n",
-    "    # perform vector search\n",
-    "    results = redis_client.ft(index_name).search(query, params_dict)\n",
-    "    for i, article in enumerate(results.docs):\n",
-    "        score = 1 - float(article.vector_score)\n",
-    "        print(f\"{i}. {article.title} (Score: {round(score ,3) })\")\n",
-    "    return results.docs"
-   ]
+   "source": "def search_redis(\n    redis_client: redis.Redis,\n    user_query: str,\n    index_name: str = \"embeddings-index\",\n    vector_field: str = \"title_vector\",\n    return_fields: list = [\"title\", \"url\", \"text\", \"vector_score\"],\n    hybrid_fields = \"*\",\n    k: int = 20,\n) -> List[dict]:\n\n    # Creates embedding vector from user query\n    embedded_query = client.embeddings.create(\n        input=user_query,\n        model=EMBEDDING_MODEL,\n    ).data[0].embedding\n\n    # Prepare the Query\n    base_query = f'{hybrid_fields}=>[KNN {k} @{vector_field} $vector AS vector_score]'\n    query = (\n        Query(base_query)\n         .return_fields(*return_fields)\n         .sort_by(\"vector_score\")\n         .paging(0, k)\n         .dialect(2)\n    )\n    params_dict = {\"vector\": np.array(embedded_query).astype(dtype=np.float32).tobytes()}\n\n    # perform vector search\n    results = redis_client.ft(index_name).search(query, params_dict)\n    for i, article in enumerate(results.docs):\n        score = 1 - float(article.vector_score)\n        print(f\"{i}. {article.title} (Score: {round(score ,3) })\")\n    return results.docs"
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "1f0eef07",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0. Museum of Modern Art (Score: 0.875)\n",
-      "1. Western Europe (Score: 0.867)\n",
-      "2. Renaissance art (Score: 0.864)\n",
-      "3. Pop art (Score: 0.86)\n",
-      "4. Northern Europe (Score: 0.855)\n",
-      "5. Hellenistic art (Score: 0.853)\n",
-      "6. Modernist literature (Score: 0.847)\n",
-      "7. Art film (Score: 0.843)\n",
-      "8. Central Europe (Score: 0.843)\n",
-      "9. European (Score: 0.841)\n"
-     ]
-    }
-   ],
-   "source": [
-    "# For using OpenAI to generate query embedding\n",
-    "openai.api_key = os.getenv(\"OPENAI_API_KEY\", \"sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\")\n",
-    "results = search_redis(redis_client, 'modern art in Europe', k=10)"
-   ]
+   "outputs": [],
+   "source": "results = search_redis(redis_client, 'modern art in Europe', k=10)"
   },
   {
    "cell_type": "code",

--- a/examples/vector_databases/redis/getting-started-with-redis-and-openai.ipynb
+++ b/examples/vector_databases/redis/getting-started-with-redis-and-openai.ipynb
@@ -109,33 +109,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "88be138c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "OPENAI_API_KEY is ready\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Test that your OpenAI API key is correctly set as an environment variable\n",
-    "# Note. if you run this notebook locally, you will need to reload your terminal and the notebook for the env variables to be live.\n",
-    "import os\n",
-    "import openai\n",
-    "\n",
-    "# Note. alternatively you can set a temporary env variable like this:\n",
-    "# os.environ[\"OPENAI_API_KEY\"] = 'sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'\n",
-    "\n",
-    "if os.getenv(\"OPENAI_API_KEY\") is not None:\n",
-    "    openai.api_key = os.getenv(\"OPENAI_API_KEY\")\n",
-    "    print (\"OPENAI_API_KEY is ready\")\n",
-    "else:\n",
-    "    print (\"OPENAI_API_KEY environment variable not found\")"
-   ]
+   "outputs": [],
+   "source": "# Verify that your OpenAI API key is correctly set as an environment variable.\n# Note. if you run this notebook locally, you will need to reload your terminal and the notebook for the env variables to be live.\nimport os\nfrom openai import OpenAI\n\n# Note. alternatively you can set a temporary env variable like this:\n# os.environ[\"OPENAI_API_KEY\"] = 'sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'\n\nif os.getenv(\"OPENAI_API_KEY\") is not None:\n    client = OpenAI()\n    print(\"OPENAI_API_KEY is ready\")\nelse:\n    print(\"OPENAI_API_KEY environment variable not found\")"
   },
   {
    "attachments": {},
@@ -500,46 +478,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "b044aa93",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def search_redis(\n",
-    "    redis_client: redis.Redis,\n",
-    "    user_query: str,\n",
-    "    index_name: str = \"embeddings-index\",\n",
-    "    vector_field: str = \"title_vector\",\n",
-    "    return_fields: list = [\"title\", \"url\", \"text\", \"vector_score\"],\n",
-    "    hybrid_fields = \"*\",\n",
-    "    k: int = 20,\n",
-    "    print_results: bool = True,\n",
-    ") -> List[dict]:\n",
-    "\n",
-    "    # Creates embedding vector from user query\n",
-    "    embedded_query = openai.Embedding.create(input=user_query,\n",
-    "                                            model=\"text-embedding-3-small\",\n",
-    "                                            )[\"data\"][0]['embedding']\n",
-    "\n",
-    "    # Prepare the Query\n",
-    "    base_query = f'{hybrid_fields}=>[KNN {k} @{vector_field} $vector AS vector_score]'\n",
-    "    query = (\n",
-    "        Query(base_query)\n",
-    "         .return_fields(*return_fields)\n",
-    "         .sort_by(\"vector_score\")\n",
-    "         .paging(0, k)\n",
-    "         .dialect(2)\n",
-    "    )\n",
-    "    params_dict = {\"vector\": np.array(embedded_query).astype(dtype=np.float32).tobytes()}\n",
-    "\n",
-    "    # perform vector search\n",
-    "    results = redis_client.ft(index_name).search(query, params_dict)\n",
-    "    if print_results:\n",
-    "        for i, article in enumerate(results.docs):\n",
-    "            score = 1 - float(article.vector_score)\n",
-    "            print(f\"{i}. {article.title} (Score: {round(score ,3) })\")\n",
-    "    return results.docs"
-   ]
+   "source": "def search_redis(\n    redis_client: redis.Redis,\n    user_query: str,\n    index_name: str = \"embeddings-index\",\n    vector_field: str = \"title_vector\",\n    return_fields: list = [\"title\", \"url\", \"text\", \"vector_score\"],\n    hybrid_fields = \"*\",\n    k: int = 20,\n    print_results: bool = True,\n) -> List[dict]:\n\n    # Creates embedding vector from user query\n    embedded_query = client.embeddings.create(\n        input=user_query,\n        model=\"text-embedding-3-small\",\n    ).data[0].embedding\n\n    # Prepare the Query\n    base_query = f'{hybrid_fields}=>[KNN {k} @{vector_field} $vector AS vector_score]'\n    query = (\n        Query(base_query)\n         .return_fields(*return_fields)\n         .sort_by(\"vector_score\")\n         .paging(0, k)\n         .dialect(2)\n    )\n    params_dict = {\"vector\": np.array(embedded_query).astype(dtype=np.float32).tobytes()}\n\n    # perform vector search\n    results = redis_client.ft(index_name).search(query, params_dict)\n    if print_results:\n        for i, article in enumerate(results.docs):\n            score = 1 - float(article.vector_score)\n            print(f\"{i}. {article.title} (Score: {round(score ,3) })\")\n    return results.docs"
   },
   {
    "cell_type": "code",

--- a/examples/vector_databases/redis/getting-started-with-redis-and-openai.ipynb
+++ b/examples/vector_databases/redis/getting-started-with-redis-and-openai.ipynb
@@ -78,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install redis wget pandas openai"
+    "! pip install redis wget pandas \"openai>=1.0\""
    ]
   },
   {

--- a/examples/vector_databases/redis/redis-hybrid-query-examples.ipynb
+++ b/examples/vector_databases/redis/redis-hybrid-query-examples.ipynb
@@ -87,7 +87,7 @@
     }
    ],
    "source": [
-    "! pip install redis pandas openai\n"
+    "! pip install redis pandas \"openai>=1.0\"\n"
    ]
   },
   {

--- a/examples/vector_databases/redis/redis-hybrid-query-examples.ipynb
+++ b/examples/vector_databases/redis/redis-hybrid-query-examples.ipynb
@@ -107,32 +107,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "88be138c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "OPENAI_API_KEY is ready\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Test that your OpenAI API key is correctly set as an environment variable\n",
-    "# Note. if you run this notebook locally, you will need to reload your terminal and the notebook for the env variables to be live.\n",
-    "import os\n",
-    "import openai\n",
-    "\n",
-    "os.environ[\"OPENAI_API_KEY\"] = '<YOUR_OPENAI_API_KEY>'\n",
-    "\n",
-    "if os.getenv(\"OPENAI_API_KEY\") is not None:\n",
-    "    openai.api_key = os.getenv(\"OPENAI_API_KEY\")\n",
-    "    print (\"OPENAI_API_KEY is ready\")\n",
-    "else:\n",
-    "    print (\"OPENAI_API_KEY environment variable not found\")\n"
-   ]
+   "outputs": [],
+   "source": "# Verify that your OpenAI API key is correctly set as an environment variable.\n# Note. if you run this notebook locally, you will need to reload your terminal and the notebook for the env variables to be live.\nimport os\nfrom openai import OpenAI\n\nos.environ[\"OPENAI_API_KEY\"] = '<YOUR_OPENAI_API_KEY>'\n\nif os.getenv(\"OPENAI_API_KEY\") is not None:\n    client = OpenAI()\n    print(\"OPENAI_API_KEY is ready\")\nelse:\n    print(\"OPENAI_API_KEY environment variable not found\")\n"
   },
   {
    "cell_type": "markdown",
@@ -613,46 +592,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "b044aa93",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def search_redis(\n",
-    "    redis_client: redis.Redis,\n",
-    "    user_query: str,\n",
-    "    index_name: str = \"product_embeddings\",\n",
-    "    vector_field: str = \"product_vector\",\n",
-    "    return_fields: list = [\"productDisplayName\", \"masterCategory\", \"gender\", \"season\", \"year\", \"vector_score\"],\n",
-    "    hybrid_fields = \"*\",\n",
-    "    k: int = 20,\n",
-    "    print_results: bool = True,\n",
-    ") -> List[dict]:\n",
-    "\n",
-    "    # Use OpenAI to create embedding vector from user query\n",
-    "    embedded_query = openai.Embedding.create(input=user_query,\n",
-    "                                            model=\"text-embedding-3-small\",\n",
-    "                                            )[\"data\"][0]['embedding']\n",
-    "\n",
-    "    # Prepare the Query\n",
-    "    base_query = f'{hybrid_fields}=>[KNN {k} @{vector_field} $vector AS vector_score]'\n",
-    "    query = (\n",
-    "        Query(base_query)\n",
-    "         .return_fields(*return_fields)\n",
-    "         .sort_by(\"vector_score\")\n",
-    "         .paging(0, k)\n",
-    "         .dialect(2)\n",
-    "    )\n",
-    "    params_dict = {\"vector\": np.array(embedded_query).astype(dtype=np.float32).tobytes()}\n",
-    "\n",
-    "    # perform vector search\n",
-    "    results = redis_client.ft(index_name).search(query, params_dict)\n",
-    "    if print_results:\n",
-    "        for i, product in enumerate(results.docs):\n",
-    "            score = 1 - float(product.vector_score)\n",
-    "            print(f\"{i}. {product.productDisplayName} (Score: {round(score ,3) })\")\n",
-    "    return results.docs\n"
-   ]
+   "source": "def search_redis(\n    redis_client: redis.Redis,\n    user_query: str,\n    index_name: str = \"product_embeddings\",\n    vector_field: str = \"product_vector\",\n    return_fields: list = [\"productDisplayName\", \"masterCategory\", \"gender\", \"season\", \"year\", \"vector_score\"],\n    hybrid_fields = \"*\",\n    k: int = 20,\n    print_results: bool = True,\n) -> List[dict]:\n\n    # Use OpenAI to create embedding vector from user query\n    embedded_query = client.embeddings.create(\n        input=user_query,\n        model=\"text-embedding-3-small\",\n    ).data[0].embedding\n\n    # Prepare the Query\n    base_query = f'{hybrid_fields}=>[KNN {k} @{vector_field} $vector AS vector_score]'\n    query = (\n        Query(base_query)\n         .return_fields(*return_fields)\n         .sort_by(\"vector_score\")\n         .paging(0, k)\n         .dialect(2)\n    )\n    params_dict = {\"vector\": np.array(embedded_query).astype(dtype=np.float32).tobytes()}\n\n    # perform vector search\n    results = redis_client.ft(index_name).search(query, params_dict)\n    if print_results:\n        for i, product in enumerate(results.docs):\n            score = 1 - float(product.vector_score)\n            print(f\"{i}. {product.productDisplayName} (Score: {round(score ,3) })\")\n    return results.docs\n"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

Three notebooks under `examples/vector_databases/redis/` still call `openai.Embedding.create(input=..., model=...)` — a pattern removed in `openai>=1.0`. Running them on a current `openai` SDK install raises `AttributeError: module 'openai' has no attribute 'Embedding'`. PR #914 ("Migrate all notebooks to API V1") landed the bulk migration but missed every embedding-only vector-database notebook because it focused on chat-completion call sites. This change closes the gap for the Redis directory.

The migration shape mirrors PR #2718 (SingleStoreDB) directly:

- `import openai` → `from openai import OpenAI`
- `openai.api_key = os.getenv(...)` → `client = OpenAI()` (reads `OPENAI_API_KEY` from env)
- `openai.Embedding.create(input=..., model=...)["data"][0]["embedding"]` → `client.embeddings.create(input=..., model=...).data[0].embedding`

## Files

- `examples/vector_databases/redis/Using_Redis_for_embeddings_search.ipynb`
- `examples/vector_databases/redis/getting-started-with-redis-and-openai.ipynb`
- `examples/vector_databases/redis/redis-hybrid-query-examples.ipynb`

## Notes

- **Embedding model unchanged.** All three notebooks already use `text-embedding-3-small` (set during an earlier partial cleanup). No model swap is needed in this PR — kept to a pure v0→v1 client migration.
- **Notebook outputs cleared.** `execution_count` reset to `null` so the diff is just source-cell changes.
- **No new dependencies.** Notebooks already declare `openai` in their setup cells.

## Test plan

- `python3 .github/scripts/check_notebooks.py` against all three modified files — `All changed notebooks are valid.`
- Verified by grep that no `openai.Embedding.create`, `openai.api_key = ...`, or standalone `import openai` remains in any of the three notebooks.
- Same fix shape as recently-filed PRs #2718–#2721, which establish the canonical template for this migration.