### PR TITLE
Archive stale cookbook entries

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -1023,6 +1023,7 @@
 - title: How to use functions with a knowledge base
   path: examples/How_to_call_functions_for_knowledge_retrieval.ipynb
   slug: how-to-call-functions-for-knowledge-retrieval
+  archived: true
   date: 2023-06-14
   authors:
     - colin-openai
@@ -3026,6 +3027,7 @@
 - title: GPT Actions library - Salesforce & Gong
   path: examples/chatgpt/gpt_actions_library/gpt_action_salesforce_gong.md
   slug: gpt-action-salesforce-gong
+  archived: true
   date: 2025-04-07
   authors:
     - girishd

--- a/registry.yaml
+++ b/registry.yaml
@@ -2338,6 +2338,7 @@
   tags:
     - chat
     - vision
+  archived: true
 
 - title: Synthetic data generation (Part 1)
   path: examples/SDG1.ipynb

--- a/registry.yaml
+++ b/registry.yaml
@@ -326,6 +326,7 @@
   path: examples/agents_sdk/session_memory.ipynb
   slug: session-memory
   date: 2025-09-09
+  archived: true
   authors:
     - emreokcular
   tags:
@@ -3248,6 +3249,7 @@
   slug: context-personalization
   description: Cookbook to build personalized agents with long-term memory state using the Agents SDK.
   date: 2026-01-05
+  archived: true
   authors:
     - emreokcular
   tags:

--- a/registry.yaml
+++ b/registry.yaml
@@ -841,6 +841,7 @@
 - title: Automating Dispute Management with Agents SDK and Stripe API
   path: examples/agents_sdk/dispute_agent.ipynb
   slug: dispute-agent
+  archived: true
   date: 2025-03-17
   authors:
     - danbell-openai

--- a/registry.yaml
+++ b/registry.yaml
@@ -2755,7 +2755,6 @@
     - msingh-openai
   tags:
     - completions
-  archived: true
 
 - title: Prompt Caching 101
   path: examples/Prompt_Caching101.ipynb
@@ -2806,7 +2805,6 @@
   tags:
     - completions
     - audio
-  archived: true
 
 - title: Enhance your prompts with meta prompting
   path: examples/Enhance_your_prompts_with_meta_prompting.ipynb
@@ -2887,7 +2885,6 @@
   tags:
     - completions
     - vision
-  archived: true
 
 - title: GPT Actions library - Workday
   path: examples/chatgpt/gpt_actions_library/gpt_action_workday.md

--- a/registry.yaml
+++ b/registry.yaml
@@ -1043,6 +1043,7 @@
   tags:
     - completions
     - functions
+  archived: true
 
 - title: How to count tokens with Tiktoken
   path: examples/How_to_count_tokens_with_tiktoken.ipynb

--- a/registry.yaml
+++ b/registry.yaml
@@ -2428,6 +2428,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-data
+  archived: true
 
 - title: Data Extraction and Transformation in ELT Workflows using GPT-4o as an OCR Alternative
   path: examples/Data_extraction_transformation.ipynb

--- a/registry.yaml
+++ b/registry.yaml
@@ -890,6 +890,7 @@
     - completions
     - tiktoken
     - fine-tuning
+  archived: true
 
 - title: Classification using embeddings
   path: examples/Classification_using_embeddings.ipynb
@@ -994,6 +995,7 @@
   tags:
     - completions
     - functions
+  archived: true
 
 - title: Using embeddings
   path: examples/Using_embeddings.ipynb
@@ -1060,6 +1062,7 @@
   tags:
     - completions
     - fine-tuning
+  archived: true
 
 - title: How to format inputs to ChatGPT models
   path: examples/How_to_format_inputs_to_ChatGPT_models.ipynb
@@ -1122,6 +1125,7 @@
   tags:
     - embeddings
     - completions
+  archived: true
 
 - title: Question answering using embeddings-based search
   path: examples/Question_answering_using_embeddings.ipynb
@@ -1165,6 +1169,7 @@
   tags:
     - embeddings
     - completions
+  archived: true
 
 - title: Semantic text search using embeddings
   path: examples/Semantic_text_search_using_embeddings.ipynb
