### PR TITLE
examples(pinecone): migrate Gen_QA and Using_Pinecone notebooks to openai>=1.0 client API

### DIFF
--- a/examples/vector_databases/pinecone/Gen_QA.ipynb
+++ b/examples/vector_databases/pinecone/Gen_QA.ipynb
@@ -20,7 +20,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -28,42 +28,23 @@
         "id": "VpMvHAYRQf9N",
         "outputId": "f2b1a704-1b38-4985-f5cf-be0479f2ac31"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/55.3 KB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m55.3/55.3 KB\u001b[0m \u001b[31m1.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25h  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
-            "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
-            "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m170.6/170.6 KB\u001b[0m \u001b[31m13.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m452.9/452.9 KB\u001b[0m \u001b[31m30.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m58.3/58.3 KB\u001b[0m \u001b[31m6.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m213.0/213.0 KB\u001b[0m \u001b[31m17.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m132.0/132.0 KB\u001b[0m \u001b[31m13.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m182.4/182.4 KB\u001b[0m \u001b[31m18.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m140.6/140.6 KB\u001b[0m \u001b[31m6.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25h  Building wheel for openai (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "!pip install -qU openai pinecone-client datasets"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
         "id": "aEreHNxYkDbK"
       },
       "outputs": [],
       "source": [
-        "import openai\n",
+        "from openai import OpenAI\n",
         "\n",
-        "# get API key from top-right dropdown on OpenAI website\n",
-        "openai.api_key = \"OPENAI_API_KEY\""
+        "# Reads OPENAI_API_KEY from the environment by default.\n",
+        "client = OpenAI()"
       ]
     },
     {
@@ -77,7 +58,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -86,27 +67,13 @@
         "id": "9FEDn7LvkDYj",
         "outputId": "dea469a8-55ab-491f-f645-356e86d361ac"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "'The 12th person on the moon was Harrison Schmitt, and he landed on December 11, 1972.'"
-            ]
-          },
-          "execution_count": 3,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "query = \"who was the 12th person on the moon and when did they land?\"\n",
         "\n",
         "# now query `gpt-3.5-turbo-instruct` WITHOUT context\n",
-        "res = openai.Completion.create(\n",
-        "    engine='gpt-3.5-turbo-instruct',\n",
+        "res = client.completions.create(\n",
+        "    model='gpt-3.5-turbo-instruct',\n",
         "    prompt=query,\n",
         "    temperature=0,\n",
         "    max_tokens=400,\n",
@@ -116,7 +83,7 @@
         "    stop=None\n",
         ")\n",
         "\n",
-        "res['choices'][0]['text'].strip()"
+        "res.choices[0].text.strip()"
       ]
     },
     {
@@ -131,15 +98,15 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
       "metadata": {
         "id": "SczFSfnjmNji"
       },
       "outputs": [],
       "source": [
         "def complete(prompt):\n",
-        "    res = openai.Completion.create(\n",
-        "        engine='gpt-3.5-turbo-instruct',\n",
+        "    res = client.completions.create(\n",
+        "        model='gpt-3.5-turbo-instruct',\n",
         "        prompt=prompt,\n",
         "        temperature=0,\n",
         "        max_tokens=400,\n",
@@ -148,7 +115,7 @@
         "        presence_penalty=0,\n",
         "        stop=None\n",
         "    )\n",
-        "    return res['choices'][0]['text'].strip()"
+        "    return res.choices[0].text.strip()"
       ]
     },
     {
@@ -165,7 +132,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -174,21 +141,7 @@
         "id": "H2fUC8BtxCt_",
         "outputId": "01beb42c-1f32-4e08-afc5-127e2dc5597a"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "'If you only have pairs of related sentences, then the best training method to use for sentence transformers is the supervised learning approach. This approach involves providing the model with labeled data, such as pairs of related sentences, and then training the model to learn the relationships between the sentences. This approach is often used for tasks such as natural language inference, semantic similarity, and paraphrase identification.'"
-            ]
-          },
-          "execution_count": 5,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "query = (\n",
         "    \"Which training method should I use for sentence transformers when \" +\n",
@@ -246,7 +199,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
         "id": "EI2iYxq16or9"
       },
@@ -254,11 +207,11 @@
       "source": [
         "embed_model = \"text-embedding-ada-002\"\n",
         "\n",
-        "res = openai.Embedding.create(\n",
+        "res = client.embeddings.create(\n",
         "    input=[\n",
         "        \"Sample document text goes here\",\n",
         "        \"there will be several phrases in each batch\"\n",
-        "    ], engine=embed_model\n",
+        "    ], model=embed_model\n",
         ")"
       ]
     },
@@ -273,7 +226,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -281,18 +234,7 @@
         "id": "57smZFmz61tj",
         "outputId": "30745411-1f44-4abb-ac36-20abcfdbb343"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "dict_keys(['object', 'data', 'model', 'usage'])"
-            ]
-          },
-          "execution_count": 7,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "res.keys()"
       ]
