### PR TITLE
Fix typos in two example notebooks

### DIFF
--- a/examples/evaluation/How_to_evaluate_LLMs_for_SQL_generation.ipynb
+++ b/examples/evaluation/How_to_evaluate_LLMs_for_SQL_generation.ipynb
@@ -406,7 +406,7 @@
    "id": "a5fdc420-94cc-4e47-80e1-82bf51e44f2a",
    "metadata": {},
    "source": [
-    "As expected, we get an exception thrown from the `test_valid_schema` fucntion."
+    "As expected, we get an exception thrown from the `test_valid_schema` function."
    ]
   },
   {

--- a/examples/reasoning_function_calls.ipynb
+++ b/examples/reasoning_function_calls.ipynb
@@ -337,7 +337,7 @@
     "As such, we ought to define a general pattern which we can use to handle arbitrarily complex reasoning workflows:\n",
     "* At each step in the conversation, initialise a loop\n",
     "* If the response contains function calls, we must assume the reasoning is ongoing and we should feed the function results (and any intermediate reasoning) back into the model for further inference\n",
-    "* If there are no function calls and we instead receive a Reponse.output with a type of 'message', we can safely assume the agent has finished reasoning and we can break out of the loop"
+    "* If there are no function calls and we instead receive a Response.output with a type of 'message', we can safely assume the agent has finished reasoning and we can break out of the loop"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Two unambiguous spelling fixes in markdown cells:

| File | current | corrected |
| --- | --- | --- |
| `examples/reasoning_function_calls.ipynb` | Reponse.output | Response.output |
| `examples/evaluation/How_to_evaluate_LLMs_for_SQL_generation.ipynb` | fucntion | function |

"Reponse" refers to the Responses API `response.output` object (spelled correctly in the code cells); "fucntion" is a misspelling of "function" (spelled correctly 8× elsewhere in the same notebook). Notebook/markdown-only; both notebooks still validate as JSON. No code or output changes.