@@ -1306,6 +1311,7 @@
     - kristapratico
   tags:
     - completions
+  archived: true
 
 - title: Azure embeddings example
   path: examples/azure/embeddings.ipynb
@@ -1328,6 +1334,7 @@
   tags:
     - completions
     - functions
+  archived: true
 
 - title: Translate a book writen in LaTeX from Slovenian into English
   path: examples/book_translation/translate_latex_book.ipynb
@@ -1370,6 +1377,7 @@
   tags:
     - embeddings
     - completions
+  archived: true
 
 - title: Getting Started with OpenAI Evals
   path: examples/evaluation/Getting_Started_with_OpenAI_Evals.ipynb
@@ -1380,6 +1388,7 @@
     - shyamal-anadkat
   tags:
     - completions
+  archived: true
 
 - title: Developing Hallucination Guardrails
   path: examples/Developing_hallucination_guardrails.ipynb
@@ -1390,6 +1399,7 @@
     - royziv11
   tags:
     - guardrails
+  archived: true
 
 - title: Fine-Tuned Q&A - collect data
   path: examples/fine-tuned_qa/olympics-1-collect-data.ipynb
@@ -1446,6 +1456,7 @@
   tags:
     - embeddings
     - completions
+  archived: true
 
 - title: Vector databases
   path: examples/vector_databases/README.md
@@ -1456,6 +1467,7 @@
     - moizsajid
   tags:
     - embeddings
+  archived: true
 
 - title: Using PolarDB-PG as a vector database for OpenAI embeddings
   path: >-
@@ -1518,6 +1530,7 @@
     - farzad528
   tags:
     - embeddings
+  archived: true
 
 - title: Philosophy with vector embeddings, OpenAI and Cassandra / Astra DB
   path: examples/vector_databases/cassandra_astradb/Philosophical_Quotes_CQL.ipynb
@@ -1558,6 +1571,7 @@
     - atroyn
   tags:
     - embeddings
+  archived: true
 
 - title: Robust question answering with Chroma and OpenAI
   path: examples/vector_databases/chroma/hyde-with-chroma-and-openai.ipynb
@@ -1579,6 +1593,7 @@
   tags:
     - embeddings
     - completions
+  archived: true
 
 - title: Retrieval augmented generation using Elasticsearch and OpenAI
   path: >-
@@ -1590,6 +1605,7 @@
   tags:
     - embeddings
     - completions
+  archived: true
 
 - title: Semantic search using Elasticsearch and OpenAI
   path: examples/vector_databases/elasticsearch/elasticsearch-semantic-search.ipynb
@@ -1599,6 +1615,7 @@
     - leemthompo
   tags:
     - embeddings
+  archived: true
 
 - title: Using Hologres as a vector database for OpenAI embeddings
   path: >-
@@ -1717,6 +1734,7 @@
     - colin-openai
   tags:
     - embeddings
+  archived: true
 
 - title: Using Qdrant as a vector database for OpenAI embeddings
   path: >-
@@ -1746,6 +1764,7 @@
     - kacperlukawski
   tags:
     - embeddings
+  archived: true
 
 - title: Redis
   path: examples/vector_databases/redis/README.md
@@ -1766,6 +1785,7 @@
     - colin-openai
   tags:
     - embeddings
+  archived: true
 
 - title: Using Redis as a vector database with OpenAI
   path: examples/vector_databases/redis/getting-started-with-redis-and-openai.ipynb
@@ -2026,6 +2046,7 @@
     - danieltprice
   tags:
     - embeddings
+  archived: true
 
 - title: Question answering with LangChain, Deep Lake, & OpenAI
   path: examples/vector_databases/deeplake/deeplake_langchain_qa.ipynb
@@ -2035,6 +2056,7 @@
     - FayazRahman
   tags:
     - embeddings
+  archived: true
 
 - title: Fine-tuning OpenAI models with Weights & Biases
   path: examples/third_party/GPT_finetuning_with_wandb.ipynb
@@ -2046,6 +2068,7 @@
     - tiktoken
     - completions
     - fine-tuning
+  archived: true
 
 - title: OpenAI API Monitoring with Weights & Biases Weave
   path: examples/third_party/Openai_monitoring_with_wandb_weave.ipynb
