### PR TITLE
Add cookbook: check citation faithfulness in RAG with a zero-token gate

### DIFF
--- a/authors.yaml
+++ b/authors.yaml
@@ -627,3 +627,8 @@ saptob:
   name: "Saptarshi Banerjee"
   website: "https://www.linkedin.com/in/saptarshi-banerjee-83472679"
   avatar: "https://avatars.githubusercontent.com/saptob"
+
+palo-alto-ai-research-lab:
+  name: "Palo Alto AI Research Lab"
+  website: "https://github.com/Palo-Alto-AI-Research-Lab"
+  avatar: "https://avatars.githubusercontent.com/u/194927794?v=4"

--- a/examples/citation_faithfulness_check.ipynb
+++ b/examples/citation_faithfulness_check.ipynb
@@ -1,0 +1,220 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b40669c5",
+   "metadata": {},
+   "source": [
+    "# Check citation faithfulness in RAG with a zero-token gate\n",
+    "\n",
+    "When a RAG answer cites its sources, the citations can fail in ways that read as\n",
+    "completely authoritative — and an LLM asked \"does this quote support the claim?\"\n",
+    "waves them through, because they *look* fluent and supportive:\n",
+    "\n",
+    "- **fabricated** — a quoted span that appears in no retrieved document;\n",
+    "- **frankenquote** — every word is real, but the exact span was never written\n",
+    "  contiguously in the source;\n",
+    "- **misattributed** — a real span, but attributed to the wrong document.\n",
+    "\n",
+    "This cookbook shows a *cheap deterministic detector → expensive judge* pattern for\n",
+    "catching these before the answer reaches a user:\n",
+    "\n",
+    "1. Ask the model, via **Structured Outputs**, to return each claim with the\n",
+    "   `document_id` it relies on and a short **verbatim quote** from that document.\n",
+    "2. Run a **0-token verbatim gate** (pure Python — no model, no API key) that checks\n",
+    "   each quote really appears in the cited document. This alone rejects the three\n",
+    "   failure modes above and runs offline.\n",
+    "3. Only for quotes that pass the gate, optionally call a **burden-of-proof judge**\n",
+    "   to decide whether the quote actually *supports* the claim (a right quote can\n",
+    "   still be the wrong evidence). Fabrications never reach the judge, so they cost\n",
+    "   zero tokens.\n",
+    "\n",
+    "The gate is inlined here; its standalone, framework-agnostic version (gate +\n",
+    "burden-of-proof judge) lives at\n",
+    "[`verbatim-citation-gate`](https://github.com/Palo-Alto-AI-Research-Lab/verbatim-citation-gate)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34a868bf",
+   "metadata": {},
+   "source": [
+    "## The verbatim gate (deterministic, runs offline)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ca719b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "\n",
+    "def normalize(text: str) -> str:\n",
+    "    \"\"\"Case/typography/whitespace-insensitive form for verbatim matching.\"\"\"\n",
+    "    text = text.lower()\n",
+    "    text = re.sub(r\"[‘’]\", \"'\", text)\n",
+    "    text = re.sub(r\"[“”]\", '\"', text)\n",
+    "    text = re.sub(r\"[–—]\", \"-\", text)\n",
+    "    text = re.sub(r\"[^a-z0-9%.]+\", \" \", text)\n",
+    "    return \" \".join(text.split())\n",
+    "\n",
+    "\n",
+    "def gate(quote: str, cited_doc_id: str, docs: dict) -> str:\n",
+    "    \"\"\"Return 'found' | 'misattributed' | 'not_found'. Fails closed on empty quotes.\"\"\"\n",
+    "    q = normalize(quote)\n",
+    "    if not q:\n",
+    "        return \"not_found\"\n",
+    "    cited = docs.get(cited_doc_id)\n",
+    "    if cited is not None and q in normalize(cited):\n",
+    "        return \"found\"\n",
+    "    if any(q in normalize(t) for d, t in docs.items() if d != cited_doc_id):\n",
+    "        return \"misattributed\"\n",
+    "    return \"not_found\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55121e4a",
+   "metadata": {},
+   "source": [
+    "### Verify it offline on structured citations\n",
+    "\n",
+    "No API key needed here — this is the shape of citations Structured Outputs returns,\n",
+    "with one faithful citation and the three planted failure modes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "659b55f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DOCS = {\n",
+    "    \"doc_0\": \"GPT-4o has a context window of 128,000 tokens.\",\n",
+    "    \"doc_1\": \"text-embedding-3-large produces embeddings with 3,072 dimensions.\",\n",
+    "}\n",
+    "\n",
+    "CITATIONS = [\n",
+    "    {\"claim\": \"GPT-4o supports a 128k context.\", \"document_id\": \"doc_0\",\n",
+    "     \"quote\": \"context window of 128,000 tokens\"},                          # faithful\n",
+    "    {\"claim\": \"The large embedding model outputs 3072 dims.\", \"document_id\": \"doc_0\",\n",
+    "     \"quote\": \"embeddings with 3,072 dimensions\"},                          # wrong doc\n",
+    "    {\"claim\": \"GPT-4o outputs 3072-dim embeddings.\", \"document_id\": \"doc_1\",\n",
+    "     \"quote\": \"GPT-4o produces 3,072 dimensions\"},                          # frankenquote\n",
+    "    {\"claim\": \"GPT-4o has a 1M token context.\", \"document_id\": \"doc_0\",\n",
+    "     \"quote\": \"context window of 1,000,000 tokens\"},                        # fabricated\n",
+    "]\n",
+    "\n",
+    "for c in CITATIONS:\n",
+    "    status = gate(c[\"quote\"], c[\"document_id\"], DOCS)\n",
+    "    flag = \"PASS\" if status == \"found\" else \"FLAG\"\n",
+    "    print(f\"{flag} [{status:>13}]  {c['claim']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a846f6eb",
+   "metadata": {},
+   "source": [
+    "`found` citations have cleared existence and attribution, so they are safe to *pass\n",
+    "on to support checking* — not automatically safe to surface: a real, correctly\n",
+    "attributed quote can still fail to support the claim it is attached to (see the\n",
+    "burden-of-proof judge below). `misattributed` and `not_found` should be flagged or\n",
+    "dropped outright — all decided deterministically, for zero tokens.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abb6ca3c",
+   "metadata": {},
+   "source": [
+    "## Generate the citations with Structured Outputs\n",
+    "\n",
+    "With an API key, ask the model to answer **and** return structured citations, then\n",
+    "run the same gate over them. Uses the Responses API with a Pydantic schema; needs\n",
+    "`OPENAI_API_KEY` (not run in CI)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "604ff28e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pip install openai pydantic\n",
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"OPENAI_API_KEY\"):\n",
+    "    print(\"Set OPENAI_API_KEY to run the live example.\")\n",
+    "else:\n",
+    "    from openai import OpenAI\n",
+    "    from pydantic import BaseModel\n",
+    "\n",
+    "    class Citation(BaseModel):\n",
+    "        claim: str\n",
+    "        document_id: str\n",
+    "        quote: str\n",
+    "\n",
+    "    class CitedAnswer(BaseModel):\n",
+    "        answer: str\n",
+    "        citations: list[Citation]\n",
+    "\n",
+    "    client = OpenAI()\n",
+    "    library = \"\\n\".join(f\"[{doc_id}] {text}\" for doc_id, text in DOCS.items())\n",
+    "    resp = client.responses.parse(\n",
+    "        model=\"gpt-4.1\",\n",
+    "        input=[\n",
+    "            {\"role\": \"system\", \"content\": \"Answer using only the library. For each claim, cite the document_id \"\n",
+    "             \"and a short quote copied verbatim from that document.\"},\n",
+    "            {\"role\": \"user\", \"content\": f\"Library:\\n{library}\\n\\nQuestion: What context window does GPT-4o have, \"\n",
+    "             \"and how many dimensions does text-embedding-3-large output?\"},\n",
+    "        ],\n",
+    "        text_format=CitedAnswer,\n",
+    "    )\n",
+    "    cited = resp.output_parsed\n",
+    "    print(cited.answer, \"\\n\")\n",
+    "    for c in cited.citations:\n",
+    "        status = gate(c.quote, c.document_id, DOCS)\n",
+    "        flag = \"PASS\" if status == \"found\" else \"FLAG\"\n",
+    "        print(f\"{flag} [{status:>13}]  {c.quote!r} -> {c.document_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "026179f4",
+   "metadata": {},
+   "source": [
+    "## Optional: a burden-of-proof judge for the ambiguous case\n",
+    "\n",
+    "The gate settles whether a quote *exists*. Whether a real, correctly-attributed\n",
+    "quote actually **supports** its claim is a judgment call best given to a model — but\n",
+    "with the burden of proof on the citation: the verdict defaults to *unsupported*, the\n",
+    "model's outside knowledge is inadmissible, and an unparseable verdict fails closed.\n",
+    "Because only `found` quotes reach it, fabricated and misattributed citations cost\n",
+    "zero judge calls.\n",
+    "\n",
+    "A ready-made, model-agnostic version of this judge is in\n",
+    "[`verbatim-citation-gate`](https://github.com/Palo-Alto-AI-Research-Lab/verbatim-citation-gate);\n",
+    "plug your `client.responses.create` call into its `llm_call` hook."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/registry.yaml
+++ b/registry.yaml
@@ -18,6 +18,18 @@
     - migration
     - whisper
 
+- title: Check citation faithfulness in RAG with a zero-token gate
+  path: examples/citation_faithfulness_check.ipynb
+  slug: citation-faithfulness-check
+  description: Catch fabricated, franken-, and misattributed RAG citations with a deterministic verbatim gate plus an optional burden-of-proof judge, using Structured Outputs.
+  date: 2026-07-24
+  authors:
+    - palo-alto-ai-research-lab
+  tags:
+    - RAG
+    - structured-outputs
+    - evals
+
 - title: Enabling Long-Term Agent Memory with Oracle AI Agent Memory
   path: examples/vector_databases/oracle_db/deep_research_openai_agents.ipynb
   slug: deep-research-openai-agents


### PR DESCRIPTION
When a RAG answer cites its sources, the citations fail in ways that read as authoritative and slip past an LLM judge: **fabricated** (a quote in no document), **frankenquote** (real words, a sentence never written contiguously), and **misattributed** (a real quote from the wrong document).

This cookbook shows a *cheap deterministic detector → expensive judge* pattern:

1. Ask the model, via **Structured Outputs** (Responses API + a Pydantic schema), to return each claim with the `document_id` it relies on and a short **verbatim quote**.
2. Run a **0-token verbatim gate** (pure Python — no model, no key) that checks each quote appears in the cited document. This rejects the three failure modes above and runs offline / in CI.
3. Only for quotes that pass the gate, optionally call a **burden-of-proof judge** — fabrications never reach it, so they cost zero tokens.

The offline section executes end-to-end (verified with `nbclient`):
```
OK   [        found]  GPT-4o supports a 128k context.
FLAG [misattributed]  The large embedding model outputs 3072 dims.
FLAG [    not_found]  GPT-4o outputs 3072-dim embeddings.
FLAG [    not_found]  GPT-4o has a 1M token context.
```

Adds `registry.yaml` and `authors.yaml` entries. The gate is inlined so the notebook has no extra dependency; its standalone, framework-agnostic version (gate + burden-of-proof judge) lives at https://github.com/Palo-Alto-AI-Research-Lab/verbatim-citation-gate .