### PR TITLE
Unarchive Agents SDK memory cookbooks

### DIFF
--- a/examples/agents_sdk/context_personalization.ipynb
+++ b/examples/agents_sdk/context_personalization.ipynb
@@ -220,7 +220,7 @@
    "id": "18a8c00f",
    "metadata": {},
    "source": [
-    "**Tip:** Do not dump all the fields from internal systems into the profile section. Make sure that every single token you add here helps agent to make better decisions. Some these fields might even be an input parameter to a tool call that you can pass from the state object without making it visible to the model."
+    "**Tip:** Do not dump all the fields from internal systems into the profile section. Make sure that every single token you add here helps the agent make better decisions. Some of these fields might instead be input parameters to a tool call that you can pass from the state object without making them visible to the model."
    ]
   },
   {
@@ -405,7 +405,7 @@
     "\n",
     "Two-phase memory processing (note taking → consolidation) is more reliable than one-shot build the whole memory system at once.\n",
     "\n",
-    "All techniques in this cookbook are implemented in a **local-first** manner. Session and global memories live in your own state object and can be kept **ZDR (Zero Data Retention)** by design, as long as you avoid remote persistence.\n",
+    "All techniques in this cookbook are implemented in a **local-first** manner. Session and global memories live in your own state object. However, any profile or memory content injected into agent instructions is sent to the model API, so apply your organization’s retention and data-handling requirements before including sensitive data.\n",
     "\n",
     "These approaches are intentionally **zero-shot**—relying on prompting, orchestration, and lightweight scaffolding rather than training. Once the end-to-end design and evaluations are validated, a natural next step is **fine-tuning** to achieve stronger and more consistent memory behaviors such as extraction, consolidation, and conflict resolution.\n"
    ]

--- a/examples/agents_sdk/session_memory.ipynb
+++ b/examples/agents_sdk/session_memory.ipynb
@@ -46,7 +46,7 @@
     "\n",
     "You can continue a conversation by passing the prior response’s `id` as `previous_response_id`, or you can manage context manually by collecting outputs into a list and resubmitting them as the `input` for the next response.\n",
     "\n",
-    "What you don’t get is **automatic memory management**. That’s where the **Agents SDK** comes in. It provides [session memory](https://openai.github.io/openai-agents-python/sessions/) on top of Responses, so you no longer need to manually append `response.output` or track IDs yourself. The session becomes the **memory object**: you simply call `session.run(\"...\")` repeatedly, and the SDK handles context length, history, and continuity—making it far easier to build coherent, multi-turn agents."
+    "What you don’t get is **automatic memory management**. That’s where the **Agents SDK** comes in. It provides [session memory](https://openai.github.io/openai-agents-python/sessions/) on top of Responses, so you no longer need to manually append `response.output` or track IDs yourself. The session becomes the **memory object**: you repeatedly call `Runner.run(agent, \"...\", session=session)`, and the SDK handles context length, history, and continuity—making it far easier to build coherent, multi-turn agents."
    ]
   },
   {

--- a/registry.yaml
+++ b/registry.yaml
@@ -374,7 +374,6 @@
   path: examples/agents_sdk/session_memory.ipynb
   slug: session-memory
   date: 2025-09-09
-  archived: true
   authors:
     - emreokcular
   tags:
@@ -3344,7 +3343,6 @@
   slug: context-personalization
   description: Cookbook to build personalized agents with long-term memory state using the Agents SDK.
   date: 2026-01-05
-  archived: true
   authors:
     - emreokcular
   tags:


### PR DESCRIPTION
## Summary
- Unarchive Context Engineering - Short-Term Memory Management with Sessions.
- Unarchive Context Engineering for Personalization - State Management with Long-Term Memory Notes.

## Why
Both cookbooks cover current Agents SDK memory patterns and do not reference outdated models or APIs. They were included in earlier bulk archive passes without a cookbook-specific reason.

## Impact
The cookbooks return to the main listings and the archived-content warning is removed from their developer-site pages.

## Validation
- Parsed `registry.yaml` with Ruby YAML.
- Ran `git diff --check`.