@@ -2067,6 +2090,7 @@
     - completions
     - functions
     - agents
+  archived: true
 
 - title: Named Entity Recognition to Enrich Text
   path: examples/Named_Entity_Recognition_to_enrich_text.ipynb
@@ -2077,6 +2101,7 @@
   tags:
     - completions
     - functions
+  archived: true
 
 - title: What makes documentation good
   path: articles/what_makes_documentation_good.md
@@ -2098,6 +2123,7 @@
   tags:
     - completions
     - functions
+  archived: true
 
 - title: Fine tuning for function calling
   path: examples/Fine_tuning_for_function_calling.ipynb
@@ -2112,6 +2138,7 @@
     - completions
     - functions
     - fine-tuning
+  archived: true
 
 - title: Processing and narrating a video with GPT-4.1-mini's visual capabilities and GPT-4o TTS API
   path: examples/GPT_with_vision_for_video_understanding.ipynb
@@ -2143,6 +2170,7 @@
     - shyamal-anadkat
   tags:
     - completions
+  archived: true
 
 - title: Assistants API Overview (Python SDK)
   path: examples/Assistants_API_overview_python.ipynb
@@ -2166,6 +2194,7 @@
     - completions
     - functions
     - agents
+  archived: true
 
 - title: MongoDB Atlas Vector Search
   path: examples/vector_databases/mongodb_atlas/README.md
@@ -2186,6 +2215,7 @@
   tags:
     - embeddings
     - completions
+  archived: true
 
 - title: Evaluate RAG with LlamaIndex
   path: examples/evaluation/Evaluate_RAG_with_LlamaIndex.ipynb
@@ -2196,6 +2226,7 @@
   tags:
     - embeddings
     - completions
+  archived: true
 
 - title: RAG with a Graph database
   path: examples/RAG_with_graph_db.ipynb
@@ -2206,6 +2237,7 @@
   tags:
     - embeddings
     - completions
+  archived: true
 
 - title: Supabase Vector Database
   path: examples/vector_databases/supabase/README.md
@@ -2215,6 +2247,7 @@
     - ggrn
   tags:
     - embeddings
+  archived: true
 
 - title: Semantic search using Supabase Vector
   path: examples/vector_databases/supabase/semantic-search.mdx
@@ -2224,6 +2257,7 @@
     - ggrn
   tags:
     - embeddings
+  archived: true
 
 - title: How to implement LLM guardrails
   path: examples/How_to_use_guardrails.ipynb
@@ -2233,6 +2267,7 @@
     - colin-openai
   tags:
     - guardrails
+  archived: true
 
 - title: How to combine GPT4o mini with RAG to create a clothing matchmaker app
   path: examples/How_to_combine_GPT4o_with_RAG_Outfit_Assistant.ipynb
@@ -2243,6 +2278,7 @@
   tags:
     - vision
     - embeddings
+  archived: true
 
 - title: How to parse PDF docs for RAG
   path: examples/Parse_PDF_docs_for_RAG.ipynb
@@ -2254,6 +2290,7 @@
   tags:
     - vision
     - embeddings
+  archived: true
 
 - title: Using GPT4o mini to tag and caption images
   path: examples/Tag_caption_images_with_GPT4V.ipynb
@@ -2264,6 +2301,7 @@
   tags:
     - vision
     - embeddings
+  archived: true
 
 - title: How to use the moderation API
   path: examples/How_to_use_moderation.ipynb
@@ -2273,6 +2311,7 @@
     - teomusatoiu
   tags:
     - moderation
+  archived: true
 
 - title: Summarizing Long Documents
   path: examples/Summarizing_long_documents.ipynb
@@ -2282,6 +2321,7 @@
     - joe-at-openai
   tags:
     - chat
+  archived: true
 
 - title: Using GPT4 Vision with Function Calling
   path: examples/multimodal/Using_GPT4_Vision_With_Function_Calling.ipynb
@@ -2302,6 +2342,7 @@
     - dylanra-openai
   tags:
     - completions
+  archived: true
 
 - title: CLIP embeddings to improve multimodal RAG with GPT-4 Vision
   path: examples/custom_image_embedding_search.ipynb
@@ -2312,6 +2353,7 @@
   tags:
     - vision
     - embeddings