@@ -308,7 +250,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -316,25 +258,14 @@
         "id": "36D4ipOR63AW",
         "outputId": "10a3d6ba-a646-4ebd-d74f-90868d04a6f6"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "2"
-            ]
-          },
-          "execution_count": 8,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "len(res['data'])"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -342,18 +273,7 @@
         "id": "dPyGLhDX62t4",
         "outputId": "f5d38bb2-f863-4d39-c8f6-d75579634ec9"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "(1536, 1536)"
-            ]
-          },
-          "execution_count": 9,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "len(res['data'][0]['embedding']), len(res['data'][1]['embedding'])"
       ]
@@ -373,7 +293,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -381,29 +301,7 @@
         "id": "t7uzxkGz73Ov",
         "outputId": "995123eb-8f78-44b0-b325-e0ce2284b168"
       },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Using custom data configuration jamescalam--youtube-transcriptions-6a482f3df0aedcdb\n",
-            "Reusing dataset json (/Users/jamesbriggs/.cache/huggingface/datasets/jamescalam___json/jamescalam--youtube-transcriptions-6a482f3df0aedcdb/0.0.0/ac0ca5f5289a6cf108e706efcf040422dbbfa8e658dee6a819f20d76bb84d26b)\n"
-          ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "Dataset({\n",
-              "    features: ['title', 'published', 'url', 'video_id', 'channel_id', 'id', 'text', 'start', 'end'],\n",
-              "    num_rows: 208619\n",
-              "})"
-            ]
-          },
-          "execution_count": 2,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "from datasets import load_dataset\n",
         "\n",
@@ -413,28 +311,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "{'title': 'Training and Testing an Italian BERT - Transformers From Scratch #4',\n",
-              " 'published': '2021-07-06 13:00:03 UTC',\n",
-              " 'url': 'https://youtu.be/35Pdoyi6ZoQ',\n",
-              " 'video_id': '35Pdoyi6ZoQ',\n",
-              " 'channel_id': 'UCv83tO5cePwHMt1952IVVHw',\n",
-              " 'id': '35Pdoyi6ZoQ-t0.0',\n",
-              " 'text': 'Hi, welcome to the video.',\n",
-              " 'start': 0.0,\n",
-              " 'end': 9.36}"
-            ]
-          },
-          "execution_count": 3,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "data[0]"
       ]
@@ -450,7 +329,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -472,22 +351,7 @@
         "id": "uG9ZTI0o-9cJ",
         "outputId": "30b65907-eea0-4de0-c457-d69531e388c3"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "8b7d062ee1c14bf6b0c55da89ff4b551",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "  0%|          | 0/52155 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "from tqdm.auto import tqdm\n",
         "\n",
@@ -517,7 +381,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -525,25 +389,7 @@
         "id": "wN0BuMWSnqId",
         "outputId": "2b733986-c26b-487b-a4cb-336602a1a3dc"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "{'start': 0.0,\n",
-              " 'end': 74.12,\n",
-              " 'title': 'Training and Testing an Italian BERT - Transformers From Scratch #4',\n",
-              " 'text': \"Hi, welcome to the video. So this is the fourth video in a Transformers from Scratch mini series. So if you haven't been following along, we've essentially covered what you can see on the screen. So we got some data. We built a tokenizer with it. And then we've set up our input pipeline ready to begin actually training our model, which is what we're going to cover in this video. So let's move over to the code. And we see here that we have essentially everything we've done so far. So we've built our input data, our input pipeline. And we're now at a point where we have a data loader, PyTorch data loader, ready. And we can begin training a model with it. So there are a few things to be aware of. So I mean, first, let's just have a quick look at the structure of our data.\",\n",
-              " 'id': '35Pdoyi6ZoQ-t0.0',\n",
-              " 'url': 'https://youtu.be/35Pdoyi6ZoQ',\n",
-              " 'published': '2021-07-06 13:00:03 UTC',\n",
-              " 'channel_id': 'UCv83tO5cePwHMt1952IVVHw'}"
-            ]
-          },
-          "execution_count": 12,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "new_data[0]"
       ]
@@ -559,7 +405,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -567,21 +413,7 @@
         "id": "UPNwQTH0RNcl",
         "outputId": "c5d22baf-0e69-4039-fda0-624ce22cd740"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "{'dimension': 1536,\n",
-              " 'index_fullness': 0.0,\n",
-              " 'namespaces': {},\n",
-              " 'total_vector_count': 0}"
-            ]
-          },
-          "execution_count": 13,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "import pinecone\n",
         "\n",
@@ -619,7 +451,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -641,22 +473,7 @@
         "id": "vPb9liovzrc8",
         "outputId": "bb69dbce-c140-49af-840f-2c03dd940e2a"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "bb392ce2d1e047daa1747c4a0f5e89b7",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "  0%|          | 0/487 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "from tqdm.auto import tqdm\n",
         "from time import sleep\n",
@@ -675,11 +492,11 @@
         "    done = False\n",
         "    while not done:\n",
         "        try:\n",
-        "            res = openai.Embedding.create(input=texts, engine=embed_model)\n",
+        "            res = client.embeddings.create(input=texts, model=embed_model)\n",
         "            done = True\n",
         "        except:\n",
         "            sleep(5)\n",
