### PR TITLE
Fix broken relative cross-notebook links (wrong path depth)

### DIFF
--- a/examples/third_party/Visualizing_embeddings_in_wandb.ipynb
+++ b/examples/third_party/Visualizing_embeddings_in_wandb.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "## Visualizing embeddings in W&B\n",
     "\n",
-    "We will upload the data to [Weights & Biases](http://wandb.ai) and use an [Embedding Projector](https://docs.wandb.ai/ref/app/features/panels/weave/embedding-projector) to visualize the embeddings using common dimension reduction algorithms like PCA, UMAP, and t-SNE. The dataset is created in the [Get_embeddings_from_dataset Notebook](Get_embeddings_from_dataset.ipynb)."
+    "We will upload the data to [Weights & Biases](http://wandb.ai) and use an [Embedding Projector](https://docs.wandb.ai/ref/app/features/panels/weave/embedding-projector) to visualize the embeddings using common dimension reduction algorithms like PCA, UMAP, and t-SNE. The dataset is created in the [Get_embeddings_from_dataset Notebook](../Get_embeddings_from_dataset.ipynb)."
    ]
   },
   {

--- a/examples/vector_databases/weaviate/Using_Weaviate_for_embeddings_search.ipynb
+++ b/examples/vector_databases/weaviate/Using_Weaviate_for_embeddings_search.ipynb
@@ -331,7 +331,7 @@
     "* for any CRUD operations\n",
     "* for semantic search\n",
     "\n",
-    "Check out the [Getting Started with Weaviate and OpenAI module cookbook](./weaviate/getting-started-with-weaviate-and-openai.ipynb) to learn step by step how to import and vectorize data in one step."
+    "Check out the [Getting Started with Weaviate and OpenAI module cookbook](./getting-started-with-weaviate-and-openai.ipynb) to learn step by step how to import and vectorize data in one step."
    ]
   },
   {


### PR DESCRIPTION
## Summary
Two relative links resolved to non-existent paths because the directory depth was wrong:

1. `examples/third_party/Visualizing_embeddings_in_wandb.ipynb` linked `Get_embeddings_from_dataset.ipynb`, but that file lives one level up in `examples/`. Fixed to `../Get_embeddings_from_dataset.ipynb`.
2. `examples/vector_databases/weaviate/Using_Weaviate_for_embeddings_search.ipynb` (already inside `.../weaviate/`) linked `./weaviate/getting-started-with-weaviate-and-openai.ipynb`, adding a spurious extra `weaviate/` segment. The target is a sibling in the same directory. Fixed to `./getting-started-with-weaviate-and-openai.ipynb`.

Both targets verified to exist at the corrected paths.

## Motivation
Fixes broken links (priority-0 per the repo's AGENTS.md review guidelines).

## Self-review
- Minimal diff (2 insertions, 2 deletions). Both notebooks still valid JSON.
- Only the relative path depth changed; link text untouched.