+  archived: true
 
 - title: Batch processing with the Batch API
   path: examples/batch_processing.ipynb
@@ -2322,6 +2364,7 @@
   tags:
     - batch
     - completions
+  archived: true
 
 - title: Using tool required for customer service
   path: examples/Using_tool_required_for_customer_service.ipynb
@@ -2332,6 +2375,7 @@
   tags:
     - completions
     - functions
+  archived: true
 
 - title: Introduction to GPT-4o and GPT-4o mini
   path: examples/gpt4o/introduction_to_gpt4o.ipynb
@@ -2343,6 +2387,7 @@
     - completions
     - vision
     - whisper
+  archived: true
 
 - title: Azure AI Search with Azure Functions and GPT Actions in ChatGPT
   path: examples/chatgpt/rag-quickstart/azure/Azure_AI_Search_with_Azure_Functions_and_GPT_Actions_in_ChatGPT.ipynb
@@ -2356,6 +2401,7 @@
     - tiktoken
     - completions
     - chatgpt-and-api
+  archived: true
 
 - title: GPT Actions library - getting started
   path: examples/chatgpt/gpt_actions_library/.gpt_action_getting_started.ipynb
@@ -2366,6 +2412,7 @@
   tags:
     - gpt-actions-library
     - chatgpt
+  archived: true
 
 - title: GPT Actions library - BigQuery
   path: examples/chatgpt/gpt_actions_library/gpt_action_bigquery.ipynb
@@ -2387,6 +2434,7 @@
   tags:
     - completions
     - vision
+  archived: true
 
 - title: GPT Actions library - Outlook
   path: examples/chatgpt/gpt_actions_library/gpt_action_outlook.ipynb
@@ -2398,6 +2446,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-communication
+  archived: true
 
 - title: GPT Actions library - Sharepoint (Return Docs)
   path: examples/chatgpt/gpt_actions_library/gpt_action_sharepoint_doc.ipynb
@@ -2409,6 +2458,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-productivity
+  archived: true
 
 - title: GPT Actions library - Sharepoint (Return Text)
   path: examples/chatgpt/gpt_actions_library/gpt_action_sharepoint_text.ipynb
@@ -2420,6 +2470,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-productivity
+  archived: true
 
 - title: GPT Actions library (Middleware) - Azure Functions
   path: examples/chatgpt/gpt_actions_library/gpt_middleware_azure_function.ipynb
@@ -2431,6 +2482,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-middleware
+  archived: true
 
 - title: GPT Actions library - Canvas Learning Management System
   path: examples/chatgpt/gpt_actions_library/gpt_action_canvas.md
@@ -2442,6 +2494,7 @@
   tags:
     - gpt-actions-library
     - chatgpt
+  archived: true
 
 - title: GPT Actions library - Salesforce
   path: examples/chatgpt/gpt_actions_library/gpt_action_salesforce.ipynb
@@ -2452,6 +2505,7 @@
   tags:
     - gpt-actions-library
     - chatgpt
+  archived: true
 
 - title: GPT Actions library - Gmail
   path: examples/chatgpt/gpt_actions_library/gpt_action_gmail.ipynb
@@ -2463,6 +2517,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-communication
+  archived: true
 
 - title: GPT Actions library - Jira
   path: examples/chatgpt/gpt_actions_library/gpt_action_jira.ipynb
@@ -2474,6 +2529,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-productivity
+  archived: true
 
 - title: GPT Actions library - Notion
   path: examples/chatgpt/gpt_actions_library/gpt_action_notion.ipynb
@@ -2485,6 +2541,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-productivity
+  archived: true
 
 - title: GPT Actions library - Confluence
   path: examples/chatgpt/gpt_actions_library/gpt_action_confluence.ipynb
@@ -2496,6 +2553,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-productivity
+  archived: true
 
 - title: GPT Actions library - SQL Database
   path: examples/chatgpt/gpt_actions_library/gpt_action_sql_database.ipynb
@@ -2507,6 +2565,7 @@
     - chatgpt
     - gpt-actions-library
     - chatgpt-data
+  archived: true
 
 - title: GPT Actions library - Box
   path: examples/chatgpt/gpt_actions_library/gpt_action_box.ipynb
