### PR TITLE
Add Shashwat Jha to SchemaFlow authors

### DIFF
--- a/examples/partners/schemaflow_design_guide/schemaflow_cookbook.ipynb
+++ b/examples/partners/schemaflow_design_guide/schemaflow_cookbook.ipynb
@@ -5144,7 +5144,8 @@
     "- [Shikhar Kwatra](https://www.linkedin.com/in/shikharkwatra/)\n",
     "- [Atharva Joshi](https://www.linkedin.com/in/attharvaj3147/)\n",
     "- [Mohan Kocherlakota](https://www.linkedin.com/in/mohan-kocherlakota/)\n",
-    "- [Adam Horvath](https://www.linkedin.com/in/horadam/)\n"
+    "- [Adam Horvath](https://www.linkedin.com/in/horadam/)\n",
+    "- [Shashwat Jha](https://www.linkedin.com/in/shashjha/)\n"
    ]
   }
  ],

--- a/registry.yaml
+++ b/registry.yaml
@@ -14,6 +14,7 @@
     - Atharva Joshi
     - Mohan Kocherlakota
     - Adam Horvath
+    - Shashwat Jha
   tags:
     - partners
     - agents-sdk


### PR DESCRIPTION
## Summary
- add Shashwat Jha to the SchemaFlow cookbook author list in `registry.yaml`
- add Shashwat Jha to the notebook's rendered author list

## Validation
- `git diff --check`
- verified push auth with Secretive certificate-backed SSH config before pushing the branch