### PR TITLE
Fix syntax error in Agents SDK example in run-vllm guide

### DIFF
--- a/articles/gpt-oss/run-vllm.md
+++ b/articles/gpt-oss/run-vllm.md
@@ -146,7 +146,7 @@ async def main(model: str, api_key: str):
                 base_url="http://localhost:8000/v1",
                 api_key="EMPTY",
             ),
-        )
+        ),
         tools=[get_weather],
     )
 


### PR DESCRIPTION
Reopens #2731, which the stale bot auto-closed on Aug 1 after 60 days with no maintainer review. The bug is still present on `main` today, so I've rebased the one-line fix onto current `main` in a fresh branch.

### The problem

In `articles/gpt-oss/run-vllm.md`, the `Agent(...)` call is missing a comma after the `model=` argument:

```python
        model=OpenAIResponsesModel(
            ...
        )
        tools=[get_weather],
```

Two keyword arguments with no separator is a hard parse error, so the snippet fails before it ever reaches vLLM:

```
SyntaxError: invalid syntax. Perhaps you forgot a comma?
```

Anyone copying the example straight out of the guide hits this immediately.

### The fix

One character — the missing comma:

```diff
-        )
+        ),
         tools=[get_weather],
```

Verified that the surrounding structure compiles cleanly with the comma and raises the above `SyntaxError` without it. No other content changed.