@@ -2518,6 +2577,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-productivity
+  archived: true
 
 - title: GCP BigQuery Vector Search with GCP Functions and GPT Actions in ChatGPT
   path: examples/chatgpt/rag-quickstart/gcp/Getting_started_with_bigquery_vector_search_and_openai.ipynb
@@ -2532,6 +2592,7 @@
     - tiktoken
     - completions
     - chatgpt-and-api
+  archived: true
 
 - title: GPT Actions library - Zapier
   path: examples/chatgpt/gpt_actions_library/gpt_action_zapier.ipynb
@@ -2543,6 +2604,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-middleware
+  archived: true
 
 - title: Structured Outputs for Multi-Agent Systems
   path: examples/Structured_outputs_multi_agent.ipynb
@@ -2554,6 +2616,7 @@
     - completions
     - functions
     - agents
+  archived: true
 
 - title: Introduction to Structured Outputs
   path: examples/Structured_Outputs_Intro.ipynb
@@ -2575,6 +2638,7 @@
     - chatgpt
     - gpt-actions-library
     - chatgpt-middleware
+  archived: true
 
 - title: GPT Actions library - AWS Redshift
   path: examples/chatgpt/gpt_actions_library/gpt_action_redshift.ipynb
@@ -2586,6 +2650,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-data
+  archived: true
 
 - title: GPT Actions library - AWS Middleware
   path: examples/chatgpt/gpt_actions_library/gpt_middleware_aws_function.ipynb
@@ -2597,6 +2662,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-middleware
+  archived: true
 
 - title: GPT Actions library - Google Drive
   path: examples/chatgpt/gpt_actions_library/gpt_action_google_drive.ipynb
@@ -2608,6 +2674,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-productivity
+  archived: true
 
 - title: GPT Actions library - Snowflake Direct
   path: examples/chatgpt/gpt_actions_library/gpt_action_snowflake_direct.ipynb
@@ -2630,6 +2697,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-data
+  archived: true
 
 - title: GPT Actions library - Retool Workflow
   path: examples/chatgpt/gpt_actions_library/gpt_action_retool_workflow.md
@@ -2641,6 +2709,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-middleware
+  archived: true
 
 - title: Using reasoning for data validation
   path: examples/o1/Using_reasoning_for_data_validation.ipynb
@@ -2651,6 +2720,7 @@
   tags:
     - completions
     - reasoning
+  archived: true
 
 - title: Using reasoning for routine generation
   path: examples/o1/Using_reasoning_for_routine_generation.ipynb
@@ -2661,6 +2731,7 @@
   tags:
     - completions
     - reasoning
+  archived: true
 
 - title: Using chained calls for o1 structured outputs
   path: examples/o1/Using_chained_calls_for_o1_structured_outputs.ipynb
@@ -2671,6 +2742,7 @@
   tags:
     - completions
     - reasoning
+  archived: true
 
 - title: Building a Bring Your Own Browser (BYOB) Tool for Web Browsing and Summarization
   path: examples/third_party/Web_search_with_google_api_bring_your_own_browser_tool.ipynb
@@ -2680,6 +2752,7 @@
     - msingh-openai
   tags:
     - completions
+  archived: true
 
 - title: Prompt Caching 101
   path: examples/Prompt_Caching101.ipynb
@@ -2693,6 +2766,7 @@
     - cost
     - prompt caching
     - completions
+  archived: true
 
 - title: GPT Actions library - Google Ads via Adzviser
   path: examples/chatgpt/gpt_actions_library/gpt_action_googleads_adzviser.ipynb
@@ -2706,6 +2780,7 @@
     - chatgpt-data
     - chatgpt-productivity
     - chatgpt-middleware
+  archived: true
 
 - title: Leveraging model distillation to fine-tune a model
   path: examples/Leveraging_model_distillation_to_fine-tune_a_model.ipynb
@@ -2717,6 +2792,7 @@
   tags:
     - completions
     - fine-tuning
+  archived: true
 
 - title: Voice Translation into Different Languages
   path: examples/voice_solutions/voice_translation_into_different_languages_using_GPT-4o.ipynb
@@ -2727,6 +2803,7 @@
   tags:
     - completions
     - audio
