### PR TITLE
Retarget Parallel MCP cookbook for an AI-native audience

### DIFF
--- a/examples/partners/parallel_search_mcp_enrichment/parallel_search_mcp_enrichment.ipynb
+++ b/examples/partners/parallel_search_mcp_enrichment/parallel_search_mcp_enrichment.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --quiet --upgrade openai"
+    "%pip install --quiet --upgrade openai pandas"
    ]
   },
   {
@@ -123,12 +123,42 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.4 Establish the baseline: the model without the web\n",
+    "\n",
+    "In the Responses API, the model only browses the web if you attach a tool and it chooses to call one. With no tools attached, GPT-5.5 answers purely from its training data. We start there on purpose: our question asks about Series A rounds in the **last 60 days**, which falls outside what any pretrained model can know. Run the cell below and you will see the model either decline or answer without grounding — the gap that live retrieval fills.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "QUESTION = (\n",
+    "    \"Which YC X25 (Spring 2025) companies have announced a Series A round in the \"\n",
+    "    \"last 60 days? For each, give the company, the round size, and the lead investor.\"\n",
+    ")\n",
+    "\n",
+    "# No tools attached: GPT-5.5 can only answer from what it learned at training time.\n",
+    "baseline = client.responses.create(\n",
+    "    model=\"gpt-5.5\",\n",
+    "    reasoning={\"effort\": \"low\"},\n",
+    "    input=QUESTION,\n",
+    ")\n",
+    "\n",
+    "print(baseline.output_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5f2bd936",
    "metadata": {},
    "source": [
-    "### 1.4 Minimum working grounded answer example\n",
+    "### 1.5 The same question, grounded with Parallel `web_search`\n",
     "\n",
-    "This first request keeps things minimal: expose only Parallel's `web_search` tool and ask a current factual question. The cell prints each MCP call's name and exact arguments before the final answer, so you can see how the model translated the question into a search objective and queries. For a straightforward lookup like this, the search excerpts should provide enough evidence without fetching full pages. We use GPT-5.5 with low reasoning effort because the request is straightforward.\n",
+    "Now we attach Parallel's `web_search` tool and ask the **same** question. The cell prints each MCP call's name and exact arguments before the final answer, so you can see how the model translated the question into a search objective and queries. For a straightforward lookup like this, the search excerpts should provide enough evidence without fetching full pages. We use GPT-5.5 with low reasoning effort because the request is straightforward.\n",
     "\n",
     "**Note:** GPT-5.5 is aware of the current date in UTC. You don’t need to add the current date to system instructions. Add explicit date or timezone context only when the application needs a business-specific timezone, policy-effective date, user-local date, or other non-UTC reference point."
    ]
@@ -138,21 +168,7 @@
    "execution_count": null,
    "id": "d453c8ad",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "MCP call: web_search\n",
-      "Arguments: {\"objective\":\"Find Apple's selling, general and administrative (SG&A) expense for fiscal Q1 2026 from Apple's quarterly report or earnings release.\",\"search_queries\":[\"Apple Q1 2026 SG&A expense\",\"Apple 10-Q 2026 selling general administrative\",\"Apple fiscal 2026 first quarter SG&A\"],\"session_id\":\"6f1c4e0f9b8a4d3c9e2f1a7b5c8d0e9f\",\"model_name\":\"gpt-4.1\"}\n",
-      "\n",
-      "Answer:\n",
-      "Apple’s SG&A expense for fiscal Q1 2026 was **$7.492 billion**.\n",
-      "\n",
-      "This is for the **three months ended December 27, 2025**; Apple’s Q1 2026 results list “Selling, general and administrative” expense as **$7,492 million**. Sources: Apple Newsroom Q1 2026 results and the corresponding Business Wire/Nasdaq financial statement excerpts.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "INSTRUCTIONS = \"\"\"\n",
     "Use Parallel web_search and answer only from retrieved evidence; if it is insufficient, say so. \n",
@@ -170,7 +186,7 @@
     "    tools=[parallel_search_only_mcp],\n",
     "    tool_choice=\"required\",\n",
     "    reasoning={\"effort\": \"low\"},\n",
-    "    input=\"What was Apple's SG&A expense for Q1 2026?\",\n",
+    "    input=QUESTION,\n",
     ")\n",
     "\n",
     "for item in response.output:\n",
@@ -188,7 +204,7 @@
    "source": [
     "Citations are useful in grounded-answer use cases because they establish the provenance and credibility of the information. Basic prompting got us citations, but they are not as structured. To optimize this, we will inspect the underlying Responses API object, which contains the source records returned by Parallel.\n",
     "\n",
-    "### 1.5 Inspect the original source records\n",
+    "### 1.6 Inspect the original source records\n",
     "\n",
     "Parallel returns each source as one item in `results`. In this notebook, each result is one document-level **citable unit**, and its top-level `url` is the identifier you carry into citations or downstream records. The URL sits beside the page title, optional publication date, and one or more inspectable excerpts. There is no separate citation object at this stage.\n",
     "\n",
@@ -200,76 +216,7 @@
    "execution_count": null,
    "id": "2b2cc1a0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[\n",
-      "  {\n",
-      "    \"url\": \"https://www.macrotrends.net/stocks/charts/AAPL/apple/selling-general-administrative-expenses\",\n",
-      "    \"title\": \"Apple SG&A Expenses 2012-2026 | AAPL - Macrotrends\",\n",
-      "    \"publish_date\": null,\n",
-      "    \"excerpt_preview\": \"Macrotrends Logo\\n\\nStock Screener Start Free Trial Sign In Manage Account Subscribe Now Sign Out\\n\\n## Apple SG&A Expenses 2012-2026 | AAPL\\n\\nApple annual/quarterly sg&a expenses history and growth rate from 2012 to 2026. Sg&a expenses can be defined as the sum of all selling, general and administrative\"\n",
-      "  },\n",
-      "  {\n",
-      "    \"url\": \"https://www.sec.gov/Archives/edgar/data/320193/000032019326000013/aapl-20260328.htm\",\n",
-      "    \"title\": \"aapl-20260328 - SEC.gov\",\n",
-      "    \"publish_date\": \"2026-03-28\",\n",
-      "    \"excerpt_preview\": \"|Research and development |\\u2014 | | |\\u2014 | | |\\u2014 | | |\\u2014 | | |\\u2014 | | |( 16,818 ) | | |( 16,818 ) | |\\n|Selling and marketing |( 5,091 ) | | |( 2,324 ) | | |( 1,176 ) | | |( 534 ) | | |( 707 ) | | |\\u2014 | | |( 9,832 ) | |\\n|General and administrative |\\u2014 | | |\\u2014 | | |\\u2014 | | |\\u2014 | | |\\u2014 | | |( 4,071 ) | | |( 4,071 ) | \"\n",
-      "  },\n",
-      "  {\n",
-      "    \"url\": \"https://www.apple.com/newsroom/2026/01/apple-reports-first-quarter-results\",\n",
-      "    \"title\": \"Apple reports first quarter results\",\n",
-      "    \"publish_date\": \"2026-01-29\",\n",
-      "    \"excerpt_preview\": \"Newsroom\\n\\nOpen Newsroom navigation Close Newsroom navigation\\n\\n* Apple Services\\n* Apple Stories\\n\\nSearch Newsroom Close\\n\\nopens in new window\\n\\nPRESS RELEASE January 29, 2026\\n\\n# Apple reports first quarter results\\n\\nAll-time records for total company revenue and EPS  \\n  \\niPhone and Services revenue reach\"\n",
-      "  },\n",
-      "  {\n",
-      "    \"url\": \"https://www.financecharts.com/stocks/AAPL/income-statement/sga-expense\",\n",
-      "    \"title\": \"Apple (AAPL) SG&A Expense - Current & Historical Data (Jun 2026)\",\n",
-      "    \"publish_date\": null,\n",
-      "    \"excerpt_preview\": \"Apple (AAPL) SG&A Expense - Current & Historical Data (Jun 2026)\\nGet the sg&a expense charts for Apple (AAPL). We're 100% free for everything. Get 20 years of historical sg&a expense charts for AAPL stock and other companies.\"\n",
-      "  },\n",
-      "  {\n",
-      "    \"url\": \"https://www.analystlens.com/stocks/aapl/10q/fy2026-q1\",\n",
-      "    \"title\": \"AAPL 10-Q Quarterly Report Jan 30, 2026 Summary | AnalystLens | AnalystLens\",\n",
-      "    \"publish_date\": \"2026-02-04\",\n",
-      "    \"excerpt_preview\": \"Early Access \\u2014 Free until March 1st!\\n\\nLearn more\\n\\nAnalystLens Stocks AAPL 10-Q fy2026-q1\\n\\nApple Inc. Technology\\n\\nSearch... `\\u2318K`\\n\\nStocks Sectors\\n\\nLog in Sign up\\n\\n10-Q Filed January 30, 2026\\n\\n# AAPL 10-Q Quarterly Report Q1 2026\\n\\n## Summary\\n\\nApple Inc. reported strong financial results for the first f\"\n",
-      "  },\n",
-      "  {\n",
-      "    \"url\": \"https://www.nasdaq.com/press-release/apple-reports-first-quarter-results-2026-01-29\",\n",
-      "    \"title\": \"Apple reports first quarter results - Nasdaq\",\n",
-      "    \"publish_date\": \"2026-01-29\",\n",
-      "    \"excerpt_preview\": \"- Market Structure Policy Advocacy\\n        - Nasdaq Public Policy\\n        - Nasdaq Sustainability\\n        - Nasdaq Entrepreneurial Center\\n        - Nasdaq Ventures\\n        - Nasdaq and the Cloud\\n  \\n  Explore All About \\\\->\\n* \\n\\n \\n\\n# Apple reports first quarter results\\n\\nPublished\\n\\nJan 29, 2026 4:30pm E\"\n",
-      "  },\n",
-      "  {\n",
-      "    \"url\": \"https://marketinference.com/analysis/r/2026/01/30/AAPL\",\n",
-      "    \"title\": \"Apple's Form 10-Q Reveals Strong Sales Growth and Increased ...\",\n",
-      "    \"publish_date\": \"2026-01-30\",\n",
-      "    \"excerpt_preview\": \"Apple's Form 10-Q Reveals Strong Sales Growth and Increased ...\\nOperating Expenses: * Research and development (R&D) expenses surged by 32% in the first quarter of 2026 compared to the same quarter in 2025, primarily driven by increases in infrastructure-related costs and headcount-related expenses.\"\n",
-      "  },\n",
-      "  {\n",
-      "    \"url\": \"https://stockcircle.com/stocks/aapl/selling-general-admin\",\n",
-      "    \"title\": \"Apple Selling, General & Admin (AAPL) - stockcircle.com\",\n",
-      "    \"publish_date\": \"2026-03-31\",\n",
-      "    \"excerpt_preview\": \"Back Apple Overview\\n\\n# Apple Selling, General & Admin\\n\\nSelling, General & Admin expenses for AAPL.\\n\\n### Quarterly SG&A Expenses\\n\\n$7.48B\\n\\n\\u219111.13% YoY\\n\\nAs of Mar 31, 2026\\n\\n### Annual SG&A Expenses (TTM)\\n\\n$28.67B\\n\\n\\u21917.18% YoY\\n\\nTrailing 12 months ending Mar 31, 2026\\n\\n### Average SG&A Expenses (Comparison\"\n",
-      "  },\n",
-      "  {\n",
-      "    \"url\": \"https://www.analystlens.com/stocks/aapl/filings\",\n",
-      "    \"title\": \"AAPL SEC Filings \\u2014 All 10-K, 10-Q, 8-K - analystlens.com\",\n",
-      "    \"publish_date\": null,\n",
-      "    \"excerpt_preview\": \"Early Access \\u2014 Free until March 1st!\\n\\nLearn more\\n\\nAnalystLens\\n\\nSEC filings, finally readable.\\n\\nResearch\\n\\n* Stocks\\n* Sectors\\n\\nLegal\\n\\n* Privacy Policy\\n* Terms of Service\\n* SEC Disclaimer\\n\\nSEC filings are public domain. AnalystLens is not affiliated with the SEC.\"\n",
-      "  },\n",
-      "  {\n",
-      "    \"url\": \"https://www.businesswire.com/news/home/20260129405756/en/Apple-reports-first-quarter-results\",\n",
-      "    \"title\": \"Apple reports first quarter results - Business Wire\",\n",
-      "    \"publish_date\": \"2026-01-29\",\n",
-      "    \"excerpt_preview\": \"Jan 29, 2026 4:30 PM Eastern Standard Time\\n\\n# **Apple reports first quarter results**\\n\\nShare\\n\\n* * *\\n\\n**All-time records for total company revenue and EPS**\\n\\n**iPhone and Services revenue reach new all-time highs**\\n\\nCUPERTINO, Calif.--( [BUSINESS WIRE](https://www.businesswire.com) )-- Apple\\u00ae today a\"\n",
-      "  }\n",
-      "]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import json\n",
     "\n",
@@ -309,9 +256,9 @@
    "id": "7c64f5a1",
    "metadata": {},
    "source": [
-    "### 1.6 Add explicit document URLs\n",
+    "### 1.7 Add explicit document URLs\n",
     "\n",
-    "Section 1.5 shows that each retrieved document's citable identifier is the top-level `url` field in the MCP output's `results` array. We can use that contract to tighten the original instructions: the model should copy `results[*].url` into a Markdown link instead of naming a source without its URL or constructing a link itself.\n",
+    "Section 1.6 shows that each retrieved document's citable identifier is the top-level `url` field in the MCP output's `results` array. We can use that contract to tighten the original instructions: the model should copy `results[*].url` into a Markdown link instead of naming a source without its URL or constructing a link itself.\n",
     "\n",
     "The complete instruction block is repeated below so the request remains readable on its own. For more advanced citation behavior, see OpenAI's [citation formatting guide](https://developers.openai.com/api/docs/guides/citation-formatting)."
    ]
@@ -321,17 +268,7 @@
    "execution_count": null,
    "id": "b9d1e6c2",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Apple’s SG&A expense for fiscal Q1 2026 was **$7.492 billion**.\n",
-      "\n",
-      "Apple’s Form 10-Q lists “Selling, general and administrative” expense of **$7,492 million** for the three months ended December 27, 2025 (Q1 2026). Source: [Apple Inc. Form 10-Q](https://s2.q4cdn.com/470004039/files/doc_earnings/2026/q1/filing/10Q-Q1-2026-as-filed.pdf).\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "INSTRUCTIONS = \"\"\"\n",
     "Use Parallel web_search and answer only from retrieved evidence; if it is insufficient, say so.\n",
@@ -345,7 +282,7 @@
     "    tools=[parallel_search_only_mcp],\n",
     "    tool_choice=\"required\",\n",
     "    reasoning={\"effort\": \"low\"},\n",
-    "    input=\"What was Apple's SG&A expense for Q1 2026?\",\n",
+    "    input=QUESTION,\n",
     ")\n",
     "\n",
     "print(citation_response.output_text)"
@@ -356,7 +293,7 @@
    "id": "e27c9b41",
    "metadata": {},
    "source": [
-    "### 1.7 Stream a multi-step grounded answer\n",
+    "### 1.8 Stream a multi-step grounded answer\n",
     "\n",
     "More complex/obscure questions may require the model to locate multiple sources, fetch detailed evidence, and reason across them. This example makes three changes:\n",
     "\n",
@@ -372,62 +309,7 @@
    "execution_count": null,
    "id": "f81d0a36",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "I’ll check Apple’s latest reported quarterly results and the prior quarter’s category revenues to compare year-over-year growth rates.\n",
-      "\n",
-      "MCP call: web_search\n",
-      "Arguments: {\"objective\":\"Find Apple's most recent quarterly earnings release with product category revenue and the prior quarter category revenue, including year-over-year comparisons.\",\"search_queries\":[\"Apple Q2 2026 earnings product revenue\",\"Apple quarterly results Q2 2026\",\"Apple Q1 2026 earnings product revenue\"],\"session_id\":\"9e83d91d75d54e36a8b4ab2c4f2c8d10\",\"model_name\":\"gpt-4.1\"}\n",
-      "MCP call completed: web_search\n",
-      "\n",
-      "I found Apple’s latest Q2 FY2026 release; now I’ll pull the Apple source and the prior-quarter Apple source/SEC data for the category details.\n",
-      "\n",
-      "MCP call: web_search\n",
-      "Arguments: {\"objective\":\"Find Apple official Q1 FY2026 results product category revenue year over year growth rates and Q2 FY2026 financial statements table.\",\"search_queries\":[\"site:apple.com/newsroom Apple reports first quarter results 2026\",\"Apple Q1 2026 results iPhone Mac iPad Services revenue\",\"SEC AAPL 10-Q 2026 product revenue\"],\"session_id\":\"9e83d91d75d54e36a8b4ab2c4f2c8d10\",\"model_name\":\"gpt-4.1\"}\n",
-      "MCP call completed: web_search\n",
-      "\n",
-      "Next I’ll fetch Apple’s Q2 and Q1 result pages to extract the category revenue tables and compute the growth-rate change.\n",
-      "\n",
-      "MCP call: web_fetch\n",
-      "Arguments: {\"urls\":[\"https://www.apple.com/newsroom/2026/04/apple-reports-second-quarter-results\",\"https://www.apple.com/newsroom/2026/01/apple-reports-first-quarter-results/\"],\"objective\":\"Extract net sales by category tables for 2026 Q2 and Q1 including prior-year figures.\",\"search_queries\":[\"Apple reports second quarter results category net sales\",\"Apple reports first quarter results category net sales\"],\"full_content\":false,\"session_id\":\"9e83d91d75d54e36a8b4ab2c4f2c8d10\",\"model_name\":\"gpt-4.1\"}\n",
-      "MCP call completed: web_fetch\n",
-      "\n",
-      "The excerpts didn’t include the financial-statement tables, so I’ll look for Apple’s PDF/SEC filings that contain the full category tables.\n",
-      "\n",
-      "MCP call: web_search\n",
-      "Arguments: {\"objective\":\"Locate Apple's Q2 FY2026 and Q1 FY2026 consolidated financial statements PDF or SEC 10-Q category revenue tables.\",\"search_queries\":[\"site:apple.com/newsroom/pdfs fy2026 q2 consolidated financial statements apple\",\"site:apple.com/newsroom/pdfs fy2026 q1 consolidated financial statements apple\",\"AAPL 2026 Q2 10-Q net sales by category\"],\"session_id\":\"9e83d91d75d54e36a8b4ab2c4f2c8d10\",\"model_name\":\"gpt-4.1\"}\n",
-      "MCP call completed: web_search\n",
-      "\n",
-      "I have the Q2 category table; now I’ll fetch the SEC Q1 filing to get the prior quarter’s category table from a primary source.\n",
-      "\n",
-      "MCP call: web_fetch\n",
-      "Arguments: {\"urls\":[\"https://www.sec.gov/Archives/edgar/data/320193/000032019326000006/aapl-20251227.htm\",\"https://www.sec.gov/Archives/edgar/data/320193/000032019326000013/aapl-20260328.htm\"],\"objective\":\"Extract net sales by category tables and percent changes for Q1 2026 and Q2 2026.\",\"search_queries\":[\"net sales by category iPhone Mac iPad Wearables Services\",\"Apple Q1 Q2 2026 category revenue\"],\"full_content\":false,\"session_id\":\"9e83d91d75d54e36a8b4ab2c4f2c8d10\",\"model_name\":\"gpt-4.1\"}\n",
-      "MCP call completed: web_fetch\n",
-      "\n",
-      "Interpreting “accelerate/slow/reverse” as **the change in year-over-year revenue growth by category in Apple’s latest reported quarter versus the immediately prior quarter**: Apple’s latest reported quarter in the retrieved primary sources is **fiscal Q2 2026, ended March 28, 2026**.\n",
-      "\n",
-      "| Category | Q1 FY2026 YoY growth | Q2 FY2026 YoY growth | Direction |\n",
-      "|---|---:|---:|---|\n",
-      "| **iPhone** | +23.3% | +21.7% | **Slowed** |\n",
-      "| **Mac** | -6.7% | +5.7% | **Reversed to growth** |\n",
-      "| **iPad** | +6.3% | +8.0% | **Accelerated** |\n",
-      "| **Wearables, Home and Accessories** | -2.2% | +5.0% | **Reversed to growth** |\n",
-      "| **Services** | +13.9% | +16.3% | **Accelerated** |\n",
-      "\n",
-      "**Summary:**\n",
-      "- **Accelerated:** iPad, Services  \n",
-      "- **Slowed:** iPhone  \n",
-      "- **Reversed:** Mac and Wearables/Home/Accessories both moved from YoY declines in Q1 to YoY growth in Q2.  \n",
-      "- **No category reversed from growth to decline** in Q2.\n",
-      "\n",
-      "Sources: [Apple Q2 FY2026 consolidated financial statements](https://www.apple.com/newsroom/pdfs/fy2026q2/FY26_Q2_Consolidated_Financial_Statements.pdf), [Apple Q1 FY2026 Form 10-Q](https://www.sec.gov/Archives/edgar/data/320193/000032019326000006/aapl-20251227.htm), [Apple Q2 FY2026 Form 10-Q](https://www.sec.gov/Archives/edgar/data/320193/000032019326000013/aapl-20260328.htm)\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "INSTRUCTIONS = \"\"\"\n",
     "Use Parallel web_search to locate relevant sources and web_fetch when full document content is needed.\n",
@@ -439,7 +321,7 @@
     "\"\"\"\n",
     "\n",
     "QUESTION = \"\"\"\n",
-    "Which Apple product categories saw their growth accelerate, slow, or reverse in the most recently reported quarter?\n",
+    "Trace Ramp's venture funding history: list each round (seed through latest) with its date, amount raised, post-money valuation if reported, and the lead investor. Cite a primary or first-party source for each round.\n",
     "\"\"\"\n",
     "\n",
     "mcp_call_names = {}\n",
@@ -523,7 +405,7 @@
     "    ceo_name: str = Field(description=\"Current chief executive officer, or 'unknown'.\")\n",
     "    ceo_source_url: Optional[str] = Field(description=\"Absolute HTTPS official source URL for the CEO, or null.\")\n",
     "    recent_company_signal: str = Field(\n",
-    "        description=\"One recent company or product signal from the last 90 days, or 'unknown'.\"\n",
+    "        description=\"One recent company or product signal from the last 7 days, or 'unknown'.\"\n",
     "    )\n",
     "    recent_company_signal_source_url: Optional[str] = Field(\n",
     "        description=\"Absolute HTTPS source URL for the recent company signal, or null.\"\n",
@@ -537,9 +419,9 @@
    "id": "7b0e8a41",
    "metadata": {},
    "source": [
-    "### 2.2 Define the input record\n",
+    "### 2.2 Define the input records\n",
     "\n",
-    "The input is deliberately small: it contains what we already know. The workflow's job is to add verified fields without changing the original identity of the record."
+    "The input is deliberately small: each record contains only what we already know. The workflow's job is to add verified fields without changing the original identity of the record. We define a short list of target accounts, walk through enriching the first one in detail, then scale to the full list in section 2.6."
    ]
   },
   {
@@ -549,10 +431,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "company_row = {\n",
-    "    \"company_name\": \"Apple\",\n",
-    "    \"official_domain\": \"apple.com\",\n",
-    "}"
+    "# A short list of marquee accounts an AI-native company would love to win.\n",
+    "# Swap in whatever logos fit the room.\n",
+    "target_accounts = [\n",
+    "    {\"company_name\": \"Ramp\", \"official_domain\": \"ramp.com\"},\n",
+    "    {\"company_name\": \"Notion\", \"official_domain\": \"notion.so\"},\n",
+    "    {\"company_name\": \"Databricks\", \"official_domain\": \"databricks.com\"},\n",
+    "    {\"company_name\": \"Rippling\", \"official_domain\": \"rippling.com\"},\n",
+    "    {\"company_name\": \"Brex\", \"official_domain\": \"brex.com\"},\n",
+    "    {\"company_name\": \"Vercel\", \"official_domain\": \"vercel.com\"},\n",
+    "]\n",
+    "\n",
+    "# We walk through one record first, then scale to the whole list in 2.6.\n",
+    "company_row = target_accounts[0]"
    ]
   },
   {
@@ -580,7 +471,7 @@
     "Copy company_name and official_domain exactly from the input.\n",
     "Use Parallel Search MCP to search the web, then fetch only the most relevant source pages selected as evidence.\n",
     "For stable facts, prefer sources from the official_domain supplied in the input.\n",
-    "For recent_company_signal, use only sources from the last 90 days.\n",
+    "For recent_company_signal, use only sources from the last 7 days (a launch, funding event, notable announcement, or widely shared post).\n",
     "Cite only retrieved sources that directly support the populated field.\n",
     "Copy citation URLs only from the top-level url of a Parallel web_search or web_fetch result; never invent or rewrite a URL.\n",
     "When multiple sources are materially needed to support a field, include each field-and-URL pair once.\n",
@@ -634,34 +525,52 @@
    "execution_count": null,
    "id": "baadf5fc",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'company_name': 'Apple',\n",
-       " 'official_domain': 'apple.com',\n",
-       " 'ceo_name': 'Tim Cook',\n",
-       " 'ceo_source_url': 'https://www.apple.com/leadership/tim-cook/',\n",
-       " 'recent_company_signal': 'Apple today announced changes impacting iOS apps in Brazil that reflect a recent agreement with Brazil’s competition regulator, CADE.',\n",
-       " 'recent_company_signal_source_url': 'https://www.apple.com/newsroom/2026/06/apple-announces-changes-to-ios-in-brazil/',\n",
-       " 'citations': [{'field': 'ceo_name',\n",
-       "   'url': 'https://www.apple.com/leadership/tim-cook/',\n",
-       "   'note': 'Tim Cook is the CEO of Apple and serves on its board of directors.'},\n",
-       "  {'field': 'recent_company_signal',\n",
-       "   'url': 'https://www.apple.com/newsroom/2026/06/apple-announces-changes-to-ios-in-brazil/',\n",
-       "   'note': 'Apple today announced changes impacting iOS apps in Brazil that reflect a recent agreement with Brazil’s competition regulator, CADE.'}],\n",
-       " 'unknown_fields': []}"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "company_enrichment = enrichment_response.output_parsed\n",
     "\n",
     "company_enrichment.model_dump()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.6 Scale to the whole list\n",
+    "\n",
+    "The single-record call above is the unit of work. To enrich the full list we run that same call once per row — the schema, instructions, and validation logic stay identical; only orchestration is new. Here we fan out with a thread pool and collect the typed results into a dataframe ready for a CRM, database, or API response.\n",
+    "\n",
+    "> The anonymous MCP endpoint runs at lower rate limits. For higher concurrency, add a Parallel API key as a Bearer token (see *Where to go next*)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from concurrent.futures import ThreadPoolExecutor\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "\n",
+    "def enrich(row):\n",
+    "    resp = client.responses.parse(\n",
+    "        model=\"gpt-5.4\",\n",
+    "        instructions=ENRICHMENT_INSTRUCTIONS,\n",
+    "        tools=[parallel_search_mcp],\n",
+    "        tool_choice=\"required\",\n",
+    "        input=json.dumps(row),\n",
+    "        text_format=CompanyEnrichment,\n",
+    "    )\n",
+    "    return resp.output_parsed\n",
+    "\n",
+    "\n",
+    "with ThreadPoolExecutor(max_workers=len(target_accounts)) as pool:\n",
+    "    enriched = list(pool.map(enrich, target_accounts))\n",
+    "\n",
+    "df = pd.DataFrame([record.model_dump() for record in enriched])\n",
+    "df[[\"company_name\", \"ceo_name\", \"recent_company_signal\", \"recent_company_signal_source_url\"]]"
    ]
   },
   {
@@ -707,7 +616,7 @@
    "source": [
     "## Wrapping up\n",
     "\n",
-    "In this cookbook we built two web-grounded workflows with the OpenAI Responses API and Parallel Search MCP. The patterns here scale beyond a single question or record. To enrich a whole dataset, run the Use Case 2 request once per row — the schema, instructions, and validation logic stay exactly the same; only the orchestration (batching, retries, rate limits) is new.\n",
+    "In this cookbook we built two web-grounded workflows with the OpenAI Responses API and Parallel Search MCP. The patterns here scale beyond a single question or record. Section 2.6 showed the core move for enriching a whole dataset: run the Use Case 2 request once per row — the schema, instructions, and validation logic stay exactly the same; only the orchestration (batching, retries, rate limits) grows from a thread pool into a production queue.\n",
     "\n",
     "### Where to go next\n",
     "\n",


### PR DESCRIPTION
## What this changes

Retargets the Parallel Search MCP cookbook for an AI-native / YC audience so the examples land with senior technical builders rather than reading as a generic finance lookup.

### Use Case 1 — Grounded Answers
- **New 1.4 baseline cell:** asks the question with *no tools* so GPT-5.5's knowledge gap is visible, then 1.5 answers the **same** question grounded via `web_search`. Makes the value of retrieval legible in one before/after.
- Swapped the Apple SG&A lookup for a fresher, post-cutoff query: **recent YC X25 (Spring 2025) Series A rounds**.
- Moved the 1.8 multi-step streaming example off Apple onto a **Ramp funding-history trace** (still exercises search + fetch + primary-source citations).

### Use Case 2 — Structured Enrichment
- Enriches a short list of **marquee target accounts** instead of a single record.
- **New section 2.6** fans the enrichment out concurrently into a pandas dataframe (the "now scale it" payoff).
- Tightened the recent-signal window from 90 → 7 days.

### Notes
- **Outputs are cleared pending a re-run with GPT-5.5 access** — opening as a draft so the team can execute the notebook and commit real outputs.
- Open questions for reviewers: exact YC query wording, the Ramp choice for 1.8, and the specific logos in the target-account list — all easy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
