### PR TITLE
docs: fix typo in api_request_parallel_processor docstring ("his" -> "hit")

### DIFF
--- a/examples/api_request_parallel_processor.py
+++ b/examples/api_request_parallel_processor.py
@@ -65,7 +65,7 @@ Inputs:
 - logging_level : int, optional
     - level of logging to use; higher numbers will log fewer messages
     - 40 = ERROR; will log only when requests fail after all retries
-    - 30 = WARNING; will log when requests his rate limits or other errors
+    - 30 = WARNING; will log when requests hit rate limits or other errors
     - 20 = INFO; will log when requests start and the status at finish
     - 10 = DEBUG; will log various things as the loop runs to see when they occur
     - if omitted, will default to 20 (INFO).


### PR DESCRIPTION
The module docstring in `examples/api_request_parallel_processor.py` describes the WARNING logging level as "will log when requests his rate limits or other errors". "his" should be "hit" — the intended phrase is "requests hit rate limits", consistent with the other uses of "rate limit ... is hit" elsewhere in the same file. This is a one-word docstring fix with no behavior change.