-        "    embeds = [record['embedding'] for record in res['data']]\n",
+        "    embeds = [record.embedding for record in res.data]\n",
         "    # cleanup metadata\n",
         "    meta_batch = [{\n",
         "        'start': x['start'],\n",
@@ -706,19 +523,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": null,
       "metadata": {
         "id": "LF1U_yZGojRJ"
       },
       "outputs": [],
       "source": [
-        "res = openai.Embedding.create(\n",
+        "res = client.embeddings.create(\n",
         "    input=[query],\n",
-        "    engine=embed_model\n",
+        "    model=embed_model\n",
         ")\n",
         "\n",
         "# retrieve from Pinecone\n",
-        "xq = res['data'][0]['embedding']\n",
+        "xq = res.data[0].embedding\n",
         "\n",
         "# get relevant contexts (including the questions)\n",
         "res = index.query(xq, top_k=2, include_metadata=True)"
@@ -726,7 +543,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -734,135 +551,14 @@
         "id": "GH_DkmsNomww",
         "outputId": "fc84b83b-164d-45a7-9e80-9b11519bf25b"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "{'matches': [{'id': 'pNvujJ1XyeQ-t418.88',\n",
-              "              'metadata': {'channel_id': 'UCv83tO5cePwHMt1952IVVHw',\n",
-              "                           'end': 568.4,\n",
-              "                           'published': datetime.date(2021, 11, 24),\n",
-              "                           'start': 418.88,\n",
-              "                           'text': 'pairs of related sentences you can go '\n",
-              "                                   'ahead and actually try training or '\n",
-              "                                   'fine-tuning using NLI with multiple '\n",
-              "                                   \"negative ranking loss. If you don't have \"\n",
-              "                                   'that fine. Another option is that you have '\n",
-              "                                   'a semantic textual similarity data set or '\n",
-              "                                   'STS and what this is is you have so you '\n",
-              "                                   'have sentence A here, sentence B here and '\n",
-              "                                   'then you have a score from from 0 to 1 '\n",
-              "                                   'that tells you the similarity between '\n",
-              "                                   'those two scores and you would train this '\n",
-              "                                   'using something like cosine similarity '\n",
-              "                                   \"loss. Now if that's not an option and your \"\n",
-              "                                   'focus or use case is on building a '\n",
-              "                                   'sentence transformer for another language '\n",
-              "                                   'where there is no current sentence '\n",
-              "                                   'transformer you can use multilingual '\n",
-              "                                   'parallel data. So what I mean by that is '\n",
-              "                                   'so parallel data just means translation '\n",
-              "                                   'pairs so if you have for example a English '\n",
-              "                                   'sentence and then you have another '\n",
-              "                                   'language here so it can it can be anything '\n",
-              "                                   \"I'm just going to put XX and that XX is \"\n",
-              "                                   'your target language you can fine-tune a '\n",
-              "                                   'model using something called multilingual '\n",
-              "                                   'knowledge distillation and what that does '\n",
-              "                                   'is takes a monolingual model for example '\n",
-              "                                   'in English and using those translation '\n",
-              "                                   'pairs it distills the knowledge the '\n",
-              "                                   'semantic similarity knowledge from that '\n",
-              "                                   'monolingual English model into a '\n",
-              "                                   'multilingual model which can handle both '\n",
-              "                                   'English and your target language. So '\n",
-              "                                   \"they're three options quite popular very \"\n",
-              "                                   'common that you can go for and as a '\n",
-              "                                   'supervised methods the chances are that '\n",
-              "                                   'probably going to outperform anything you '\n",
-              "                                   'do with unsupervised training at least for '\n",
-              "                                   'now. So if none of those sound like '\n",
-              "                                   'something',\n",
-              "                           'title': 'Today Unsupervised Sentence Transformers, '\n",
-              "                                    'Tomorrow Skynet (how TSDAE works)',\n",
-              "                           'url': 'https://youtu.be/pNvujJ1XyeQ'},\n",
-              "              'score': 0.865277052,\n",
-              "              'sparseValues': {},\n",
-              "              'values': []},\n",
-              "             {'id': 'WS1uVMGhlWQ-t737.28',\n",
-              "              'metadata': {'channel_id': 'UCv83tO5cePwHMt1952IVVHw',\n",
-              "                           'end': 900.72,\n",
-              "                           'published': datetime.date(2021, 10, 20),\n",
-              "                           'start': 737.28,\n",
-              "                           'text': \"were actually more accurate. So we can't \"\n",
-              "                                   \"really do that. We can't use this what is \"\n",
-              "                                   'called a mean pooling approach. Or we '\n",
-              "                                   \"can't use it in its current form. Now the \"\n",
-              "                                   'solution to this problem was introduced by '\n",
-              "                                   'two people in 2019 Nils Reimers and Irenia '\n",
-              "                                   'Gurevich. They introduced what is the '\n",
-              "                                   'first sentence transformer or sentence '\n",
-              "                                   'BERT. And it was found that sentence BERT '\n",
-              "                                   'or S BERT outformed all of the previous '\n",
-              "                                   'Save the Art models on pretty much all '\n",
-              "                                   'benchmarks. Not all of them but most of '\n",
-              "                                   'them. And it did it in a very quick time. '\n",
-              "                                   'So if we compare it to BERT, if we wanted '\n",
-              "                                   'to find the most similar sentence pair '\n",
-              "                                   'from 10,000 sentences in that 2019 paper '\n",
-              "                                   'they found that with BERT that took 65 '\n",
-              "                                   'hours. With S BERT embeddings they could '\n",
-              "                                   'create all the embeddings in just around '\n",
-              "                                   'five seconds. And then they could compare '\n",
-              "                                   'all those with cosine similarity in 0.01 '\n",
-              "                                   \"seconds. So it's a lot faster. We go from \"\n",
-              "                                   '65 hours to just over five seconds which '\n",
-              "                                   'is I think pretty incredible. Now I think '\n",
-              "                                   \"that's pretty much all the context we need \"\n",
-              "                                   'behind sentence transformers. And what we '\n",
-              "                                   'do now is dive into a little bit of how '\n",
-              "                                   'they actually work. Now we said before we '\n",
-              "                                   'have the core transform models and what S '\n",
-              "                                   'BERT does is fine tunes on sentence pairs '\n",
-              "                                   'using what is called a Siamese '\n",
-              "                                   'architecture or Siamese network. What we '\n",
-              "                                   'mean by a Siamese network is that we have '\n",
-              "                                   'what we can see, what can view as two BERT '\n",
-              "                                   'models that are identical and the weights '\n",
-              "                                   'between those two models are tied. Now in '\n",
-              "                                   'reality when implementing this we just use '\n",
-              "                                   'a single BERT model. And what we do is we '\n",
-              "                                   'process one sentence, a sentence A through '\n",
-              "                                   'the model and then we process another '\n",
-              "                                   'sentence, sentence B through the model. '\n",
-              "                                   \"And that's the sentence pair. So with our \"\n",
-              "                                   'cross-linked we were processing the '\n",
-              "                                   'sentence pair together. We were putting '\n",
-              "                                   'them both together, processing them all at '\n",
-              "                                   'once. This time we process them '\n",
-              "                                   'separately. And during training what '\n",
-              "                                   'happens is the weights',\n",
-              "                           'title': 'Intro to Sentence Embeddings with '\n",
-              "                                    'Transformers',\n",
-              "                           'url': 'https://youtu.be/WS1uVMGhlWQ'},\n",
-              "              'score': 0.85855335,\n",
-              "              'sparseValues': {},\n",
-              "              'values': []}],\n",
-              " 'namespace': ''}"
-            ]
-          },
-          "execution_count": 16,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "res"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 30,
+      "execution_count": null,
       "metadata": {
         "id": "92NmGGJ1TKQp"
       },
