### PR TITLE
Fix GPT Image mask edit file handling

### DIFF
--- a/examples/Generate_Images_With_GPT_Image.ipynb
+++ b/examples/Generate_Images_With_GPT_Image.ipynb
@@ -587,6 +587,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "img_input.seek(0)\n",
+    "\n",
     "result_mask_edit = client.images.edit(\n",
     "    model=\"gpt-image-1\",         \n",
     "    prompt=prompt_mask_edit,\n",
@@ -616,7 +618,7 @@
    "source": [
     "# Display result\n",
     "\n",
-    "img_path_mask_edit = \"imgs/mask_edit.png\"\n",
+    "img_path_mask_edit = \"imgs/mask_edit.jpg\"\n",
     "\n",
     "image_base64 = result_mask_edit.data[0].b64_json\n",
     "image_bytes = base64.b64decode(image_base64)\n",


### PR DESCRIPTION
## Summary

- Reset the mask-edit input file before reusing it in the second image edit request.
- Rename the final output to `mask_edit.jpg` so the filename matches the intentionally compressed JPEG output.

## Motivation

The notebook reuses `img_input` after it has already been uploaded once. Resetting the file position makes the second mask edit reliably upload the source image again. The output keeps JPEG compression for smaller cookbook previews while using the correct file extension.

## Validation

- `git diff --check`
- `python3 -m json.tool examples/Generate_Images_With_GPT_Image.ipynb`
- `env PYTHONPATH=/private/tmp/cookbook-check-deps python3 .github/scripts/check_notebooks.py`