### PR TITLE
Add mandatory docs-editor review gate

### DIFF
--- a/.codex/skills/docs-editor/SKILL.md
+++ b/.codex/skills/docs-editor/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: docs-editor
+description: Review and edit technical documentation (Markdown/MDX) with Chicago Manual of Style + Microsoft Writing Style Guide alignment. Use when asked to review, edit, or QA docs for clarity, grammar, consistency, and style; to run Vale linting with a repo .vale.ini; to identify and prioritize doc issues and fixes; or to write or edit Ads docs using the repo's Ads-specific docs style guidance.
+metadata:
+  short-description: Review and edit docs
+---
+
+# Docs Editor
+
+## Overview
+
+Review technical documentation for style, clarity, and consistency. Run Vale when available, then perform a human review, fix easy issues, and report remaining issues by priority.
+
+## Workflow
+
+### 1) Gather inputs
+
+- Prefer a specific file path. If none is provided, confirm scope.
+- Accept a glob for MD/MDX when the user wants a sweep (for example: `--glob='*.{mdx,md}'`).
+- Never invent or add new factual content.
+
+### 2) Run repository Vale
+
+- Check for `.vale.ini` in the project root. If it is missing, note that and proceed with manual review.
+- Run `pnpm run setup` when Vale 3 or newer, or synchronized packages, are unavailable. This is the repository's supported bootstrap path.
+- Run `pnpm run vale -- <path...>` with explicit Markdown or MDX paths. Resolve globs to paths before invoking the command.
+- Don't call global Vale directly for repository files. The wrapper enforces repository configuration, package checks, exclusions, and `--no-global` behavior.
+
+### 2a) Astro partials via stdin
+
+The repository wrapper accepts files, not stdin. If content lives in an `.astro` file and only a subset of copy should be linted, extract the relevant Markdown or MDX and pass it to Vale with the same repository flags:
+
+```bash
+printf '%s\n' "*This* is Markdown" | vale --no-global --no-wrap --ext=.mdx
+```
+
+### 3) Triage findings
+
+- Parse Vale output and map each alert to a priority.
+- Apply the repo rule: any spelling or grammar issues in `.mdx` are **P0/P1**.
+- If Vale reports vocabulary/spelling errors, ask the user first whether any terms should be added to the appropriate `accept.txt` vocabulary list before editing content.
+- Use this priority scale:
+  - **P0**: Critical correctness or meaning issues; spelling/grammar in `.mdx`.
+  - **P1**: Major clarity, ambiguity, or misleading statements.
+  - **P2**: Consistency, tone, minor grammar, or style issues.
+  - **P3**: Nits and optional improvements.
+
+### 4) Manual review (Chicago + Microsoft style)
+
+Focus on:
+
+- Clarity and brevity (tighten wordiness, active voice).
+- Consistent terminology and capitalization.
+- Parallel structure in lists and headings.
+- Consistent punctuation, spacing, and heading styles.
+- Logical consistency: list counts, referenced items, numbering, examples, and cross-references.
+- For detailed developer-doc rules, load `resources/style-guide.md` and apply the checklist.
+
+### 4a) Developer content checks
+
+Apply Microsoft Writing Style Guide guidance that targets developer documentation:
+
+- **Audience + voice**: Assume baseline dev knowledge; skip basics and focus on product-specific goals. Keep the voice warm, crisp, and helpful.
+- **Reference documentation**: Favor consistent structure and predictable headings. Ensure a concise description, syntax/signature, requirements/applies-to, examples, exceptions/permissions where applicable, and “See also” links. Don’t repeat the element name in the description.
+- **Code examples**: Make examples task-based, concise, and practical; start simple, avoid contrived scenarios, list prerequisites, show expected output, and ensure secure, tested code. Don’t add exception handling unless intrinsic to the example.
+- **Formatting developer text**: Use code style for programmatic elements; match capitalization used in code and language conventions. Use code style for commands, options, identifiers, and markup.
+- **Instructions**: Use imperative verbs, complete sentences, and consistent step structure; cap the first word, end steps with periods, and keep procedures short. Use sentence-style capitalization for headings and UI labels.
+- **UI labels in prose**: When referring to UI text, either describe the action without a label, or clearly set off the label; use quotes or bold sparingly and consistently.
+
+### 4b) Ads docs checks
+
+When writing or editing Ads docs:
+
+- Write for marketing developers: assume technical fluency, but explain Ads concepts in plain, direct, practical language before implementation details.
+- Start with the job to be done: setup measurement, create campaigns, sync audiences, query insights, or debug delivery.
+- Use concrete, workflow-shaped examples with realistic advertiser scenarios, short steps, and small happy-path code snippets.
+- Build mental models around outcomes: data flow, update timing, defaults, and how choices affect reporting, targeting, or optimization.
+- Stay crisp and direct: short sections, short paragraphs, practical bullets, useful tables and snippets, no marketing fluff.
+- For Ads API docs, use the API when possible to confirm behavior; ask the human for an API key if needed.
+- Do not add Ads changelog entries under `/content/changelogs`. For API-impacting Ads changes, update `/ads/api-overview#changelog`.
+
+### 4c) Tighten prose without changing meaning
+
+- Put accuracy first, clarity second, and cadence third. Before rewriting, identify protected actors, actions, objects, values, counts, sequences, conditions, scope, modality, negation, literals, and uncertainty markers. Compare them with the revision before finishing. Revert any introduced drift. If the source is ambiguous, preserve the original wording and flag the ambiguity for review.
+- Lead with the point. Prefer concrete nouns, strong verbs, and the plainest accurate wording.
+- Apply a literal-action test to abstract phrasing only when the source supplies the answer: who or what acts, what changes, and what happens next? Never invent or broaden an actor to avoid passive voice. Keep process-focused passive voice when the actor is unknown, irrelevant, or intentionally omitted.
+- Treat phrases such as “not just X but Y,” “leverage,” “unlock,” “seamless,” “at scale,” “drive alignment,” “move work forward,” and “operationalize” as review prompts, not banned words. Replace them only when plainer wording is more specific.
+- Cut throat-clearing, filler, repeated conclusions, vague praise, and ornamental transitions. Read the result once for natural cadence without flattening useful warmth or nuance.
+- Correct a count or logical mismatch only when the surrounding source establishes the intended value or logic. A list-count mismatch alone is not enough evidence to choose a correction. Otherwise, preserve the original wording and flag the mismatch for review.
+- Preserve exact product terminology, UI labels, error messages, commands, paths, code identifiers, normative keywords, negation, and security conditions. Repository mechanics and Vale remain constraints.
+- Keep this pass local to the requested or already-touched prose. Don't create formatting, structural, or file-wide churn solely for rhythm.
+
+### 5) Fix what is safe
+
+- Auto-fix obvious typos, punctuation, spacing, and clear grammar errors.
+- Keep edits minimal and reversible.
+- If a fix could change meaning or requires product knowledge, flag it instead of editing.
+- After edits, re-run Vale on the same scope when available.
+
+### 6) Report results
+
+- Provide a short summary, then list issues by priority with file/line references.
+- Clearly separate:
+  - **Auto-fixed** items (already changed)
+  - **Needs review** items (awaiting user decision)
+- Ask for confirmation before making non-trivial rewrites or meaning-altering edits.
+
+## Output expectations
+
+- Default to concise, reviewer-style feedback.
+- Highlight inconsistencies (for example: “list says three items but shows two”).
+- If no issues are found, say so explicitly and mention whether Vale ran.