@@ -871,13 +567,13 @@
         "limit = 3750\n",
         "\n",
         "def retrieve(query):\n",
-        "    res = openai.Embedding.create(\n",
+        "    res = client.embeddings.create(\n",
         "        input=[query],\n",
-        "        engine=embed_model\n",
+        "        model=embed_model\n",
         "    )\n",
         "\n",
         "    # retrieve from Pinecone\n",
-        "    xq = res['data'][0]['embedding']\n",
+        "    xq = res.data[0].embedding\n",
         "\n",
         "    # get relevant contexts\n",
         "    res = index.query(xq, top_k=3, include_metadata=True)\n",
@@ -913,7 +609,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 31,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -922,21 +618,7 @@
         "id": "LwsZuxiTvU2d",
         "outputId": "7e3acf8b-7356-41bc-8c9e-5405a21153e0"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "\"Answer the question based on the context below.\\n\\nContext:\\npairs of related sentences you can go ahead and actually try training or fine-tuning using NLI with multiple negative ranking loss. If you don't have that fine. Another option is that you have a semantic textual similarity data set or STS and what this is is you have so you have sentence A here, sentence B here and then you have a score from from 0 to 1 that tells you the similarity between those two scores and you would train this using something like cosine similarity loss. Now if that's not an option and your focus or use case is on building a sentence transformer for another language where there is no current sentence transformer you can use multilingual parallel data. So what I mean by that is so parallel data just means translation pairs so if you have for example a English sentence and then you have another language here so it can it can be anything I'm just going to put XX and that XX is your target language you can fine-tune a model using something called multilingual knowledge distillation and what that does is takes a monolingual model for example in English and using those translation pairs it distills the knowledge the semantic similarity knowledge from that monolingual English model into a multilingual model which can handle both English and your target language. So they're three options quite popular very common that you can go for and as a supervised methods the chances are that probably going to outperform anything you do with unsupervised training at least for now. So if none of those sound like something\\n\\n---\\n\\nwere actually more accurate. So we can't really do that. We can't use this what is called a mean pooling approach. Or we can't use it in its current form. Now the solution to this problem was introduced by two people in 2019 Nils Reimers and Irenia Gurevich. They introduced what is the first sentence transformer or sentence BERT. And it was found that sentence BERT or S BERT outformed all of the previous Save the Art models on pretty much all benchmarks. Not all of them but most of them. And it did it in a very quick time. So if we compare it to BERT, if we wanted to find the most similar sentence pair from 10,000 sentences in that 2019 paper they found that with BERT that took 65 hours. With S BERT embeddings they could create all the embeddings in just around five seconds. And then they could compare all those with cosine similarity in 0.01 seconds. So it's a lot faster. We go from 65 hours to just over five seconds which is I think pretty incredible. Now I think that's pretty much all the context we need behind sentence transformers. And what we do now is dive into a little bit of how they actually work. Now we said before we have the core transform models and what S BERT does is fine tunes on sentence pairs using what is called a Siamese architecture or Siamese network. What we mean by a Siamese network is that we have what we can see, what can view as two BERT models that are identical and the weights between those two models are tied. Now in reality when implementing this we just use a single BERT model. And what we do is we process one sentence, a sentence A through the model and then we process another sentence, sentence B through the model. And that's the sentence pair. So with our cross-linked we were processing the sentence pair together. We were putting them both together, processing them all at once. This time we process them separately. And during training what happens is the weights\\n\\n---\\n\\nTransformer-based Sequential Denoising Autoencoder. So what we'll do is jump straight into it and take a look at where we might want to use this training approach and and how we can actually implement it. So the first question we need to ask is do we really need to resort to unsupervised training? Now what we're going to do here is just have a look at a few of the most popular training approaches and what sort of data we need for that. So the first one we're looking at here is Natural Language Inference or NLI and NLI requires that we have pairs of sentences that are labeled as either contradictory, neutral which means they're not necessarily related or as entailing or as inferring each other. So you have pairs that entail each other so they are both very similar pairs that are neutral and also pairs that are contradictory. And this is the traditional NLI data. Now using another version of fine-tuning with NLI called a multiple negatives ranking loss you can get by with only entailment pairs so pairs that are related to each other or positive pairs and it can also use contradictory pairs to improve the performance of training as well but you don't need it. So if you have positive pairs of related sentences you can go ahead and actually try training or fine-tuning using NLI with multiple negative ranking loss. If you don't have that fine. Another option is that you have a semantic textual similarity data set or STS and what this is is you have so you have sentence A here, sentence B\\n\\nQuestion: Which training method should I use for sentence transformers when I only have pairs of related sentences?\\nAnswer:\""
