### PR TITLE
[codex] Archive outdated Realtime cookbooks

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -3072,6 +3072,7 @@
   slug: one-way-translation-using-realtime-api
   description: Cookbook to build one-way speech translation with the Realtime API.
   date: 2025-03-24
+  archived: true
   authors:
     - erikakettleson-openai
   tags:

--- a/registry.yaml
+++ b/registry.yaml
@@ -285,6 +285,7 @@
   path: examples/building_w_rt_mini/building_w_rt_mini.ipynb
   slug: building-w-rt-mini
   date: 2025-10-11
+  archived: true
   authors:
     - carter-oai
   tags:


### PR DESCRIPTION
## Summary

- Archive **Building with Realtime Mini**.
- Archive **Multi-Language One-Way Translation with the Realtime API**.

## Motivation

`gpt-realtime-2.1-mini` is the same price as the previous Realtime mini while adding reasoning, stronger tool use, and improved alphanumeric handling. The older model-specific cookbook can steer readers toward outdated guidance.

The one-way translation cookbook depends on `@openai/realtime-api-beta` and hardcodes `gpt-4o-realtime-preview-2024-12-17`, both of which are no longer available. Its fan-out pattern remains useful, but the current implementation needs a substantial GA Realtime/WebRTC refresh.

## Impact

Both cookbooks remain in the repository and their direct URLs continue to work, but they no longer appear among active cookbook content.

## Self-review

- [x] Registry metadata stays valid and in sync.
- [x] No notebook or author metadata changes are needed.
- [x] Changes are limited to the two intended cookbook entries.

## Validation

- `python3 -c 'import yaml; yaml.safe_load(open("registry.yaml"))'`
