### PR TITLE
Refine Parallel Search MCP cookbook copy and add Monitor API

### DIFF
--- a/examples/partners/parallel_search_mcp_enrichment/parallel_search_mcp_enrichment.ipynb
+++ b/examples/partners/parallel_search_mcp_enrichment/parallel_search_mcp_enrichment.ipynb
@@ -5,18 +5,18 @@
    "id": "1d00f7ab",
    "metadata": {},
    "source": [
-    "# Reliable data enrichment with the OpenAI Responses API and Parallel MCP Server\n",
+    "# Grounded data enrichment with the OpenAI Responses API and Parallel MCP Server\n",
     "\n",
     "## Introduction\n",
     "\n",
     "### Purpose of this cookbook\n",
     "\n",
-    "Many enterprise workflows depend on web data that is current and verifiable: sales teams enriching CRM records, analysts tracking competitors and filings, compliance teams monitoring counterparties, support and research assistants answering questions about the world as it is today. This cookbook shows how to build these workflows by connecting the OpenAI Responses API to Parallel's free Search MCP server, through two production patterns:\n",
+    "For many enterprise workflows, AI is only useful if it is current and verifiable. Think of sales teams enriching CRM records, analysts tracking competitors and filings, or compliance teams monitoring the rapidly changing regulatory landscape. False or outdated information can have steep consequences. On the other hand getting factual, grounded research in minutes can be a huge unlock for teams. In this cookbook we combine the OpenAI Responses API to Parallel's free Search MCP server to demonstrate how to use AI to produce web research that is trustworthy and verifiable. We'll implement two production patterns: \n",
     "\n",
-    "1. **Answering a factual question with citations** — the model answers from sources retrieved on the live web, and every claim links back to the document that supports it.\n",
-    "2. **Enriching a data record** — the same approach, but the output is a clean, structured object (via Structured Outputs) ready to load into a dataframe, database, or API response.\n",
+    "1. **Answering a factual question with citations** — the model answers from sources retrieved on the live web, and every claim links back to the document that supports it. \n",
+    "2. **Enriching a data record** — the same approach but the output is a clean, structured object (via Structured Outputs) ready to load into a dataframe, database, or API response.\n",
     "\n",
-    "We build each pattern step by step: start with the smallest request that works, look at what the model actually retrieved, then add guardrails along the way — instructing the model to cite only the sources it retrieved, and to return `\"unknown\"` instead of guessing when the evidence isn't there. These small habits are what make the difference between a quick demo and a workflow you can trust in production.\n",
+    "In both cases, the results will be grounded in citations and specific page excerpts returned by Parallel's Search MCP. Authoritative citations and excerpts can be the difference between your team trusting AI output and ignoring it, and can elevate a demo to a workflow you can trust in production.\n",
     "\n",
     "### Who this is for\n",
     "\n",
@@ -34,6 +34,8 @@
    "metadata": {},
    "source": [
     "## Use Case 1: Grounded Answers with Citations\n",
+    "\n",
+    "The first use case is retrieving factual information from the web. For example, a competitive intelligence team might want to maintain updated information about competitors' pricing or a risk team might want to track any regulatory actions against a vendor. The steps below show how to automate these manual research tasks. \n",
     "\n",
     "### 1.1 Install the OpenAI SDK\n",
     "\n",
@@ -91,7 +93,7 @@
     "\n",
     "A remote MCP server exposes tools that a model can use while generating a response. Parallel Search MCP exposes two read-only tools:\n",
     "\n",
-    "- `web_search`: search the web for relevant sources\n",
+    "- `web_search`: search the web for relevant pages and specific excerpts from those pages related to your query\n",
     "- `web_fetch`: retrieve agent-optimized markdown content from a selected URL\n",
     "\n",
     "The grounded-answer example uses `web_search` to find source documents. The enrichment example also uses `web_fetch` so the model can inspect selected pages before producing a structured record.\n",
@@ -338,9 +340,7 @@
    "source": [
     "## Use Case 2: Structured Data Enrichment\n",
     "\n",
-    "The grounded answer above is useful for a person. A reusable enrichment workflow needs a typed object instead. OpenAI Structured Outputs constrain the final response shape, while Parallel Search MCP supplies the web evidence used to fill it.\n",
-    "\n",
-    "We will build this in small steps. First, define the output contract. Then provide one input record, apply reusable application instructions, make the request, and inspect the result. This notebook intentionally focuses on one record so the OpenAI and Parallel integration remains visible; applying the same pattern to many rows is an orchestration concern rather than a different integration.\n",
+    "Often times, teams will want to build or enrich a database of information versus just disparate facts. This requires AI to return a typed object versus free form text. To achieve this, we can use OpenAI's Structured Outputs. This notebook intentionally enriches one record so the OpenAI and Parallel integration remains visible. It should be straightforward to then apply this pattern to many rows. \n",
     "\n",
     "### 2.1 Define the output contract\n",
     "\n",
@@ -541,15 +541,22 @@
     "- **Higher limits and production traffic**: add a [Parallel API key](https://docs.parallel.ai) as a Bearer token, or use the OAuth endpoint at `https://search.parallel.ai/mcp-oauth`.\n",
     "- **Stricter source control**: the direct [Parallel Search API](https://docs.parallel.ai/search-api/search-quickstart) supports retrieval-time domain filtering via [`source_policy`](https://docs.parallel.ai/resources/source-policy).\n",
     "- **Large-scale enrichment**: for thousands of rows, the [Parallel Task API](https://docs.parallel.ai/task-api/task-quickstart) runs deep research asynchronously with built-in structured outputs.\n",
+    "- **Proactive web intelligence**: To get always-on intelligence about rapidly changing topics, see the [Parallel Monitor API](https://docs.parallel.ai/monitor-api/monitor-quickstart). \n",
     "- **Citation formatting**: see the OpenAI guide to [citation formatting](https://developers.openai.com/api/docs/guides/citation-formatting) for richer citation behavior."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b038bd0",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.12 (parallelcookbook)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "parallelcookbook"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -561,7 +568,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary
- Reframes the introduction to emphasize grounded, verifiable research (vs. generic "reliable")
- Adds contextual lead-ins for each use case section
- Documents the Parallel Monitor API in Next Steps
- Normalizes notebook kernel metadata

## Test plan
- [x] Notebook renders correctly in GitHub preview
- [ ] Notebook runs top-to-bottom with `OPENAI_API_KEY` set


Made with [Cursor](https://cursor.com)