-            ]
-          },
-          "execution_count": 31,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "# first we retrieve relevant items from Pinecone\n",
         "query_with_contexts = retrieve(query)\n",
@@ -945,7 +627,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 32,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -954,21 +636,7 @@
         "id": "ioDVGF7lkDQL",
         "outputId": "88bbbd48-89b1-4485-f511-cc5014bf3a5b"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "'You should use Natural Language Inference (NLI) with multiple negative ranking loss.'"
-            ]
-          },
-          "execution_count": 32,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "# then we complete the context-infused query\n",
         "complete(query_with_contexts)"

--- a/examples/vector_databases/pinecone/Gen_QA.ipynb
+++ b/examples/vector_databases/pinecone/Gen_QA.ipynb
@@ -13,7 +13,7 @@
         "\n",
         "In this notebook we will learn how to query relevant contexts to our queries from Pinecone, and pass these to a generative OpenAI model to generate an answer backed by real data sources.\n",
         "\n",
-        "A common problem with using GPT-3 to factually answer questions is that GPT-3 can sometimes make things up. The GPT models have a broad range of general knowledge, but this does not necessarily apply to more specific information. For that we use the Pinecone vector database as our _\"external knowledge base\"_ — like *long-term memory* for GPT-3.\n",
+        "A common problem with using GPT-3 to factually answer questions is that GPT-3 can sometimes make things up. The GPT models have a broad range of general knowledge, but this does not necessarily apply to more specific information. For that we use the Pinecone vector database as our _\"external knowledge base\"_ \u2014 like *long-term memory* for GPT-3.\n",
         "\n",
         "Required installs for this notebook are:"
       ]
