### PR TITLE
Fix typos in session_memory.ipynb

### DIFF
--- a/examples/agents_sdk/session_memory.ipynb
+++ b/examples/agents_sdk/session_memory.ipynb
@@ -83,7 +83,7 @@
     "\n",
     "  - **Best when**\n",
     "\n",
-    "    - Your tasks in the conversation is indepentent from each other with non-overlapping context that does not reuqire carrying previous details further.\n",
+    "    - Your tasks in the conversation is independent from each other with non-overlapping context that does not require carrying previous details further.\n",
     "    - You need predictability, easy evals, and low latency (ops automations, CRM/API actions).\n",
     "    - The conversation’s useful context is local (recent steps matter far more than distant history).\n",
     "\n",
@@ -105,7 +105,7 @@
     "\n",
     "  - **Best when**\n",
     "\n",
-    "    - You have use cases where your tasks needs context collected accross the flow such as  planning/coaching, RAG-heavy analysis, policy Q&A.\n",
+    "    - You have use cases where your tasks needs context collected across the flow such as  planning/coaching, RAG-heavy analysis, policy Q&A.\n",
     "    - You need continuity over long horizons and carry the important details further to solve related tasks.\n",
     "    - Sessions exceed N turns but must preserve decisions, IDs, and constraints reliably.\n",
     "<br>"

--- a/examples/agents_sdk/session_memory.ipynb
+++ b/examples/agents_sdk/session_memory.ipynb
@@ -83,7 +83,7 @@
     "\n",
     "  - **Best when**\n",
     "\n",
-    "    - Your tasks in the conversation is independent from each other with non-overlapping context that does not require carrying previous details further.\n",
+    "    - Your tasks in the conversation are independent from each other with non-overlapping context that does not require carrying previous details further.\n",
     "    - You need predictability, easy evals, and low latency (ops automations, CRM/API actions).\n",
     "    - The conversation’s useful context is local (recent steps matter far more than distant history).\n",
     "\n",
@@ -105,7 +105,7 @@
     "\n",
     "  - **Best when**\n",
     "\n",
-    "    - You have use cases where your tasks needs context collected across the flow such as  planning/coaching, RAG-heavy analysis, policy Q&A.\n",
+    "    - You have use cases where your tasks need context collected across the flow such as planning/coaching, RAG-heavy analysis, policy Q&A.\n",
     "    - You need continuity over long horizons and carry the important details further to solve related tasks.\n",
     "    - Sessions exceed N turns but must preserve decisions, IDs, and constraints reliably.\n",
     "<br>"


### PR DESCRIPTION
## Summary

Fixes three spelling errors in the guidance markdown cell of `examples/agents_sdk/session_memory.ipynb`:

| current | corrected |
| --- | --- |
| indepentent | independent |
| reuqire | require |
| accross | across |

Docs/notebook-only change — corrects misspellings, no code or output changes. The notebook JSON still validates.