### PR TITLE
Fix corrupted khttps:// link in BigQuery vector search notebook

### DIFF
--- a/examples/chatgpt/rag-quickstart/gcp/Getting_started_with_bigquery_vector_search_and_openai.ipynb
+++ b/examples/chatgpt/rag-quickstart/gcp/Getting_started_with_bigquery_vector_search_and_openai.ipynb
@@ -231,7 +231,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We are going to use some techniques highlighted in [this cookbook](khttps://github.com/openai/openai-cookbook/blob/main/examples/Embedding_long_inputs.ipynb). This is a quick way to embed text, without taking into account variables like sections, using our vision model to describe images/graphs/diagrams, overlapping text between chunks for longer documents, etc. "
+    "We are going to use some techniques highlighted in [this cookbook](https://github.com/openai/openai-cookbook/blob/main/examples/Embedding_long_inputs.ipynb). This is a quick way to embed text, without taking into account variables like sections, using our vision model to describe images/graphs/diagrams, overlapping text between chunks for longer documents, etc. "
    ]
   },
   {


### PR DESCRIPTION
## Summary
A markdown link in `examples/chatgpt/rag-quickstart/gcp/Getting_started_with_bigquery_vector_search_and_openai.ipynb` had a stray leading `k` corrupting the URL scheme:

```
[this cookbook](khttps://github.com/openai/openai-cookbook/blob/main/examples/Embedding_long_inputs.ipynb)
```

`khttps://` is not a valid scheme, so the link is dead. Removed the stray `k`:

```
[this cookbook](https://github.com/openai/openai-cookbook/blob/main/examples/Embedding_long_inputs.ipynb)
```

## Motivation
Fixes a broken link (priority-0 per the repo's AGENTS.md review guidelines). The target notebook `examples/Embedding_long_inputs.ipynb` exists.

## Self-review
- Minimal diff (1 insertion, 1 deletion). Notebook still valid JSON.
- This was the only `khttps://` occurrence in the repo.