@@ -236,7 +236,7 @@
       },
       "outputs": [],
       "source": [
-        "res.keys()"
+        "res.model_dump().keys()"
       ]
     },
     {
@@ -260,7 +260,7 @@
       },
       "outputs": [],
       "source": [
-        "len(res['data'])"
+        "len(res.data)"
       ]
     },
     {
@@ -275,7 +275,7 @@
       },
       "outputs": [],
       "source": [
-        "len(res['data'][0]['embedding']), len(res['data'][1]['embedding'])"
+        "len(res.data[0].embedding), len(res.data[1].embedding)"
       ]
     },
     {
@@ -430,7 +430,7 @@
         "    # if does not exist, create index\n",
         "    pinecone.create_index(\n",
         "        index_name,\n",
-        "        dimension=len(res['data'][0]['embedding']),\n",
+        "        dimension=len(res.data[0].embedding),\n",
         "        metric='cosine',\n",
         "        metadata_config={'indexed': ['channel_id', 'published']}\n",
         "    )\n",

--- a/examples/vector_databases/pinecone/Using_Pinecone_for_embeddings_search.ipynb
+++ b/examples/vector_databases/pinecone/Using_Pinecone_for_embeddings_search.ipynb
@@ -42,32 +42,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "8d8810f9",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: pinecone-client in /Users/colin.jarvis/Documents/dev/cookbook/openai-cookbook/vector_db/lib/python3.10/site-packages (2.2.2)\n",
-      "Requirement already satisfied: requests>=2.19.0 in /Users/colin.jarvis/Documents/dev/cookbook/openai-cookbook/vector_db/lib/python3.10/site-packages (from pinecone-client) (2.31.0)\n",
-      "Requirement already satisfied: pyyaml>=5.4 in /Users/colin.jarvis/Documents/dev/cookbook/openai-cookbook/vector_db/lib/python3.10/site-packages (from pinecone-client) (6.0)\n",
-      "Requirement already satisfied: loguru>=0.5.0 in /Users/colin.jarvis/Documents/dev/cookbook/openai-cookbook/vector_db/lib/python3.10/site-packages (from pinecone-client) (0.7.0)\n",
-      "Requirement already satisfied: typing-extensions>=3.7.4 in /Users/colin.jarvis/Documents/dev/cookbook/openai-cookbook/vector_db/lib/python3.10/site-packages (from pinecone-client) (4.5.0)\n",
-      "Requirement already satisfied: dnspython>=2.0.0 in /Users/colin.jarvis/Documents/dev/cookbook/openai-cookbook/vector_db/lib/python3.10/site-packages (from pinecone-client) (2.3.0)\n",
-      "Requirement already satisfied: python-dateutil>=2.5.3 in /Users/colin.jarvis/Documents/dev/cookbook/openai-cookbook/vector_db/lib/python3.10/site-packages (from pinecone-client) (2.8.2)\n",
-      "Requirement already satisfied: urllib3>=1.21.1 in /Users/colin.jarvis/Documents/dev/cookbook/openai-cookbook/vector_db/lib/python3.10/site-packages (from pinecone-client) (1.26.16)\n",
-      "Requirement already satisfied: tqdm>=4.64.1 in /Users/colin.jarvis/Documents/dev/cookbook/openai-cookbook/vector_db/lib/python3.10/site-packages (from pinecone-client) (4.65.0)\n",
-      "Requirement already satisfied: numpy>=1.22.0 in /Users/colin.jarvis/Documents/dev/cookbook/openai-cookbook/vector_db/lib/python3.10/site-packages (from pinecone-client) (1.25.0)\n",
-      "Requirement already satisfied: six>=1.5 in /Users/colin.jarvis/Documents/dev/cookbook/openai-cookbook/vector_db/lib/python3.10/site-packages (from python-dateutil>=2.5.3->pinecone-client) (1.16.0)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /Users/colin.jarvis/Documents/dev/cookbook/openai-cookbook/vector_db/lib/python3.10/site-packages (from requests>=2.19.0->pinecone-client) (3.1.0)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in /Users/colin.jarvis/Documents/dev/cookbook/openai-cookbook/vector_db/lib/python3.10/site-packages (from requests>=2.19.0->pinecone-client) (3.4)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /Users/colin.jarvis/Documents/dev/cookbook/openai-cookbook/vector_db/lib/python3.10/site-packages (from requests>=2.19.0->pinecone-client) (2023.5.7)\n",
-      "Requirement already satisfied: wget in /Users/colin.jarvis/Documents/dev/cookbook/openai-cookbook/vector_db/lib/python3.10/site-packages (3.2)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# We'll need to install the Pinecone client\n",
     "!pip install pinecone-client\n",
@@ -78,21 +56,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "5be94df6",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/colin.jarvis/Documents/dev/cookbook/openai-cookbook/vector_db/lib/python3.10/site-packages/pinecone/index.py:4: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
-      "  from tqdm.autonotebook import tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import openai\n",
+    "from openai import OpenAI\n",
     "\n",
     "from typing import List, Iterator\n",
     "import pandas as pd\n",
@@ -104,8 +73,11 @@
     "# Pinecone's client library for Python\n",
     "import pinecone\n",
     "\n",
+    "# Reads OPENAI_API_KEY from the environment by default.\n",
+    "client = OpenAI()\n",
+    "\n",
     "# I've set this to our new embeddings model, this can be changed to the embedding model of your choice\n",
-    "EMBEDDING_MODEL = \"text-embedding-3-small\"\n",
+    "EMBEDDING_MODEL = \"text-embedding-ada-002\"\n",
     "\n",
     "# Ignore unclosed SSL socket warnings - optional in case you get these errors\n",
     "import warnings\n",
@@ -151,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "70bbd8ba",
    "metadata": {},
    "outputs": [],
@@ -161,137 +133,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "1721e45d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>url</th>\n",
-       "      <th>title</th>\n",
-       "      <th>text</th>\n",
-       "      <th>title_vector</th>\n",
-       "      <th>content_vector</th>\n",
-       "      <th>vector_id</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>https://simple.wikipedia.org/wiki/April</td>\n",
-       "      <td>April</td>\n",
-       "      <td>April is the fourth month of the year in the J...</td>\n",
-       "      <td>[0.001009464613161981, -0.020700545981526375, ...</td>\n",
-       "      <td>[-0.011253940872848034, -0.013491976074874401,...</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>https://simple.wikipedia.org/wiki/August</td>\n",
-       "      <td>August</td>\n",
-       "      <td>August (Aug.) is the eighth month of the year ...</td>\n",
-       "      <td>[0.0009286514250561595, 0.000820168002974242, ...</td>\n",
-       "      <td>[0.0003609954728744924, 0.007262262050062418, ...</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>6</td>\n",
-       "      <td>https://simple.wikipedia.org/wiki/Art</td>\n",
-       "      <td>Art</td>\n",
-       "      <td>Art is a creative activity that expresses imag...</td>\n",
-       "      <td>[0.003393713850528002, 0.0061537534929811954, ...</td>\n",
-       "      <td>[-0.004959689453244209, 0.015772193670272827, ...</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>8</td>\n",
-       "      <td>https://simple.wikipedia.org/wiki/A</td>\n",
-       "      <td>A</td>\n",
-       "      <td>A or a is the first letter of the English alph...</td>\n",
-       "      <td>[0.0153952119871974, -0.013759135268628597, 0....</td>\n",
-       "      <td>[0.024894846603274345, -0.022186409682035446, ...</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>9</td>\n",
-       "      <td>https://simple.wikipedia.org/wiki/Air</td>\n",
-       "      <td>Air</td>\n",
-       "      <td>Air refers to the Earth's atmosphere. Air is a...</td>\n",
-       "      <td>[0.02224554680287838, -0.02044147066771984, -0...</td>\n",
-       "      <td>[0.021524671465158463, 0.018522677943110466, -...</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   id                                       url   title  \\\n",
-       "0   1   https://simple.wikipedia.org/wiki/April   April   \n",
-       "1   2  https://simple.wikipedia.org/wiki/August  August   \n",
-       "2   6     https://simple.wikipedia.org/wiki/Art     Art   \n",
-       "3   8       https://simple.wikipedia.org/wiki/A       A   \n",
-       "4   9     https://simple.wikipedia.org/wiki/Air     Air   \n",
-       "\n",
-       "                                                text  \\\n",
-       "0  April is the fourth month of the year in the J...   \n",
-       "1  August (Aug.) is the eighth month of the year ...   \n",
-       "2  Art is a creative activity that expresses imag...   \n",
-       "3  A or a is the first letter of the English alph...   \n",
-       "4  Air refers to the Earth's atmosphere. Air is a...   \n",
-       "\n",
-       "                                        title_vector  \\\n",
-       "0  [0.001009464613161981, -0.020700545981526375, ...   \n",
-       "1  [0.0009286514250561595, 0.000820168002974242, ...   \n",
-       "2  [0.003393713850528002, 0.0061537534929811954, ...   \n",
-       "3  [0.0153952119871974, -0.013759135268628597, 0....   \n",
-       "4  [0.02224554680287838, -0.02044147066771984, -0...   \n",
-       "\n",
-       "                                      content_vector  vector_id  \n",
-       "0  [-0.011253940872848034, -0.013491976074874401,...          0  \n",
-       "1  [0.0003609954728744924, 0.007262262050062418, ...          1  \n",
-       "2  [-0.004959689453244209, 0.015772193670272827, ...          2  \n",
-       "3  [0.024894846603274345, -0.022186409682035446, ...          3  \n",
-       "4  [0.021524671465158463, 0.018522677943110466, -...          4  "
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "article_df.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "960b82af",
    "metadata": {},
    "outputs": [],
@@ -306,31 +158,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "a334ab8b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'pandas.core.frame.DataFrame'>\n",
-      "RangeIndex: 25000 entries, 0 to 24999\n",
-      "Data columns (total 7 columns):\n",
-      " #   Column          Non-Null Count  Dtype \n",
-      "---  ------          --------------  ----- \n",
-      " 0   id              25000 non-null  int64 \n",
-      " 1   url             25000 non-null  object\n",
-      " 2   title           25000 non-null  object\n",
-      " 3   text            25000 non-null  object\n",
-      " 4   title_vector    25000 non-null  object\n",
-      " 5   content_vector  25000 non-null  object\n",
-      " 6   vector_id       25000 non-null  object\n",
-      "dtypes: int64(1), object(6)\n",
-      "memory usage: 1.3+ MB\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "article_df.info(show_counts=True)"
    ]