--- a/.codex/skills/docs-editor/SKILL.md
+++ b/.codex/skills/docs-editor/SKILL.md
@@ -1,112 +1,84 @@
 ---
 name: docs-editor
-description: Review and edit technical documentation (Markdown/MDX) with Chicago Manual of Style + Microsoft Writing Style Guide alignment. Use when asked to review, edit, or QA docs for clarity, grammar, consistency, and style; to run Vale linting with a repo .vale.ini; to identify and prioritize doc issues and fixes; or to write or edit Ads docs using the repo's Ads-specific docs style guidance.
-metadata:
-  short-description: Review and edit docs
+description: Review and edit OpenAI Cookbook notebooks, Markdown, and MDX for technical accuracy, clarity, grammar, consistency, runnable examples, and repository publication requirements. Use for editorial reviews, pre-merge documentation checks, or notebook Markdown-cell sweeps in openai-cookbook.
 ---
 
-# Docs Editor
+# OpenAI Cookbook docs editor
 
-## Overview
+## Objective
 
-Review technical documentation for style, clarity, and consistency. Run Vale when available, then perform a human review, fix easy issues, and report remaining issues by priority.
+Review Cookbook content conservatively. Improve correctness and readability without changing the author's intent, inventing facts, or creating unrelated churn.
 
 ## Workflow
 
-### 1) Gather inputs
+### 1. Define the scope
 
-- Prefer a specific file path. If none is provided, confirm scope.
-- Accept a glob for MD/MDX when the user wants a sweep (for example: `--glob='*.{mdx,md}'`).
-- Never invent or add new factual content.
+- Prefer explicit paths or the files changed in the pull request.
+- For pull requests, review changed `.md` and `.mdx` files plus Markdown cells in changed `.ipynb` files.
+- Review `registry.yaml` and `authors.yaml` when content is added, moved, removed, or attributed to a new author.
+- Stay within the requested content. Do not turn a focused review into a repository-wide rewrite.
 
-### 2) Run repository Vale
+### 2. Protect notebook integrity
 
-- Check for `.vale.ini` in the project root. If it is missing, note that and proceed with manual review.
-- Run `pnpm run setup` when Vale 3 or newer, or synchronized packages, are unavailable. This is the repository's supported bootstrap path.
-- Run `pnpm run vale -- <path...>` with explicit Markdown or MDX paths. Resolve globs to paths before invoking the command.
-- Don't call global Vale directly for repository files. The wrapper enforces repository configuration, package checks, exclusions, and `--no-global` behavior.
+- When the request is editorial, edit only notebook Markdown cells.
+- Preserve code cells, outputs, execution counts, attachments, cell order, cell IDs, and notebook and cell metadata.
+- Avoid reserializing an entire notebook for a small prose change. Inspect the diff for unintended JSON churn.
+- Do not execute notebook code unless the user requests it or code changes are in scope. Markdown-only edits require structural validation, not calls to external services.
+- Never add hard-coded secrets. Document required environment variables such as `OPENAI_API_KEY`.
 
-### 2a) Astro partials via stdin
+### 3. Review the content
 
-The repository wrapper accepts files, not stdin. If content lives in an `.astro` file and only a subset of copy should be linted, extract the relevant Markdown or MDX and pass it to Vale with the same repository flags:
+Load `resources/style-guide.md` and check:
+
+- Technical claims, API names, model names, identifiers, commands, paths, and URLs.
+- Agreement between prose, code, sample inputs, and expected outputs.
+- Prerequisites, dependencies, environment variables, and steps needed to run an example.
+- File and notebook names, headings, lists, numbering, cross-references, and links.
+- Grammar, spelling, punctuation, terminology, capitalization, and concise wording.
+- Publication metadata in `registry.yaml` and author metadata in `authors.yaml` when applicable.
+
+Verify uncertain technical claims from an authoritative source or flag them for review. Do not guess.
+
+### 4. Prioritize findings
+
+Use the repository's review bar:
+
+- **P0**: Broken notebook JSON; hard-coded secrets; materially false or unsafe guidance; or any repository-defined P0 issue, including naming violations, typos, broken links, inconsistent formatting, placeholder identifiers, undocumented environment variables, or out-of-sync publication metadata.
+- **P1**: Misleading instructions, prose that contradicts code or output, missing prerequisites, or a required link that does not work.
+- **P2**: Clear improvements to grammar, consistency, organization, or readability that do not affect correctness.
+- **P3**: Optional polish with little effect on comprehension.
+
+### 5. Make safe edits
+
+- Fix obvious typos, grammar, punctuation, broken local references, and clear prose/code mismatches.
+- Keep changes minimal, local, and reversible.
+- Preserve exact literals, code identifiers, commands, values, counts, conditions, modality, negation, and uncertainty markers.
+- Tighten prose only when meaning stays unchanged. Prefer concrete nouns, strong verbs, short introductions, and direct instructions.
+- Flag any change that depends on product knowledge or could alter meaning instead of guessing.
+- Do not make file-wide formatting or stylistic changes solely for uniformity.
+
+### 6. Validate the result
+
+For any changed notebook, run the repository validator:
 
 ```bash
-printf '%s\n' "*This* is Markdown" | vale --no-global --no-wrap --ext=.mdx
+env -u VIRTUAL_ENV uv run --with nbformat python .github/scripts/check_notebooks.py
 ```
 
-### 3) Triage findings
+Then:
 
