### PR TITLE
Fix walk eval validator rejecting valid failed rows with missing audio

### DIFF
--- a/examples/evals/realtime_evals/shared/scripts/validate_eval_output.py
+++ b/examples/evals/realtime_evals/shared/scripts/validate_eval_output.py
@@ -188,7 +188,7 @@ def _validate_walk_results(results: pd.DataFrame, results_path: Path) -> None:
         _parse_json_list(row.get("tool_calls", "[]"), field_name="tool_calls", row_number=row_number)
         _optional_existing_path(
             row.get("audio_path", ""),
-            row_status="ok",
+            row_status=row_status,
             field_name="audio_path",
             row_number=row_number,
         )

--- a/examples/evals/realtime_evals/tests/test_validation_scripts.py
+++ b/examples/evals/realtime_evals/tests/test_validation_scripts.py
@@ -196,3 +196,32 @@ def test_validate_output_rejects_missing_run_grade_mean(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="instruction_following_grade_mean"):
         validate_output("run", run_dir)
+
+
+def test_validate_walk_results_skips_missing_audio_for_failed_rows(tmp_path: Path) -> None:
+    """A failed walk row may reference a missing audio_path; validation must skip it.
+
+    Regression test: _validate_walk_results hard-coded row_status="ok" for the
+    audio_path existence check, so failed rows (whose audio_path legitimately
+    points to a non-existent file) raised ValueError instead of being skipped.
+    """
+    from shared.scripts.validate_eval_output import _validate_walk_results
+
+    missing_audio = str(tmp_path / "missing_audio.wav")
+    failed_row = {
+        "example_id": "ex_1",
+        "user_text": "hello",
+        "assistant_text": "",
+        "tool_calls": "[]",
+        "audio_path": missing_audio,
+        "event_log_path": "",
+        "status": "failed",
+    }
+
+    # Failed row with a missing audio file must validate without raising.
+    _validate_walk_results(pd.DataFrame([failed_row]), tmp_path / "results.csv")
+
+    # Control: the same missing path on an "ok" row must still be rejected.
+    ok_row = {**failed_row, "status": "ok"}
+    with pytest.raises(ValueError, match="audio_path"):
+        _validate_walk_results(pd.DataFrame([ok_row]), tmp_path / "results.csv")


### PR DESCRIPTION
## Problem

In `examples/evals/realtime_evals/shared/scripts/validate_eval_output.py`, `_validate_walk_results` hard-codes `row_status="ok"` for the `audio_path` existence check instead of forwarding the row's real status:

```python
row_status = str(row.get("status", "")).strip()
...
_optional_existing_path(
    row.get("audio_path", ""),
    row_status="ok",          # <-- should be row_status
    field_name="audio_path",
    row_number=row_number,
)
```

`_optional_existing_path` only skips the existence check when `row_status == "failed"`. Passing the literal `"ok"` forces the check even on failed rows. The walk harness (`walk_harness/run_realtime_evals.py`, `build_failed_result`) writes failed rows with an `audio_path` that points to a non-existent file (`missing_audio.wav`), so the validator raises `ValueError` on output the harness **legitimately produces**.

Every sibling check passes the real status — the crawl and run validators, **and the other two `_optional_existing_path` calls in `_validate_walk_results` itself** (`output_audio_path`, `event_log_path`) all use `row_status=row_status`. This one call was the outlier — a copy/paste slip.

## Fix

```python
    row_status=row_status,
```

## Verification

```
before:  pytest tests/test_validation_scripts.py::test_validate_walk_results_skips_missing_audio_for_failed_rows
         ValueError: `audio_path` in results row 2 points to a missing file: .../missing_audio.wav
after :  5 passed   (full tests/test_validation_scripts.py: 4 existing + 1 new)
```

Added a regression test asserting a failed walk row with a missing `audio_path` validates, while the same missing path on an `ok` row is still rejected.
