### PR TITLE
Add exact-action receipts to Agents SDK approvals

### DIFF
--- a/examples/agents_sdk/executor_bound_approval_receipts/README.md
+++ b/examples/agents_sdk/executor_bound_approval_receipts/README.md
@@ -1,0 +1,46 @@
+# Add accountable receipts to Agents SDK approvals
+
+The OpenAI Agents SDK already [pauses a `needs_approval` tool](https://openai.github.io/openai-agents-python/human_in_the_loop/) before it executes and binds the decision to a specific tool call in `RunState`. This example adds an application-owned receipt for teams that also need to answer:
+
+- What exact action did the reviewer approve?
+- Who approved it, and when did the approval expire?
+- Was the approval consumed more than once?
+- What record can the executor retain after the run resumes?
+
+The pattern joins the SDK's native approval interruption with a [tool input guardrail](https://openai.github.io/openai-agents-python/guardrails/#tool-guardrails):
+
+```text
+tool call → SDK interruption → reviewer decision → authenticated receipt
+          → RunState approval → tool input guardrail consumes receipt → effect
+```
+
+The tool guardrail runs after approval and immediately before the function tool executes. It recomputes the digest from `tool_name`, `tool_call_id`, and the canonical JSON arguments. Missing, expired, changed, replayed, or tampered receipts fail closed.
+
+## Run the example
+
+Set the API key and receipt-authentication secret, then run the app:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r examples/agents_sdk/executor_bound_approval_receipts/requirements.txt
+export OPENAI_API_KEY="..."
+export APPROVAL_RECEIPT_SECRET="replace-with-at-least-32-random-bytes"
+python examples/agents_sdk/executor_bound_approval_receipts/app.py
+```
+
+The sample uses an in-memory ledger and an HMAC key controlled by the application. That proves which application issued the receipt; it does not by itself prove that a named person used a hardware-held key. In production, use a transactional store, authenticate the reviewer, protect the signing key, and define reconciliation for a provider result that becomes indeterminate after receipt consumption.
+
+Run the offline negative tests without an API call:
+
+```bash
+pytest -q examples/agents_sdk/executor_bound_approval_receipts/test_receipt_ledger.py
+```
+
+The tests cover changed arguments, wrong call IDs, expiry, replay, and receipt tampering.
+
+## Why keep the receipt outside the model
+
+The model may propose an action and explain it, but it should not mint or consume its own authorization. The application owns reviewer identity, receipt policy, the signing key, and the final execution boundary. This keeps approval enforcement separate from prompt compliance.
+
+This example adapts the executor-bound approval pattern and adversarial cases developed by [EMILIA Protocol](https://github.com/emiliaprotocol/emilia-protocol/pull/451) to the Agents SDK's native `needs_approval`, `RunState`, `ToolContext`, and tool-guardrail surfaces.

--- a/examples/agents_sdk/executor_bound_approval_receipts/app.py
+++ b/examples/agents_sdk/executor_bound_approval_receipts/app.py
@@ -1,0 +1,87 @@
+"""OpenAI Agents SDK approval flow with an executor-checked receipt."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+from agents import Agent, Runner, ToolGuardrailFunctionOutput
+from agents.decorators import tool, tool_input_guardrail
+from agents.tool_context import ToolContext
+from receipt_ledger import ReceiptError, ReceiptLedger
+
+
+@dataclass
+class AppContext:
+    ledger: ReceiptLedger
+    executed_transfers: list[dict[str, Any]] = field(default_factory=list)
+
+
+@tool_input_guardrail
+def require_exact_approval(data) -> ToolGuardrailFunctionOutput:
+    context: ToolContext[AppContext] = data.context
+    try:
+        receipt = context.context.ledger.consume(
+            tool_name=context.tool_name,
+            tool_call_id=context.tool_call_id,
+            raw_arguments=context.tool_arguments,
+        )
+    except ReceiptError as exc:
+        return ToolGuardrailFunctionOutput.raise_exception(str(exc))
+    return ToolGuardrailFunctionOutput.allow(
+        {"approval_receipt_id": receipt.receipt_id}
+    )
+
+
+@tool(needs_approval=True, tool_input_guardrails=[require_exact_approval])
+def transfer_funds(
+    context: ToolContext[AppContext], amount_usd: int, destination: str
+) -> dict[str, Any]:
+    """Transfer funds to a destination account after exact approval."""
+    transfer = {"amount_usd": amount_usd, "destination": destination}
+    context.context.executed_transfers.append(transfer)
+    return {"status": "submitted", **transfer}
+
+
+def _call_id(interruption) -> str:
+    raw_item = interruption.raw_item
+    if isinstance(raw_item, dict):
+        return str(raw_item["call_id"])
+    return str(raw_item.call_id)
+
+
+async def main() -> None:
+    secret = os.environ["APPROVAL_RECEIPT_SECRET"].encode()
+    app_context = AppContext(ledger=ReceiptLedger(secret))
+    agent = Agent[AppContext](
+        name="Treasury assistant",
+        instructions="Propose the requested transfer and wait for application approval.",
+        tools=[transfer_funds],
+    )
+
+    result = await Runner.run(
+        agent,
+        "Transfer $8,200 to vendor account acct_2471.",
+        context=app_context,
+    )
+    state = result.to_state()
+
+    for interruption in result.interruptions:
+        # Replace this local decision with your authenticated reviewer workflow.
+        app_context.ledger.issue(
+            tool_name=interruption.name or "unknown_tool",
+            tool_call_id=_call_id(interruption),
+            raw_arguments=interruption.arguments or "{}",
+            reviewer="finance-operator@example.com",
+        )
+        state.approve(interruption)
+
+    resumed = await Runner.run(agent, state)
+    print(resumed.final_output)
+    print(app_context.executed_transfers)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/agents_sdk/executor_bound_approval_receipts/receipt_ledger.py
+++ b/examples/agents_sdk/executor_bound_approval_receipts/receipt_ledger.py
@@ -1,0 +1,116 @@
+"""Application-owned receipts for exact, one-time tool approvals."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+class ReceiptError(RuntimeError):
+    """Raised when an approval receipt cannot authorize execution."""
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+
+
+def action_digest(tool_name: str, tool_call_id: str, raw_arguments: str) -> str:
+    arguments = json.loads(raw_arguments)
+    if not isinstance(arguments, dict):
+        raise ReceiptError("tool arguments must be a JSON object")
+    action = {
+        "tool_name": tool_name,
+        "tool_call_id": tool_call_id,
+        "arguments": arguments,
+    }
+    return hashlib.sha256(_canonical_json(action)).hexdigest()
+
+
+@dataclass
+class ApprovalReceipt:
+    receipt_id: str
+    tool_call_id: str
+    action_digest: str
+    reviewer: str
+    issued_at: float
+    expires_at: float
+    signature: str = ""
+    consumed_at: float | None = None
+
+    def signed_payload(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload.pop("signature")
+        payload.pop("consumed_at")
+        return payload
+
+
+class ReceiptLedger:
+    """Minimal in-memory ledger; use a transactional store in production."""
+
+    def __init__(self, secret: bytes):
+        if len(secret) < 32:
+            raise ValueError("APPROVAL_RECEIPT_SECRET must be at least 32 bytes")
+        self._secret = secret
+        self._by_call_id: dict[str, ApprovalReceipt] = {}
+
+    def _sign(self, receipt: ApprovalReceipt) -> str:
+        return hmac.new(
+            self._secret,
+            _canonical_json(receipt.signed_payload()),
+            hashlib.sha256,
+        ).hexdigest()
+
+    def issue(
+        self,
+        *,
+        tool_name: str,
+        tool_call_id: str,
+        raw_arguments: str,
+        reviewer: str,
+        ttl_seconds: int = 900,
+        now: float | None = None,
+    ) -> ApprovalReceipt:
+        issued_at = time.time() if now is None else now
+        receipt = ApprovalReceipt(
+            receipt_id=f"approval_{uuid.uuid4().hex}",
+            tool_call_id=tool_call_id,
+            action_digest=action_digest(tool_name, tool_call_id, raw_arguments),
+            reviewer=reviewer,
+            issued_at=issued_at,
+            expires_at=issued_at + ttl_seconds,
+        )
+        receipt.signature = self._sign(receipt)
+        self._by_call_id[tool_call_id] = receipt
+        return receipt
+
+    def consume(
+        self,
+        *,
+        tool_name: str,
+        tool_call_id: str,
+        raw_arguments: str,
+        now: float | None = None,
+    ) -> ApprovalReceipt:
+        evaluated_at = time.time() if now is None else now
+        receipt = self._by_call_id.get(tool_call_id)
+        if receipt is None:
+            raise ReceiptError("missing approval receipt")
+        if not hmac.compare_digest(receipt.signature, self._sign(receipt)):
+            raise ReceiptError("invalid approval receipt signature")
+        if receipt.consumed_at is not None:
+            raise ReceiptError("approval receipt already consumed")
+        if evaluated_at > receipt.expires_at:
+            raise ReceiptError("approval receipt expired")
+        expected = action_digest(tool_name, tool_call_id, raw_arguments)
+        if not hmac.compare_digest(receipt.action_digest, expected):
+            raise ReceiptError("approval receipt does not match this exact action")
+
+        # Reserve before the side effect. A production store should make this
+        # compare-and-set atomic and reconcile an indeterminate provider result.
+        receipt.consumed_at = evaluated_at
+        return receipt

--- a/examples/agents_sdk/executor_bound_approval_receipts/requirements.txt
+++ b/examples/agents_sdk/executor_bound_approval_receipts/requirements.txt
@@ -1,0 +1,2 @@
+openai-agents
+pytest

--- a/examples/agents_sdk/executor_bound_approval_receipts/test_receipt_ledger.py
+++ b/examples/agents_sdk/executor_bound_approval_receipts/test_receipt_ledger.py
@@ -1,0 +1,107 @@
+import pytest
+from receipt_ledger import ReceiptError, ReceiptLedger
+
+SECRET = b"a-test-secret-that-is-at-least-32-bytes-long"
+ARGS = '{"amount_usd":8200,"destination":"acct_2471"}'
+
+
+def ledger() -> ReceiptLedger:
+    return ReceiptLedger(SECRET)
+
+
+def issue(target: ReceiptLedger, *, now: float = 100.0):
+    return target.issue(
+        tool_name="transfer_funds",
+        tool_call_id="call_123",
+        raw_arguments=ARGS,
+        reviewer="finance@example.com",
+        ttl_seconds=60,
+        now=now,
+    )
+
+
+def test_exact_action_consumes_once():
+    target = ledger()
+    receipt = issue(target)
+
+    consumed = target.consume(
+        tool_name="transfer_funds",
+        tool_call_id="call_123",
+        raw_arguments=ARGS,
+        now=110.0,
+    )
+
+    assert consumed.receipt_id == receipt.receipt_id
+    assert consumed.consumed_at == 110.0
+
+
+def test_changed_arguments_fail_closed():
+    target = ledger()
+    issue(target)
+
+    with pytest.raises(ReceiptError, match="exact action"):
+        target.consume(
+            tool_name="transfer_funds",
+            tool_call_id="call_123",
+            raw_arguments='{"amount_usd":82000,"destination":"acct_2471"}',
+            now=110.0,
+        )
+
+
+def test_wrong_call_id_has_no_receipt():
+    target = ledger()
+    issue(target)
+
+    with pytest.raises(ReceiptError, match="missing"):
+        target.consume(
+            tool_name="transfer_funds",
+            tool_call_id="call_456",
+            raw_arguments=ARGS,
+            now=110.0,
+        )
+
+
+def test_expired_receipt_fails_closed():
+    target = ledger()
+    issue(target)
+
+    with pytest.raises(ReceiptError, match="expired"):
+        target.consume(
+            tool_name="transfer_funds",
+            tool_call_id="call_123",
+            raw_arguments=ARGS,
+            now=161.0,
+        )
+
+
+def test_replay_fails_closed():
+    target = ledger()
+    issue(target)
+    target.consume(
+        tool_name="transfer_funds",
+        tool_call_id="call_123",
+        raw_arguments=ARGS,
+        now=110.0,
+    )
+
+    with pytest.raises(ReceiptError, match="already consumed"):
+        target.consume(
+            tool_name="transfer_funds",
+            tool_call_id="call_123",
+            raw_arguments=ARGS,
+            now=111.0,
+        )
+
+
+def test_tampered_receipt_fails_closed():
+    target = ledger()
+    receipt = issue(target)
+    receipt.reviewer = "attacker@example.com"
+
+    with pytest.raises(ReceiptError, match="signature"):
+        target.consume(
+            tool_name="transfer_funds",
+            tool_call_id="call_123",
+            raw_arguments=ARGS,
+            now=110.0,
+        )

--- a/registry.yaml
+++ b/registry.yaml
@@ -296,6 +296,19 @@
     - sandbox
     - security
 
+- title: Add Accountable Receipts to Agents SDK Approvals
+  path: examples/agents_sdk/executor_bound_approval_receipts/README.md
+  slug: executor-bound-approval-receipts
+  description: Bind native Agents SDK approvals to exact tool calls with expiring, single-use, application-owned receipts and a pre-execution tool guardrail.
+  date: 2026-08-01
+  authors:
+    - FutureEnterprises
+  tags:
+    - agents-sdk
+    - agents
+    - security
+    - guardrails
+
 - title: Agents SDK Deployment Manager
   path: examples/agents_sdk/deployment_manager/README.md
   slug: agents-sdk-deployment-manager

--- a/registry.yaml
+++ b/registry.yaml
@@ -197,6 +197,19 @@
     - sandbox
     - security
 
+- title: Add Accountable Receipts to Agents SDK Approvals
+  path: examples/agents_sdk/executor_bound_approval_receipts/README.md
+  slug: executor-bound-approval-receipts
+  description: Bind native Agents SDK approvals to exact tool calls with expiring, single-use, application-owned receipts and a pre-execution tool guardrail.
+  date: 2026-08-01
+  authors:
+    - FutureEnterprises
+  tags:
+    - agents-sdk
+    - agents
+    - security
+    - guardrails
+
 - title: Agents SDK Deployment Manager
   path: examples/agents_sdk/deployment_manager/README.md
   slug: agents-sdk-deployment-manager


### PR DESCRIPTION
## Summary

Adds a runnable Agents SDK example that combines native, call-specific `needs_approval` interruptions with an application-owned receipt. The receipt binds the reviewer, exact tool call, canonical arguments, expiry, and one-time consumption; a tool input guardrail verifies it immediately before execution.

## Motivation

The SDK already pauses an approval-gated function tool and resumes a specific interrupted call. Teams operating consequential tools may also need a durable application record of exactly what was approved, by whom, for how long, and whether it was replayed or changed before execution. This example adds that layer without replacing or weakening the SDK's native approval mechanism.

---

## For new content

- [x] I have added a new entry in `registry.yaml` so that my content renders on the cookbook website.
- [x] I have conducted a self-review of my content based on the contribution guidelines:
  - [x] Relevance: The example extends Agents SDK approvals for consequential function tools.
  - [x] Uniqueness: Existing approval examples cover pause and resume; this one adds exact-action receipts, expiry, replay protection, and an executor-side guardrail.
  - [x] Spelling and Grammar: README and code comments received a final editorial pass.
  - [x] Clarity: The flow, limitations, production requirements, and offline test path are documented.
  - [x] Correctness: The code imports against the current `openai-agents` package and all offline tests pass.
  - [x] Completeness: Native approval and guardrail documentation, limitations, and source pattern are linked.

## Validation

- `python3 -m py_compile .../receipt_ledger.py .../app.py`
- `pytest -q examples/agents_sdk/executor_bound_approval_receipts/test_receipt_ledger.py` — 6 passed
- installed-SDK check confirmed `needs_approval=True`, one input guardrail, allow on first exact consumption, and refusal on replay
- `ruff check` and `ruff format --check`
- `registry.yaml` validates against `.github/registry_schema.json`; slugs and paths are unique
- `git diff --check`