-- Parse Vale output and map each alert to a priority.
-- Apply the repo rule: any spelling or grammar issues in `.mdx` are **P0/P1**.
-- If Vale reports vocabulary/spelling errors, ask the user first whether any terms should be added to the appropriate `accept.txt` vocabulary list before editing content.
-- Use this priority scale:
-  - **P0**: Critical correctness or meaning issues; spelling/grammar in `.mdx`.
-  - **P1**: Major clarity, ambiguity, or misleading statements.
-  - **P2**: Consistency, tone, minor grammar, or style issues.
-  - **P3**: Nits and optional improvements.
+- Run `git diff --check`.
+- Inspect the diff and confirm that notebook changes are limited to intended Markdown cells.
+- Run an available YAML linter if `registry.yaml` or `authors.yaml` changed.
+- Run the relevant example or test only when executable content changed and its dependencies are available.
 
-### 4) Manual review (Chicago + Microsoft style)
+### 7. Report the review
 
-Focus on:
+Provide:
 
-- Clarity and brevity (tighten wordiness, active voice).
-- Consistent terminology and capitalization.
-- Parallel structure in lists and headings.
-- Consistent punctuation, spacing, and heading styles.
-- Logical consistency: list counts, referenced items, numbering, examples, and cross-references.
-- For detailed developer-doc rules, load `resources/style-guide.md` and apply the checklist.
+- A short summary of the scope and edits.
+- Auto-fixed items.
+- Remaining findings grouped by priority with file and cell or line references.
+- The validation commands run and their results.
 
-### 4a) Developer content checks
-
-Apply Microsoft Writing Style Guide guidance that targets developer documentation:
-
-- **Audience + voice**: Assume baseline dev knowledge; skip basics and focus on product-specific goals. Keep the voice warm, crisp, and helpful.
-- **Reference documentation**: Favor consistent structure and predictable headings. Ensure a concise description, syntax/signature, requirements/applies-to, examples, exceptions/permissions where applicable, and “See also” links. Don’t repeat the element name in the description.
-- **Code examples**: Make examples task-based, concise, and practical; start simple, avoid contrived scenarios, list prerequisites, show expected output, and ensure secure, tested code. Don’t add exception handling unless intrinsic to the example.
-- **Formatting developer text**: Use code style for programmatic elements; match capitalization used in code and language conventions. Use code style for commands, options, identifiers, and markup.
-- **Instructions**: Use imperative verbs, complete sentences, and consistent step structure; cap the first word, end steps with periods, and keep procedures short. Use sentence-style capitalization for headings and UI labels.
-- **UI labels in prose**: When referring to UI text, either describe the action without a label, or clearly set off the label; use quotes or bold sparingly and consistently.
-
-### 4b) Ads docs checks
-
-When writing or editing Ads docs:
-
-- Write for marketing developers: assume technical fluency, but explain Ads concepts in plain, direct, practical language before implementation details.
-- Start with the job to be done: setup measurement, create campaigns, sync audiences, query insights, or debug delivery.
-- Use concrete, workflow-shaped examples with realistic advertiser scenarios, short steps, and small happy-path code snippets.
-- Build mental models around outcomes: data flow, update timing, defaults, and how choices affect reporting, targeting, or optimization.
-- Stay crisp and direct: short sections, short paragraphs, practical bullets, useful tables and snippets, no marketing fluff.
-- For Ads API docs, use the API when possible to confirm behavior; ask the human for an API key if needed.
-- Do not add Ads changelog entries under `/content/changelogs`. For API-impacting Ads changes, update `/ads/api-overview#changelog`.
-
-### 4c) Tighten prose without changing meaning
-
-- Put accuracy first, clarity second, and cadence third. Before rewriting, identify protected actors, actions, objects, values, counts, sequences, conditions, scope, modality, negation, literals, and uncertainty markers. Compare them with the revision before finishing. Revert any introduced drift. If the source is ambiguous, preserve the original wording and flag the ambiguity for review.
-- Lead with the point. Prefer concrete nouns, strong verbs, and the plainest accurate wording.
-- Apply a literal-action test to abstract phrasing only when the source supplies the answer: who or what acts, what changes, and what happens next? Never invent or broaden an actor to avoid passive voice. Keep process-focused passive voice when the actor is unknown, irrelevant, or intentionally omitted.
-- Treat phrases such as “not just X but Y,” “leverage,” “unlock,” “seamless,” “at scale,” “drive alignment,” “move work forward,” and “operationalize” as review prompts, not banned words. Replace them only when plainer wording is more specific.
-- Cut throat-clearing, filler, repeated conclusions, vague praise, and ornamental transitions. Read the result once for natural cadence without flattening useful warmth or nuance.
-- Correct a count or logical mismatch only when the surrounding source establishes the intended value or logic. A list-count mismatch alone is not enough evidence to choose a correction. Otherwise, preserve the original wording and flag the mismatch for review.
-- Preserve exact product terminology, UI labels, error messages, commands, paths, code identifiers, normative keywords, negation, and security conditions. Repository mechanics and Vale remain constraints.
-- Keep this pass local to the requested or already-touched prose. Don't create formatting, structural, or file-wide churn solely for rhythm.
-
-### 5) Fix what is safe
-
-- Auto-fix obvious typos, punctuation, spacing, and clear grammar errors.
-- Keep edits minimal and reversible.
-- If a fix could change meaning or requires product knowledge, flag it instead of editing.
-- After edits, re-run Vale on the same scope when available.
-
-### 6) Report results
-
-- Provide a short summary, then list issues by priority with file/line references.
-- Clearly separate:
-  - **Auto-fixed** items (already changed)
-  - **Needs review** items (awaiting user decision)
-- Ask for confirmation before making non-trivial rewrites or meaning-altering edits.
-
-## Output expectations
-
-- Default to concise, reviewer-style feedback.
-- Highlight inconsistencies (for example: “list says three items but shows two”).
-- If no issues are found, say so explicitly and mention whether Vale ran.
+If no issues remain, say so explicitly.