@@ -354,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "92e6152a",
    "metadata": {},
    "outputs": [],
@@ -377,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "0a71c575",
    "metadata": {},
    "outputs": [],
@@ -409,21 +240,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "7ea9ad46",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['podcasts', 'wikipedia-articles']"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Pick a name for the new index\n",
     "index_name = 'wikipedia-articles'\n",
@@ -442,18 +262,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "5daeba00",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Uploading vectors to content namespace..\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Upsert content vectors in content namespace - this can take a few minutes\n",
     "print(\"Uploading vectors to content namespace..\")\n",
@@ -463,18 +275,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "5fc1b083",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Uploading vectors to title namespace..\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Upsert title vectors in title namespace - this can also take a few minutes\n",
     "print(\"Uploading vectors to title namespace..\")\n",
@@ -484,25 +288,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "f90c7fba",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'dimension': 1536,\n",
-       " 'index_fullness': 0.1,\n",
-       " 'namespaces': {'content': {'vector_count': 25000},\n",
-       "                'title': {'vector_count': 25000}},\n",
-       " 'total_vector_count': 50000}"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Check index size for each namespace to confirm all of our docs have loaded\n",
     "index.describe_index_stats()"
@@ -520,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "c8280363",
    "metadata": {},
    "outputs": [],
@@ -532,7 +321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "3c8c2aa1",
    "metadata": {},
    "outputs": [],