+  archived: true
 
 - title: Enhance your prompts with meta prompting
   path: examples/Enhance_your_prompts_with_meta_prompting.ipynb
@@ -2737,6 +2814,7 @@
   tags:
     - completions
     - reasoning
+  archived: true
 
 - title: GPT Actions library - GitHub
   path: examples/chatgpt/gpt_actions_library/gpt_action_github.md
@@ -2759,6 +2837,7 @@
   tags:
     - evals
     - completions
+  archived: true
 
 - title: Vision Fine-tuning on GPT-4o for Visual Question Answering
   path: examples/multimodal/Vision_Fine_tuning_on_GPT4o_for_Visual_Question_Answering.ipynb
@@ -2781,6 +2860,7 @@
   tags:
     - completions
     - audio
+  archived: true
 
 - title: Pinecone Vector Database and Retool Workflow with GPT Actions
   path: examples/chatgpt/rag-quickstart/pinecone-retool/gpt-action-pinecone-retool-rag.ipynb
@@ -2793,6 +2873,7 @@
     - embeddings
     - chatgpt
     - chatgpt-and-api
+  archived: true
 
 - title: Optimizing Retrieval-Augmented Generation using GPT-4o Vision Modality
   path: examples/vector_databases/pinecone/Using_vision_modality_for_RAG_with_Pinecone.ipynb
@@ -2803,6 +2884,7 @@
   tags:
     - completions
     - vision
+  archived: true
 
 - title: GPT Actions library - Workday
   path: examples/chatgpt/gpt_actions_library/gpt_action_workday.md
@@ -2815,6 +2897,7 @@
     - gpt-actions-library
     - chatgpt-productivity
     - chatgpt
+  archived: true
 
 - title: GPT Actions library - Google Calendar
   path: examples/chatgpt/gpt_actions_library/gpt_action_google_calendar.md
@@ -2826,6 +2909,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-communication
+  archived: true
 
 - title: GPT Actions library - Tray.ai APIM
   path: examples/chatgpt/gpt_actions_library/gpt_action_trayai_apim.md
@@ -2837,6 +2921,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-middleware
+  archived: true
 
 - title: Reasoning over Code Quality and Security in GitHub Pull Requests
   path: examples/third_party/Code_quality_and_security_scan_with_GitHub_Actions.md
@@ -2857,6 +2942,7 @@
     - colin-openai
   tags:
     - guardrails
+  archived: true
 
 - title: How to use the Usage API and Cost API to monitor your OpenAI usage
   path: examples/completions_usage_api.ipynb

--- a/registry.yaml
+++ b/registry.yaml
@@ -1585,6 +1585,7 @@
   tags:
     - embeddings
     - completions
+  archived: true
 
 - title: Elasticsearch
   path: examples/vector_databases/elasticsearch/README.md

--- a/registry.yaml
+++ b/registry.yaml
@@ -674,6 +674,7 @@
   path: examples/o-series/o3o4-mini_prompting_guide.ipynb
   slug: o3o4-mini-prompting-guide
   description: Cookbook to improve o3/o4-mini function calling with prompt best practices.
+  archived: true
   date: 2025-05-26
   authors:
     - billchen-openai

--- a/registry.yaml
+++ b/registry.yaml
@@ -2023,6 +2023,7 @@
 - title: How to automate AWS tasks with function calling
   path: examples/third_party/How_to_automate_S3_storage_with_functions.ipynb
   slug: how-to-automate-s3-storage-with-functions
+  archived: true
   date: 2023-09-27
   authors:
     - Barqawiz

--- a/registry.yaml
+++ b/registry.yaml
@@ -452,6 +452,7 @@
 - title: Using NVIDIA TensorRT-LLM to run gpt-oss-20b
   path: articles/gpt-oss/run-nvidia.ipynb
   slug: run-nvidia
+  archived: true
   date: 2025-08-05
   authors:
     - jayrodge


### PR DESCRIPTION
## Summary
- Marks stale cookbook entries as archived in `registry.yaml`.
- Keeps archived pages available while removing them from the main cookbook listings.

## Verification
- Parsed `registry.yaml` with PyYAML and ran a simple schema check.
- Ran `git diff --check`.
