### PR TITLE
fix: fail fast for oversized token requests

### DIFF
--- a/examples/api_request_parallel_processor.py
+++ b/examples/api_request_parallel_processor.py
@@ -150,6 +150,7 @@ async def process_api_requests_from_file(
         StatusTracker()
     )  # single instance to track a collection of variables
     next_request = None  # variable to hold the next request to call
+    oversized_request_error = None
 
     # initialize available capacity counts
     available_request_capacity = max_requests_per_minute
@@ -182,12 +183,14 @@ async def process_api_requests_from_file(
                                 request_json, api_endpoint, token_encoding_name
                             )
                             if token_consumption > max_tokens_per_minute:
-                                raise ValueError(
+                                oversized_request_error = ValueError(
                                     "Request requires an estimated "
                                     f"{token_consumption} tokens, exceeding "
                                     f"max_tokens_per_minute ({max_tokens_per_minute}). "
                                     "Increase the limit or split the request."
                                 )
+                                file_not_finished = False
+                                continue
                             next_request = APIRequest(
                                 task_id=next(task_id_generator),
                                 request_json=request_json,
@@ -247,6 +250,8 @@ async def process_api_requests_from_file(
 
                 # if all tasks are finished, break
                 if status_tracker.num_tasks_in_progress == 0:
+                    if oversized_request_error:
+                        raise oversized_request_error
                     break
 
                 # main loop sleeps briefly so concurrent tasks can run

--- a/examples/api_request_parallel_processor.py
+++ b/examples/api_request_parallel_processor.py
@@ -119,6 +119,11 @@ async def process_api_requests_from_file(
     logging_level: int,
 ):
     """Processes API requests in parallel, throttling to stay under rate limits."""
+    if not max_requests_per_minute >= 1:
+        raise ValueError("max_requests_per_minute must be at least 1")
+    if not max_tokens_per_minute > 0:
+        raise ValueError("max_tokens_per_minute must be greater than 0")
+
     # constants
     seconds_to_pause_after_rate_limit_error = 15
     seconds_to_sleep_each_loop = (
@@ -173,12 +178,20 @@ async def process_api_requests_from_file(
                         try:
                             # get new request
                             request_json = json.loads(next(requests))
+                            token_consumption = num_tokens_consumed_from_request(
+                                request_json, api_endpoint, token_encoding_name
+                            )
+                            if token_consumption > max_tokens_per_minute:
+                                raise ValueError(
+                                    "Request requires an estimated "
+                                    f"{token_consumption} tokens, exceeding "
+                                    f"max_tokens_per_minute ({max_tokens_per_minute}). "
+                                    "Increase the limit or split the request."
+                                )
                             next_request = APIRequest(
                                 task_id=next(task_id_generator),
                                 request_json=request_json,
-                                token_consumption=num_tokens_consumed_from_request(
-                                    request_json, api_endpoint, token_encoding_name
-                                ),
+                                token_consumption=token_consumption,
                                 attempts_left=max_attempts,
                                 metadata=request_json.pop("metadata", None),
                             )


### PR DESCRIPTION
## Summary

- Fail fast when a request's estimated token cost exceeds the configured token-per-minute limit.
- Reject nonpositive token limits and request limits below one before scheduling begins.

## Motivation

The token bucket never grows beyond the configured token-per-minute limit. A request with a larger estimate could therefore never be scheduled, while its in-progress count kept the processing loop alive indefinitely. The new validation reports the invalid configuration or oversized request immediately and suggests the two supported remedies: raise the limit or split the request.

## Validation

- Compiled the updated Python script.
- Ran an isolated asynchronous reproduction with an estimated two-token embedding request and a one-token-per-minute limit; it raises ValueError before any HTTP activity.
- Verified an equal-to-limit request completes, and zero capacity limits fail fast.
