### PR TITLE
chore(codeowners): require DX review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require Developer Experience approval for every change.
+* @openai/developer-experience


### PR DESCRIPTION
## Summary

- make `@openai/developer-experience` the sole code owner for every repository path
- require branch protection for repository administrators, preserving the existing approval policy

## Why

`main` already required one approval and code-owner review, but the repository had no CODEOWNERS file and administrators could bypass branch protection. This change supplies the missing ownership rule and closes that bypass.

## Validation

- GitHub CODEOWNERS validation reports no errors on this branch
- the `developer-experience` team is visible and has admin access to this repository
- `main` now reports `require_code_owner_reviews: true`, one required approval, and `enforce_admins: true`
- the branch contains one commit and only adds `.github/CODEOWNERS`

## Rollout note

GitHub evaluates CODEOWNERS from the pull request's base branch. Because `main` does not have this file yet, this PR itself is not code-owner-enforced. After this PR merges, future pull requests targeting `main` will require approval from `@openai/developer-experience`.