--- a/.codex/skills/docs-editor/resources/style-guide.md
+++ b/.codex/skills/docs-editor/resources/style-guide.md
@@ -1,359 +1,80 @@
-# Developer documentation style rules
-
-_Based on the Microsoft Style Guide._
-
-This document is a **review + rewrite checklist** optimized for consistent wording, capitalization, UI verbs, list/step structure, formatting patterns, and conventions.
-
-## Scope and intent
-
-- Write for developers and technical users: assume **general programming knowledge** and focus on **product- or technology-specific** guidance that helps readers accomplish goals.
-- Prefer content that is **task- and outcome-oriented**: what the reader can do and what happens when they do it.
-- Treat **reference documentation and code examples** as first-class documentation artifacts.
-
----
-
-## Voice and tone rules
-
-### Get to the point
-
-- Put the **key takeaway first**. Lead with the action/outcome the reader wants.
-- Keep intros short; avoid long warmups before any actionable content.
-
-### Sound human (not casual, not corporate)
-
-- Use short, everyday words.
-- Use contractions when they improve flow.
-- Avoid unnecessary formality and inflated language.
-
-### Keep it simple
-
-- Prefer shorter sentences and paragraphs.
-- Break complex ideas into steps, lists, or layered explanations.
-- Remove filler and repeated information.
-
----
-
-## Scannability and structure
-
-- Put the most important information **near the top**.
-- Use headings, lists, and tables to make content **scan-first**.
-- Keep paragraphs short (rule of thumb: **3–7 lines**). Single-line paragraphs are okay occasionally.
-- Keep formatting consistent within a section (especially for UI labels and procedures).
-- Use parallel sentence structure in comparisons, lists, and sibling headings.
-
----
-
-## Headings
-
-### What headings should do
-
-- Keep headings short and **front-load the key idea**.
-- Prefer headings about **what the reader can do**, not internal feature names.
-- Avoid consecutive headings with no text between them.
-- Use parallel structure at the same heading level.
-
-Recommended heading patterns by level:
-
-- Top-level: **noun phrases** (topic labels)
-- Second-level: **verb phrases** (actions within the topic)
-- Task/procedure headings: **infinitive phrases** (“To …”)
-
-### Heading formatting
-
-- Use **sentence-style capitalization** for headings and titles:
-  - Capitalize the first word; lowercase the rest except proper nouns.
-- Don’t end headings with a period. Use question marks only when needed.
-- Avoid `&` and `+` unless they are literal UI text or space is extremely constrained.
-- Avoid hyphens in headings when you can rewrite.
-- Use **“vs.”** (not “v.” or “versus”).
-
----
-
-## Lists
-
-### Choose the right list type
-
-- Use **bullets** for items in no particular order.
-- Use **numbers** for sequences, procedures, rankings, or priority.
-
-### Introduce lists correctly
-
-Use one of:
-
-- A heading, or
-- A complete sentence, or
-- A fragment ending with a colon.
-
-Avoid list-intros that must be “completed” by the list items (harder to translate and easier to mispunctuate).
-
-### Capitalization and punctuation in list items
-
-- Start each item with a capital letter unless it must be lowercase (e.g., a command).
-- Don’t end items with semicolons, commas, or conjunctions (“and/or”).
-- Don’t end items with periods unless items are complete sentences.
-- If a fragment + colon intro makes list items read as full sentences when combined, use periods on **all** items.
-  - Exception: don’t add periods if all items are **three or fewer words** or if items are **UI labels/strings/headings**.
-
----
-
-## Procedures and step-by-step instructions
-
-### Structure and consistency
-
-- Use a numbered list for multi-step procedures.
-- Use a procedure heading that states what the reader will accomplish.
-- Use one numbered entry per step (combine only very short actions that occur in the same place).
-- Include “finalize” actions (like selecting **OK**/**Apply**) when they matter.
-- Use **imperative verbs** and complete sentences.
-- Keep steps consistent:
-  - Use a location phrase only when needed (“On the …, …”).
-  - Otherwise start with a verb.
-
-### Formatting rules
-
-- Capitalize the first word in each step.
-- End each step with a period.
-  - Exception: if a step is _only_ user input that must not include punctuation, put the input on its own line and don’t force a period into the input.
-- Keep procedures short: aim for **7 steps or fewer** (prefer fewer); try to fit on one screen.
-
-### Single-step procedures
-
-- If your docs consistently use “steps,” keep the same structure but use a **bullet** for single-step instructions.
-
----
-
-## Describing interactions with UI
-
-### Prefer input-neutral verbs
-
-Avoid input-specific verbs (mouse/touch dependent). Prefer verbs that work across input methods.
-
-Preferred verb patterns:
-
-- **Open**: apps, files, folders, panels (not typically commands/menus).
-- **Close**: apps, dialogs, tabs, panels.
-- **Go to**: locations in UI, pages, tabs, websites.
-- **Select**: buttons, checkboxes, menu items, links, list values, and keys/shortcuts.
-- **Choose**: selecting among options based on preference/outcome.
-- **Clear**: removing a checkbox selection.
-- **Turn on / Turn off / Switch**: toggles.
-- **Select and hold (or right-click)**: when both interaction modes are relevant.
-
-### UI path shorthand using `>`
-
-Use `>` to abbreviate simple sequences when:
-
-- The path is obvious, and
-- The interaction method is consistent across steps.
-
-Formatting rules:
-
-- Use spaces around the symbol: `A > B > C`
-- Don’t bold the `>`.
-
----
-
-## Formatting conventions in instructions
-
-General rule: focus on actions; avoid unnecessary UI-element jargon. When you must name UI text, follow consistent formatting rules.
-
-### UI labels and elements (procedures)
-
-- **Bold** literal UI names when the reader must interact with them (buttons, menu items, toggles, dialog names, panel names).
-- Don’t include element types (“button”, “menu”, “pane”, “panel”) unless it clarifies meaning.
-- If a UI label ends with a colon or ellipsis, omit that punctuation when writing instructions.
-
-Examples:
-
-- Prefer: Select **Save as**
-- Avoid: Click the **Save as…** button
-
-### Commands and command-line
-
-- Use `code style` for command-line commands and anything the reader must type verbatim.
-- Use `code style` for options/switches/flags; match required capitalization exactly.
-
-### Dialogs
-
-- Refer to them as “dialog” (avoid “dialog box” and “pop-up window”).
-- Bold dialog names when referenced as literal UI text.
-
-### Error messages
-
-- Use sentence-style capitalization.
-- When referencing an error message in prose, put it in **quotation marks**.
-
-### plaintext vs. plain text
-
-- Use **plaintext** when describing data that is stored or transmitted without encryption or encoding (for example, "stored in a plaintext file").
-- Use **plain text** when describing formatting or rich-text behavior (for example, "enter plain text").
-
-### Files, folders, extensions, attributes
-
-- File attributes: lowercase.
-- File extensions: lowercase (e.g., `.json`, `.yaml`).
-- File/folder names:
-  - Use `code style` when used as code or literal paths.
-  - In procedures, bold file/folder names when the reader must select or enter them.
-
-### Keys and keyboard shortcuts
-
-- Bold key names and shortcuts in instructions.
-- No spaces around plus signs in shortcuts (e.g., `Ctrl+Alt+Del`).
-
-### Placeholders, strings, URLs, user input
-
-- Placeholders:
-  - Use italics for placeholder UI text when needed.
-  - Use angle brackets for code placeholders when they aren’t part of the language syntax: `<placeholder>`.
-- Slashes:
-  - If the reader must type a slash, name it and show the symbol: “enter a backslash (`\`)”.
-- Strings:
-  - Use sentence-style capitalization unless the literal text differs.
-  - Use `code style` for literal strings used in code.
-- URLs:
-  - Use lowercase for complete URLs.
-  - Don’t hyphenate URLs; line-break before a slash when possible.
-- User input:
-  - Use lowercase unless case-sensitive.
-  - Don’t italicize user input unless it’s a placeholder.
-
----
-
-## Developer text elements: what to format as code
-
-Use `code style` (inline code or fenced blocks) for programmatic elements, including:
-
-- Class, method, function, parameter, and member names
-- Keywords and tokens
-- Markup tags
-- Commands, flags, and environment variables
-- File paths and code identifiers
-
-Capitalization:
-
-- Match the language/environment conventions.
-- Match exact casing when the reader must type it.
-
----
-
-## Reference documentation rules
-
-Enforce consistency: predictable structure helps readers quickly find what they need.
-
-### Reference article titles
-
-- Title format: `ElementName` + element type (e.g., “Thing method”, “Thing class”).
-- If names collide, add a differentiator (parent element, technology name) for clarity in navigation and search.
-
-### Reference article content checklist
-
-Include sections as applicable:
-
-- **Title and description**: concise description of what the element does; don’t just repeat the element name.
-- **Syntax/Declaration**: signature(s); per-language syntax where relevant.
-- **Parameters**: for each parameter, include type and meaningful behavioral detail; don’t just restate name/type.
-- **Return value**: describe the type and meaning; for booleans, define the condition.
-- **Remarks**: behavior, edge cases, comparisons, pitfalls.
-- **Example**: a practical usage example (see next section).
-- **Requirements / Applies to**: platform/language requirements.
-- **See also**: related elements.
-
----
-
-## Code examples rules
-
-Code examples are often copy/pasted, so make them usable and meaningful.
-
-### Planning examples
-
-- Prefer concise examples for key tasks.
-- Start with simple, common scenarios; add complexity later.
-- Prioritize frequently used or tricky elements.
-- Avoid contrived examples that illustrate obvious points.
-
-### Writing examples
-
-- Add a short intro describing the scenario.
-- List prerequisites/dependencies needed to run the code.
-- Make it easy to copy and run.
-- Use comments to explain non-obvious parts (don’t narrate the code line-by-line).
-- Show expected output when output matters.
-- Prefer secure patterns: don’t hard-code secrets; validate input.
-- Include exception handling only when it’s intrinsic to the concept being demonstrated.
-- Ensure examples are tested and correct.
-
----
-
-## Capitalization
-
-Default to **sentence-style capitalization** in headings, titles, UI labels, and standalone phrases:
-
-- Capitalize the first word.
-- Capitalize proper nouns.
-- Lowercase everything else.
-
-Avoid:
-
-- ALL CAPS for emphasis.
-- Internal capitalization unless it’s part of a proper name.
-
-Colon rule:
-
-- In titles/headings with a colon, capitalize the first word after the colon.
-
----
-
-## Bias-free and inclusive language (lintable word rules)
-
-### Gender-neutral language
-
-Replace gendered job titles and generic gendered phrasing with neutral alternatives.
-
-Examples (non-exhaustive):
-
-- chairman → chair, moderator
-- mankind/man → humanity, people
-- salesman → sales representative
-- manmade → synthetic, manufactured
-- manpower → workforce, staff, personnel
-
-### Pronouns in generic references
-
-Avoid “he/him” and “she/her” for generic references. Prefer:
-
-- “you”
-- plural nouns/pronouns
-- “the” + noun (“the user”, “the admin”)
-- role terms (“reader”, “customer”, “developer”)
-
-Singular “they” is acceptable when needed. Avoid “he/she” or “s/he”.
-
-### Avoid biased or loaded terms
-
-Replace terms with problematic historical or militaristic associations or common biased usage.
-Examples:
-
-- master/slave → primary/secondary, primary/subordinate
-- demilitarized zone (DMZ) → perimeter network
-- hang (in computing sense) → stop responding
-
-### Disability language
-
-- Focus on people, not disabilities.
-- Avoid pity language (“suffering from”).
-- Don’t mention disability unless relevant.
-
----
-
-## Fast agent workflow checklist
-
-1. **Developer fit**: remove basics; focus on product/tech-specific tasks and details.
-2. **Scannability**: shorten intro, headings, paragraphs; add lists/steps for scannability.
-3. **Headings**: sentence case; no periods; parallel structure; avoid `&/+/-`; use `vs.`
-4. **Lists**: correct list type; clean intros; consistent punctuation/capitalization.
-5. **Procedures**: imperative steps; correct UI verbs; <=7 steps; step punctuation rules.
-6. **UI formatting**: bold UI labels; omit element-type words unless needed; drop label colons/ellipses.
-7. **Developer formatting**: `code style` for identifiers/commands; lowercase extensions/URLs; quote error messages; shortcut formatting.
-8. **Inclusive language**: neutral terms; avoid generic he/she; avoid loaded terminology.
-9. **Reference + examples**: ensure required sections and non-contrived, runnable examples; ensure secure patterns.
+# OpenAI Cookbook editorial checklist
+
+Use this checklist for articles and notebook Markdown cells in `openai-cookbook`. Apply only the rules relevant to the content under review.
+
+## Audience and purpose
+
+- Write for developers who want to understand and run an OpenAI API example.
+- State the task or outcome early. Keep background material only when it helps the reader use the example correctly.
+- Assume general programming knowledge, but explain Cookbook-specific setup, choices, and tradeoffs.
+- Avoid promotional language, vague praise, and claims that the example does not demonstrate.
+
+## Technical accuracy
+
+- Match API, model, method, parameter, field, file, and environment-variable names exactly.
+- Keep prose consistent with the code, sample inputs, outputs, diagrams, and nearby cells.
+- Check counts, ordered steps, cross-references, defaults, constraints, and stated results.
+- Do not infer a correction when the intended fact is unclear. Preserve the source and flag it for review.
+- Use authoritative sources to verify uncertain product behavior.
+- Do not imply that an optional step is required or that a required step is optional.
+
+## Runnable examples
+
+- List prerequisites and dependencies that readers need before running the example.
+- Document required environment variables. Never hard-code API keys, tokens, credentials, or other secrets.
+- Keep setup instructions in the same order that readers perform them.
+- Introduce code with the goal or reason for the step; do not narrate every line.
+- Use realistic inputs and clearly label placeholders.
+- Show expected output only when it helps readers verify success, and keep it consistent with the code.
+- Keep external-service calls and other opt-in behavior clearly labeled.
+
+## Notebook integrity
+
+- Edit Markdown cells only during an editorial pass.
+- Preserve code cells, outputs, execution counts, attachments, cell IDs, cell order, and metadata.
+- Keep notebook JSON valid and avoid whole-file reserialization for a small prose edit.
+- Keep each Markdown cell focused. Split or merge cells only when the structure is genuinely confusing and the request permits it.
+- Use Markdown headings in a logical hierarchy without skipping levels unnecessarily.
+
+## Prose
+
+- Lead with the point. Prefer concrete nouns and strong verbs.
+- Use direct instructions and address the reader as “you” when helpful.
+- Prefer active voice, but keep passive voice when the actor is unknown or unimportant.
+- Remove throat-clearing, repeated conclusions, filler, and ornamental transitions.
+- Keep paragraphs short enough to scan and use lists for genuinely parallel items.
+- Use numbered lists for ordered procedures and bullets for unordered groups.
+- Keep sibling headings and list items parallel.
+- Use sentence-style capitalization for headings and do not end headings with periods.
+- Preserve useful warmth and explanation; do not flatten the content into terse fragments.
+
+## Terminology and formatting
+
+- Use exact product terminology and consistent capitalization.
+- Format commands, options, environment variables, paths, filenames, code identifiers, and literal values with backticks.
+- Match the capitalization and spelling used by the language or API.
+- Expand uncommon abbreviations on first use unless the surrounding audience clearly knows them.
+- Use inclusive, precise language and neutral role terms.
+- Do not replace a technically precise term merely to vary wording.
+
+## Links and assets
+
+- Prefer descriptive link text over “here” or a pasted URL.
+- Verify local links, anchors, image paths, and referenced notebook or article paths.
+- Use stable, authoritative external links when available.
+- Give images meaningful alt text unless they are purely decorative.
+- Keep diagrams, screenshots, captions, and prose consistent.
+
+## Publication metadata
+
+- Add or update `registry.yaml` for new, moved, renamed, or removed published content.
+- Confirm registry paths, dates, tags, and titles match the content.
+- Add or update `authors.yaml` when introducing or changing author attribution.
+- Check that filenames follow the repository's naming conventions and clearly describe the content.
+
+## Final review
+
+- Read each edited passage in context, not only as an isolated diff hunk.
+- Confirm no factual meaning, literal value, condition, negation, or uncertainty changed unintentionally.
+- Confirm all repository-defined P0 issues are fixed.
+- Run the notebook structural validator for changed notebooks and inspect the final diff for unintended changes.

--- a/.codex/skills/docs-editor/resources/style-guide.md
+++ b/.codex/skills/docs-editor/resources/style-guide.md
@@ -1,0 +1,359 @@
+# Developer documentation style rules
+
+_Based on the Microsoft Style Guide._
+
+This document is a **review + rewrite checklist** optimized for consistent wording, capitalization, UI verbs, list/step structure, formatting patterns, and conventions.
+
+## Scope and intent
+
+- Write for developers and technical users: assume **general programming knowledge** and focus on **product- or technology-specific** guidance that helps readers accomplish goals.
+- Prefer content that is **task- and outcome-oriented**: what the reader can do and what happens when they do it.
+- Treat **reference documentation and code examples** as first-class documentation artifacts.
+
+---
+
+## Voice and tone rules
+
+### Get to the point
+
+- Put the **key takeaway first**. Lead with the action/outcome the reader wants.
+- Keep intros short; avoid long warmups before any actionable content.
+
+### Sound human (not casual, not corporate)
+
+- Use short, everyday words.
+- Use contractions when they improve flow.
+- Avoid unnecessary formality and inflated language.
+
+### Keep it simple
+
+- Prefer shorter sentences and paragraphs.
+- Break complex ideas into steps, lists, or layered explanations.
+- Remove filler and repeated information.
+
+---
+
+## Scannability and structure
+
+- Put the most important information **near the top**.
+- Use headings, lists, and tables to make content **scan-first**.
+- Keep paragraphs short (rule of thumb: **3–7 lines**). Single-line paragraphs are okay occasionally.
+- Keep formatting consistent within a section (especially for UI labels and procedures).
+- Use parallel sentence structure in comparisons, lists, and sibling headings.
+
+---
+
+## Headings
+
+### What headings should do
+
+- Keep headings short and **front-load the key idea**.
+- Prefer headings about **what the reader can do**, not internal feature names.
+- Avoid consecutive headings with no text between them.
+- Use parallel structure at the same heading level.
+
+Recommended heading patterns by level:
+
+- Top-level: **noun phrases** (topic labels)
+- Second-level: **verb phrases** (actions within the topic)
+- Task/procedure headings: **infinitive phrases** (“To …”)
+
+### Heading formatting
+
+- Use **sentence-style capitalization** for headings and titles:
+  - Capitalize the first word; lowercase the rest except proper nouns.
+- Don’t end headings with a period. Use question marks only when needed.
+- Avoid `&` and `+` unless they are literal UI text or space is extremely constrained.
+- Avoid hyphens in headings when you can rewrite.
+- Use **“vs.”** (not “v.” or “versus”).
+
+---
+
+## Lists
+
+### Choose the right list type
+
+- Use **bullets** for items in no particular order.
+- Use **numbers** for sequences, procedures, rankings, or priority.
+
+### Introduce lists correctly
+
+Use one of:
+
+- A heading, or
+- A complete sentence, or
+- A fragment ending with a colon.
+
+Avoid list-intros that must be “completed” by the list items (harder to translate and easier to mispunctuate).
+
+### Capitalization and punctuation in list items
+
+- Start each item with a capital letter unless it must be lowercase (e.g., a command).
+- Don’t end items with semicolons, commas, or conjunctions (“and/or”).
+- Don’t end items with periods unless items are complete sentences.
+- If a fragment + colon intro makes list items read as full sentences when combined, use periods on **all** items.
+  - Exception: don’t add periods if all items are **three or fewer words** or if items are **UI labels/strings/headings**.
+
+---
+
+## Procedures and step-by-step instructions
+
+### Structure and consistency
+
+- Use a numbered list for multi-step procedures.
+- Use a procedure heading that states what the reader will accomplish.
+- Use one numbered entry per step (combine only very short actions that occur in the same place).
+- Include “finalize” actions (like selecting **OK**/**Apply**) when they matter.
+- Use **imperative verbs** and complete sentences.
+- Keep steps consistent:
+  - Use a location phrase only when needed (“On the …, …”).
+  - Otherwise start with a verb.
+
+### Formatting rules
+
+- Capitalize the first word in each step.
+- End each step with a period.
+  - Exception: if a step is _only_ user input that must not include punctuation, put the input on its own line and don’t force a period into the input.
+- Keep procedures short: aim for **7 steps or fewer** (prefer fewer); try to fit on one screen.
+
+### Single-step procedures
+
+- If your docs consistently use “steps,” keep the same structure but use a **bullet** for single-step instructions.
+
+---
+
+## Describing interactions with UI
+
+### Prefer input-neutral verbs
+
+Avoid input-specific verbs (mouse/touch dependent). Prefer verbs that work across input methods.
+
+Preferred verb patterns:
+
+- **Open**: apps, files, folders, panels (not typically commands/menus).
+- **Close**: apps, dialogs, tabs, panels.
+- **Go to**: locations in UI, pages, tabs, websites.
+- **Select**: buttons, checkboxes, menu items, links, list values, and keys/shortcuts.
+- **Choose**: selecting among options based on preference/outcome.
+- **Clear**: removing a checkbox selection.
+- **Turn on / Turn off / Switch**: toggles.
+- **Select and hold (or right-click)**: when both interaction modes are relevant.
+
+### UI path shorthand using `>`
+
+Use `>` to abbreviate simple sequences when:
+
+- The path is obvious, and
+- The interaction method is consistent across steps.
+
+Formatting rules:
+
+- Use spaces around the symbol: `A > B > C`
+- Don’t bold the `>`.
+
+---
+
+## Formatting conventions in instructions
+
+General rule: focus on actions; avoid unnecessary UI-element jargon. When you must name UI text, follow consistent formatting rules.
+
+### UI labels and elements (procedures)
+
+- **Bold** literal UI names when the reader must interact with them (buttons, menu items, toggles, dialog names, panel names).
+- Don’t include element types (“button”, “menu”, “pane”, “panel”) unless it clarifies meaning.
+- If a UI label ends with a colon or ellipsis, omit that punctuation when writing instructions.
+
+Examples:
+
+- Prefer: Select **Save as**
+- Avoid: Click the **Save as…** button
+
+### Commands and command-line
+
+- Use `code style` for command-line commands and anything the reader must type verbatim.
+- Use `code style` for options/switches/flags; match required capitalization exactly.
+
+### Dialogs
+
+- Refer to them as “dialog” (avoid “dialog box” and “pop-up window”).
+- Bold dialog names when referenced as literal UI text.
+
+### Error messages
+
+- Use sentence-style capitalization.
+- When referencing an error message in prose, put it in **quotation marks**.
+
+### plaintext vs. plain text
+
+- Use **plaintext** when describing data that is stored or transmitted without encryption or encoding (for example, "stored in a plaintext file").
+- Use **plain text** when describing formatting or rich-text behavior (for example, "enter plain text").
+
+### Files, folders, extensions, attributes
+
+- File attributes: lowercase.
+- File extensions: lowercase (e.g., `.json`, `.yaml`).
+- File/folder names:
+  - Use `code style` when used as code or literal paths.
+  - In procedures, bold file/folder names when the reader must select or enter them.
+
+### Keys and keyboard shortcuts
+
+- Bold key names and shortcuts in instructions.
+- No spaces around plus signs in shortcuts (e.g., `Ctrl+Alt+Del`).
+
+### Placeholders, strings, URLs, user input
+
+- Placeholders:
+  - Use italics for placeholder UI text when needed.
+  - Use angle brackets for code placeholders when they aren’t part of the language syntax: `<placeholder>`.
+- Slashes:
+  - If the reader must type a slash, name it and show the symbol: “enter a backslash (`\`)”.
+- Strings:
+  - Use sentence-style capitalization unless the literal text differs.
+  - Use `code style` for literal strings used in code.
+- URLs:
+  - Use lowercase for complete URLs.
+  - Don’t hyphenate URLs; line-break before a slash when possible.
+- User input:
+  - Use lowercase unless case-sensitive.
+  - Don’t italicize user input unless it’s a placeholder.
+
+---
+
+## Developer text elements: what to format as code
+
+Use `code style` (inline code or fenced blocks) for programmatic elements, including:
+
+- Class, method, function, parameter, and member names
+- Keywords and tokens
+- Markup tags
+- Commands, flags, and environment variables
+- File paths and code identifiers
+
+Capitalization:
+
+- Match the language/environment conventions.
+- Match exact casing when the reader must type it.
+
+---
+
+## Reference documentation rules
+
+Enforce consistency: predictable structure helps readers quickly find what they need.
+
+### Reference article titles
+
+- Title format: `ElementName` + element type (e.g., “Thing method”, “Thing class”).
+- If names collide, add a differentiator (parent element, technology name) for clarity in navigation and search.
+
+### Reference article content checklist
+
+Include sections as applicable:
+
+- **Title and description**: concise description of what the element does; don’t just repeat the element name.
+- **Syntax/Declaration**: signature(s); per-language syntax where relevant.
+- **Parameters**: for each parameter, include type and meaningful behavioral detail; don’t just restate name/type.
+- **Return value**: describe the type and meaning; for booleans, define the condition.
+- **Remarks**: behavior, edge cases, comparisons, pitfalls.
+- **Example**: a practical usage example (see next section).
+- **Requirements / Applies to**: platform/language requirements.
+- **See also**: related elements.
+
+---
+
+## Code examples rules
+
+Code examples are often copy/pasted, so make them usable and meaningful.
+
+### Planning examples
+
+- Prefer concise examples for key tasks.
+- Start with simple, common scenarios; add complexity later.
+- Prioritize frequently used or tricky elements.
+- Avoid contrived examples that illustrate obvious points.
+
+### Writing examples
+
+- Add a short intro describing the scenario.
+- List prerequisites/dependencies needed to run the code.
+- Make it easy to copy and run.
+- Use comments to explain non-obvious parts (don’t narrate the code line-by-line).
+- Show expected output when output matters.
+- Prefer secure patterns: don’t hard-code secrets; validate input.
+- Include exception handling only when it’s intrinsic to the concept being demonstrated.
+- Ensure examples are tested and correct.
+
+---
+
+## Capitalization
+
+Default to **sentence-style capitalization** in headings, titles, UI labels, and standalone phrases:
+
+- Capitalize the first word.
+- Capitalize proper nouns.
+- Lowercase everything else.
+
+Avoid:
+
+- ALL CAPS for emphasis.
+- Internal capitalization unless it’s part of a proper name.
+
+Colon rule:
+
+- In titles/headings with a colon, capitalize the first word after the colon.
+
+---
+
+## Bias-free and inclusive language (lintable word rules)
+
+### Gender-neutral language
+
+Replace gendered job titles and generic gendered phrasing with neutral alternatives.
+
+Examples (non-exhaustive):
+
+- chairman → chair, moderator
+- mankind/man → humanity, people
+- salesman → sales representative
+- manmade → synthetic, manufactured
+- manpower → workforce, staff, personnel
+
+### Pronouns in generic references
+
+Avoid “he/him” and “she/her” for generic references. Prefer:
+
+- “you”
+- plural nouns/pronouns
+- “the” + noun (“the user”, “the admin”)
+- role terms (“reader”, “customer”, “developer”)
+
+Singular “they” is acceptable when needed. Avoid “he/she” or “s/he”.
+
+### Avoid biased or loaded terms
+
+Replace terms with problematic historical or militaristic associations or common biased usage.
+Examples:
+
+- master/slave → primary/secondary, primary/subordinate
+- demilitarized zone (DMZ) → perimeter network
+- hang (in computing sense) → stop responding
+
+### Disability language
+
+- Focus on people, not disabilities.
+- Avoid pity language (“suffering from”).
+- Don’t mention disability unless relevant.
+
+---
+
+## Fast agent workflow checklist
+
+1. **Developer fit**: remove basics; focus on product/tech-specific tasks and details.
+2. **Scannability**: shorten intro, headings, paragraphs; add lists/steps for scannability.
+3. **Headings**: sentence case; no periods; parallel structure; avoid `&/+/-`; use `vs.`
+4. **Lists**: correct list type; clean intros; consistent punctuation/capitalization.
+5. **Procedures**: imperative steps; correct UI verbs; <=7 steps; step punctuation rules.
+6. **UI formatting**: bold UI labels; omit element-type words unless needed; drop label colons/ellipses.
+7. **Developer formatting**: `code style` for identifiers/commands; lowercase extensions/URLs; quote error messages; shortcut formatting.
+8. **Inclusive language**: neutral terms; avoid generic he/she; avoid loaded terminology.
+9. **Reference + examples**: ensure required sections and non-contrived, runnable examples; ensure secure patterns.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ Execute notebooks top-to-bottom after installing dependencies and clear lingerin
 
 Use concise, imperative commit messages that describe the change scope (e.g., "Add agent portfolio collaboration demo"). Every PR should provide a summary, motivation, and self-review, and must tick the registry and authors checklist from `.github/pull_request_template.md`. Link issues when applicable and attach screenshots or output snippets for UI-heavy content. Confirm CI notebook validation passes locally before requesting review.
 
+Before a pull request is merged, run the repository's `docs-editor` skill on every changed Markdown, MDX, and notebook Markdown cell. Fix safe issues, rerun the relevant checks, and resolve or explicitly document all remaining P0 and P1 findings in the pull request.
+
 ## Metadata & Publication Workflow
 
 New or relocated content must have an entry in `registry.yaml` with an accurate path, date, and tag set so the static site generator includes it. When collaborating, coordinate author slugs in `authors.yaml` to avoid duplicates, and run `python -m yaml lint registry.yaml` (or your preferred YAML linter) to catch syntax errors before submitting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Execute notebooks top-to-bottom after installing dependencies and clear lingerin
 
 Use concise, imperative commit messages that describe the change scope (e.g., "Add agent portfolio collaboration demo"). Every PR should provide a summary, motivation, and self-review, and must tick the registry and authors checklist from `.github/pull_request_template.md`. Link issues when applicable and attach screenshots or output snippets for UI-heavy content. Confirm CI notebook validation passes locally before requesting review.
 
-Before a pull request is merged, run the repository's `docs-editor` skill on every changed Markdown, MDX, and notebook Markdown cell. Fix safe issues, rerun the relevant checks, and resolve or explicitly document all remaining P0 and P1 findings in the pull request.
+Before a pull request is merged, run the repository's `docs-editor` skill on every changed article, Markdown or MDX file, and notebook Markdown cell. For editorial notebook changes, preserve code cells, outputs, execution counts, attachments, cell order, and metadata. Fix safe issues, rerun the relevant checks, and resolve or explicitly document all remaining P0 and P1 findings in the pull request.
 
 ## Metadata & Publication Workflow
 


### PR DESCRIPTION
## Summary

- Adapt the latest `docs-editor` workflow for `openai/openai-cookbook`.
- Focus the skill on articles, Markdown/MDX, notebook Markdown cells, runnable examples, publication metadata, and notebook-safe validation.
- Remove developers-website-specific Vale, Astro, Ads, API-reference, and UI-writing guidance.
- Require the Cookbook-specific review before merge, including preservation of notebook code, outputs, execution state, attachments, ordering, and metadata.

## Motivation

The upstream skill was a useful starting point, but several sections were specific to `developers-website` and did not match this repository. This version keeps only the checks and procedures that apply to Cookbook content and makes that focused review an explicit pre-merge step.

## Self-review

- [x] Validated the skill with `skill-creator/scripts/quick_validate.py`.
- [x] Ran `git diff --check`.
- [x] Confirmed the skill contains no Vale, Astro, Ads, API-reference, or UI-doc procedures.
- [x] Forward-tested the skill read-only against an existing notebook; it stayed within Markdown cells and applied the expected notebook-integrity safeguards.
- [x] Confirmed no notebook, registry, or author metadata changes are required for this repository-policy update.

## For new content

- [x] Registry/authors checklist is not applicable; this PR adds repository tooling and policy, not published Cookbook content.