### PR TITLE
Fix Promptfoo migration cookbook publication date

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -3338,7 +3338,7 @@
   path: examples/evaluation/moving-from-openai-evals-to-promptfoo.md
   slug: moving-from-openai-evals-to-promptfoo
   description: Migrate supported OpenAI Evals evaluations to runnable Promptfoo configurations and preserve historical results.
-  date: 2026-05-27
+  date: 2026-06-03
   authors:
     - kkahadze-oai
   tags:


### PR DESCRIPTION
## Summary

Updates the publication date for the Promptfoo migration cookbook from May 27, 2026 to June 3, 2026.