### PR TITLE
Guard deployment processes against PID reuse

### DIFF
--- a/examples/agents_sdk/deployment_manager/app/runner.py
+++ b/examples/agents_sdk/deployment_manager/app/runner.py
@@ -28,14 +28,19 @@ TRACE_CAPTURE_RUNTIME = (
 )
 
 
-def _is_running(pid: int | None) -> bool:
+def _is_running(pid: int | None, deployment_id: str) -> bool:
     if not pid:
         return False
     try:
         os.kill(pid, 0)
     except OSError:
         return False
-    return True
+    try:
+        environ = Path(f"/proc/{pid}/environ").read_bytes().split(b"\0")
+    except OSError:
+        return False
+    marker = f"AGENTS_SDK_DEPLOYMENT_ID={deployment_id}".encode()
+    return marker in environ
 
 
 def _port_is_open(port: int) -> bool:
@@ -158,7 +163,7 @@ def refresh_status(deployment: Deployment) -> Deployment:
             deployment.stopped_at = deployment.stopped_at or now_iso()
         return deployment
     if deployment.process_pid and deployment.status == "running":
-        if not _is_running(deployment.process_pid):
+        if not _is_running(deployment.process_pid, deployment.id):
             deployment.status = "stopped"
             deployment.stopped_at = deployment.stopped_at or now_iso()
     return deployment
@@ -170,7 +175,9 @@ def start_local_process(
     deployment: Deployment,
 ) -> Deployment:
     deployment = refresh_status(deployment)
-    if deployment.status == "running" and _is_running(deployment.process_pid):
+    if deployment.status == "running" and _is_running(
+        deployment.process_pid, deployment.id
+    ):
         return deployment
     if not project.run_command:
         raise RuntimeError("project does not have a runnable command")
@@ -368,7 +375,9 @@ def start_local_docker(
 
 
 def stop_local_process(deployment: Deployment) -> Deployment:
-    if deployment.process_pid and _is_running(deployment.process_pid):
+    if deployment.process_pid and _is_running(
+        deployment.process_pid, deployment.id
+    ):
         try:
             os.killpg(deployment.process_pid, signal.SIGTERM)
         except ProcessLookupError:

--- a/examples/agents_sdk/deployment_manager/app/runner.py
+++ b/examples/agents_sdk/deployment_manager/app/runner.py
@@ -35,12 +35,18 @@ def _is_running(pid: int | None, deployment_id: str) -> bool:
         os.kill(pid, 0)
     except OSError:
         return False
-    try:
-        environ = Path(f"/proc/{pid}/environ").read_bytes().split(b"\0")
-    except OSError:
-        return False
     marker = f"AGENTS_SDK_DEPLOYMENT_ID={deployment_id}".encode()
-    return marker in environ
+    environ_path = Path(f"/proc/{pid}/environ")
+    for attempt in range(5):
+        try:
+            environ = environ_path.read_bytes().split(b"\0")
+        except OSError:
+            return False
+        if marker in environ:
+            return True
+        if attempt < 4:
+            time.sleep(0.01)
+    return False
 
 
 def _port_is_open(port: int) -> bool:

--- a/examples/agents_sdk/deployment_manager/tests/test_runner.py
+++ b/examples/agents_sdk/deployment_manager/tests/test_runner.py
@@ -1,0 +1,28 @@
+import importlib
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+_is_running = importlib.import_module("app.runner")._is_running
+
+
+def test_is_running_matches_managed_process() -> None:
+    deployment_id = "deployment-pid-guard-test"
+    env = os.environ.copy()
+    env["AGENTS_SDK_DEPLOYMENT_ID"] = deployment_id
+    process = subprocess.Popen(
+        ["sleep", "30"],
+        env=env,
+        start_new_session=True,
+    )
+    try:
+        assert _is_running(process.pid, deployment_id)
+        assert not _is_running(process.pid, "different-deployment")
+    finally:
+        os.killpg(process.pid, signal.SIGTERM)
+        process.wait(timeout=5)
+
+    assert not _is_running(process.pid, deployment_id)


### PR DESCRIPTION
## Summary
- Verify the deployment marker in `/proc/<pid>/environ` before treating a stored PID as a managed process.
- Add a regression test covering matching, mismatched, and exited processes.

## Motivation
PID reuse could make the deployment manager report or signal an unrelated process.

## Self-review
The change is limited to Linux process identity detection and preserves existing lifecycle behavior for managed processes.

## Validation
- `.venv/bin/pytest -q tests/test_runner.py` (1 passed)
- Python syntax and diff checks passed

Registry/authors are unchanged because no cookbook content was added or relocated.