### PR TITLE
Register Oracle agent memory cookbook

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -4,6 +4,19 @@
 # should build pages for, and indicates metadata such as tags, creation date and
 # authors for each page.
 
+- title: Enabling Long-Term Agent Memory with Oracle AI Agent Memory
+  path: examples/agents_sdk/deep_research_openai_agents.ipynb
+  slug: deep-research-openai-agents
+  description: Build a deep-research agent with the OpenAI Agents SDK, Oracle-backed session persistence, durable memory, and Tavily web search.
+  date: 2026-07-16
+  authors:
+    - Ela689
+  tags:
+    - agents-sdk
+    - agents
+    - memory
+    - deep-research
+
 - title: Trigger a Workspace Agent from the API
   path: examples/chatgpt/workspace_agents/workspace-agents-api-trigger.ipynb
   slug: workspace-agents-api-trigger


### PR DESCRIPTION
## Summary

Register the Oracle-backed deep research notebook added in #2772 so the developers website ingestion pipeline includes and renders it.

## Motivation

PR #2772 merged `examples/agents_sdk/deep_research_openai_agents.ipynb` without the required `registry.yaml` entry. A successful `developers-website` production build after that merge still returns 404 for the notebook because Cookbook ingestion is registry-driven.

## Validation

- Validated `registry.yaml` against `.github/registry_schema.json`
- Confirmed the slug is unique
- Confirmed the registered notebook path exists
- Ran `git diff --check`

## For new content

- [x] Added the missing `registry.yaml` entry so the content renders on the Cookbook website.
- [x] Reused the contributor's GitHub username for author attribution; `authors.yaml` customization is optional.
- [x] Confirmed the metadata matches the merged notebook.

Related infrastructure issue: #2799. The obsolete Cookbook deploy hook is failing repo-wide, but this registry fix is independently required for #2772 to become routable during the next `developers-website` production build.