@@ -542,10 +331,10 @@
     "     namespace and prints results.'''\n",
     "\n",
     "    # Create vector embeddings based on the title column\n",
-    "    embedded_query = openai.Embedding.create(\n",
+    "    embedded_query = client.embeddings.create(\n",
     "                                            input=query,\n",
     "                                            model=EMBEDDING_MODEL,\n",
-    "                                            )[\"data\"][0]['embedding']\n",
+    "                                            ).data[0].embedding\n",
     "\n",
     "    # Query namespace passed as parameter using title vector\n",
     "    query_result = index.query(embedded_query, \n",
@@ -578,54 +367,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "3402b1b1",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Most similar results to modern art in Europe in \"title\" namespace:\n",
-      "\n",
-      "Museum of Modern Art (score = 0.875177085)\n",
-      "Western Europe (score = 0.867441177)\n",
-      "Renaissance art (score = 0.864156306)\n",
-      "Pop art (score = 0.860346854)\n",
-      "Northern Europe (score = 0.854658186)\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "query_output = query_article('modern art in Europe','title')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "64a3f90a",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Most similar results to Famous battles in Scottish history in \"content\" namespace:\n",
-      "\n",
-      "Battle of Bannockburn (score = 0.869336188)\n",
-      "Wars of Scottish Independence (score = 0.861470938)\n",
-      "1651 (score = 0.852588475)\n",
-      "First War of Scottish Independence (score = 0.84962213)\n",
-      "Robert I of Scotland (score = 0.846214116)\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "content_query_output = query_article(\"Famous battles in Scottish history\",'content')"
    ]


### PR DESCRIPTION
## Summary

Two of the three notebooks under `examples/vector_databases/pinecone/` still call removed pre-1.0 SDK methods and fail with `AttributeError: module 'openai' has no attribute 'Embedding'` (or `'Completion'`) on any current `openai>=1.0` install. This PR migrates both to the v1 client API, mirroring #2718 / #2719 / #2720 / #2721 (Kiwi's directory-by-directory sweep) and #2745 (Redis).

The third file in this directory, `GPT4_Retrieval_Augmentation.ipynb`, is already covered by Kiwi's open #2720 — no overlap.

### Files migrated

- `examples/vector_databases/pinecone/Gen_QA.ipynb` — seven cells: `openai.api_key`, `openai.Completion.create` (×3, including a `complete()` helper that fans out across the notebook), `openai.Embedding.create` (×3 across single-call, batch, and `retrieve()` helper).
- `examples/vector_databases/pinecone/Using_Pinecone_for_embeddings_search.ipynb` — one bug cell (`openai.Embedding.create` inside `query_article()`) plus the setup cell (replace `import openai` with `from openai import OpenAI` and instantiate a module-level `client`).

### Embedding model — deliberate revert in Using_Pinecone

`Using_Pinecone_for_embeddings_search.ipynb` ships with `EMBEDDING_MODEL = "text-embedding-3-small"`, but the precomputed embeddings blob it downloads in cell 5 (`https://cdn.openai.com/API/examples/data/vector_database_wikipedia_articles_embedded.zip`) was generated with `text-embedding-ada-002`. With the model mismatch the notebook's `query_article()` helper returns unrelated articles. This PR reverts the constant to `text-embedding-ada-002` so the notebook runs end-to-end as documented. A closed earlier attempt (#1355) flagged the same mismatch in 2024 — closure was stale-bot driven, the bug was never fixed.

If the preference is to keep `text-embedding-3-small` and rehost the precomputed blob with new embeddings, happy to back out this single-line revert.

`Gen_QA.ipynb` keeps `text-embedding-ada-002` (its existing value) since it computes embeddings live; no blob coupling there.

### Notebook hygiene

Output cells stripped, `execution_count` reset to `null` per CONTRIBUTING.md. `python3 .github/scripts/check_notebooks.py` passes locally:

```
Validating 3 notebook(s)...
All changed notebooks are valid.
```

Each file preserves its original JSON indent (Gen_QA uses 2, Using_Pinecone uses 1).