### PR TITLE
Migrate Assistants API notebooks to Responses API

### DIFF
--- a/examples/Assistants_API_overview_python.ipynb
+++ b/examples/Assistants_API_overview_python.ipynb
@@ -4,39 +4,43 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Assistants API Overview (Python SDK)"
-   ]
+    "# Responses API Overview (Python SDK)"
+   ],
+   "id": "cell-000"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The new [Assistants API](https://platform.openai.com/docs/assistants/overview) is a stateful evolution of our [Chat Completions API](https://platform.openai.com/docs/guides/text-generation/chat-completions-api) meant to simplify the creation of assistant-like experiences, and enable developer access to powerful tools like Code Interpreter and File Search."
-   ]
+    "The [Responses API](https://platform.openai.com/docs/guides/migrate-to-responses) is a unified interface for building assistant-like experiences with text generation, conversation state, and built-in tools such as Code Interpreter and File Search."
+   ],
+   "id": "cell-001"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![Assistants API Diagram](../images/assistants_overview_diagram.png)"
-   ]
+    "![Responses API Diagram](../images/responses-diagram.png)"
+   ],
+   "id": "cell-002"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Chat Completions API vs Assistants API\n",
+    "## Chat Completions API vs Responses API\n",
     "\n",
-    "The primitives of the **Chat Completions API** are `Messages`, on which you perform a `Completion` with a `Model` (`gpt-4o`, `gpt-4o-mini`, etc). It is lightweight and powerful, but inherently stateless, which means you have to manage conversation state, tool definitions, retrieval documents, and code execution manually.\n",
+    "The primitives of the **Chat Completions API** are messages, on which you perform a completion with a model. It is lightweight and powerful, but application code must manage conversation state, tool definitions, retrieval documents, and code execution.\n",
     "\n",
-    "The primitives of the **Assistants API** are\n",
+    "The **Responses API** combines these concerns in a single response:\n",
     "\n",
-    "- `Assistants`, which encapsulate a base model, instructions, tools, and (context) documents,\n",
-    "- `Threads`, which represent the state of a conversation, and\n",
-    "- `Runs`, which power the execution of an `Assistant` on a `Thread`, including textual responses and multi-step tool use.\n",
+    "- `input`, which contains the user request or a list of conversation items,\n",
+    "- `instructions`, which provide developer-level guidance for the response, and\n",
+    "- `tools`, which expose built-in capabilities and custom functions to the model.\n",
     "\n",
-    "We'll take a look at how these can be used to create powerful, stateful experiences.\n"
-   ]
+    "Responses can be chained with `previous_response_id` when you want the API to manage conversation state, or passed an explicit input history when you need full control."
+   ],
+   "id": "cell-003"
   },
   {
    "cell_type": "markdown",
@@ -46,752 +50,165 @@
     "\n",
     "### Python SDK\n",
     "\n",
-    "> **Note**\n",
-    "> We've updated our [Python SDK](https://github.com/openai/openai-python) to add support for the Assistants API, so you'll need to update it to the latest version (`1.59.4` at time of writing).\n"
-   ]
+    "Install or upgrade the [OpenAI Python SDK](https://github.com/openai/openai-python) before running the examples. Set `OPENAI_API_KEY` in your environment; the notebook does not embed a key."
+   ],
+   "id": "cell-004"
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: openai in /Users/lee.spacagna/myenv/lib/python3.12/site-packages (1.59.4)\n",
-      "Requirement already satisfied: anyio<5,>=3.5.0 in /Users/lee.spacagna/myenv/lib/python3.12/site-packages (from openai) (3.7.1)\n",
-      "Requirement already satisfied: distro<2,>=1.7.0 in /Users/lee.spacagna/myenv/lib/python3.12/site-packages (from openai) (1.9.0)\n",
-      "Requirement already satisfied: httpx<1,>=0.23.0 in /Users/lee.spacagna/myenv/lib/python3.12/site-packages (from openai) (0.27.0)\n",
-      "Requirement already satisfied: jiter<1,>=0.4.0 in /Users/lee.spacagna/myenv/lib/python3.12/site-packages (from openai) (0.7.0)\n",
-      "Requirement already satisfied: pydantic<3,>=1.9.0 in /Users/lee.spacagna/myenv/lib/python3.12/site-packages (from openai) (2.8.2)\n",
-      "Requirement already satisfied: sniffio in /Users/lee.spacagna/myenv/lib/python3.12/site-packages (from openai) (1.3.1)\n",
-      "Requirement already satisfied: tqdm>4 in /Users/lee.spacagna/myenv/lib/python3.12/site-packages (from openai) (4.66.4)\n",
-      "Requirement already satisfied: typing-extensions<5,>=4.11 in /Users/lee.spacagna/myenv/lib/python3.12/site-packages (from openai) (4.12.2)\n",
-      "Requirement already satisfied: idna>=2.8 in /Users/lee.spacagna/myenv/lib/python3.12/site-packages (from anyio<5,>=3.5.0->openai) (3.7)\n",
-      "Requirement already satisfied: certifi in /Users/lee.spacagna/myenv/lib/python3.12/site-packages (from httpx<1,>=0.23.0->openai) (2024.7.4)\n",
-      "Requirement already satisfied: httpcore==1.* in /Users/lee.spacagna/myenv/lib/python3.12/site-packages (from httpx<1,>=0.23.0->openai) (1.0.5)\n",
-      "Requirement already satisfied: h11<0.15,>=0.13 in /Users/lee.spacagna/myenv/lib/python3.12/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.14.0)\n",
-      "Requirement already satisfied: annotated-types>=0.4.0 in /Users/lee.spacagna/myenv/lib/python3.12/site-packages (from pydantic<3,>=1.9.0->openai) (0.7.0)\n",
-      "Requirement already satisfied: pydantic-core==2.20.1 in /Users/lee.spacagna/myenv/lib/python3.12/site-packages (from pydantic<3,>=1.9.0->openai) (2.20.1)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!pip install --upgrade openai"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And make sure it's up to date by running:\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Version: 1.59.4\n"
-     ]
-    }
    ],
-   "source": [
-    "!pip show openai | grep Version"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Pretty Printing Helper\n"
-   ]
+   "id": "cell-005"
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import json\n",
-    "\n",
-    "def show_json(obj):\n",
-    "    display(json.loads(obj.model_dump_json()))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Complete Example with Assistants API\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Assistants\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The easiest way to get started with the Assistants API is through the [Assistants Playground](https://platform.openai.com/playground).\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "![Assistants Playground](../images/assistants_overview_assistants_playground.png)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's begin by creating an assistant! We'll create a Math Tutor just like in our [docs](https://platform.openai.com/docs/assistants/overview).\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "![Creating New Assistant](../images/assistants_overview_new_assistant.png)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can also create Assistants directly through the Assistants API, like so:\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 'asst_qvXmYlZV8zhABI2RtPzDfV6z',\n",
-       " 'created_at': 1736340398,\n",
-       " 'description': None,\n",
-       " 'instructions': 'You are a personal math tutor. Answer questions briefly, in a sentence or less.',\n",
-       " 'metadata': {},\n",
-       " 'model': 'gpt-4o',\n",
-       " 'name': 'Math Tutor',\n",
-       " 'object': 'assistant',\n",
-       " 'tools': [],\n",
-       " 'response_format': 'auto',\n",
-       " 'temperature': 1.0,\n",
-       " 'tool_resources': {'code_interpreter': None, 'file_search': None},\n",
-       " 'top_p': 1.0}",
-       " 'tools': [],\n",
-       " 'response_format': 'auto',\n",
-       " 'temperature': 1.0,\n",
-       " 'tool_resources': {'code_interpreter': None, 'file_search': None},\n",
-       " 'top_p': 1.0}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "from openai import OpenAI\n",
     "import os\n",
     "\n",
-    "client = OpenAI(api_key=os.environ.get(\"OPENAI_API_KEY\", \"<your OpenAI API key if not set as env var>\"))\n",
-    "\n",
-    "\n",
-    "assistant = client.beta.assistants.create(\n",
-    "    name=\"Math Tutor\",\n",
-    "    instructions=\"You are a personal math tutor. Answer questions briefly, in a sentence or less.\",\n",
-    "    model=\"gpt-4o\",\n",
-    ")\n",
-    "show_json(assistant)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Regardless of whether you create your Assistant through the Dashboard or with the API, you'll want to keep track of the Assistant ID. This is how you'll refer to your Assistant throughout Threads and Runs.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Next, we'll create a new Thread and add a Message to it. This will hold the state of our conversation, so we don't have re-send the entire message history each time.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Threads\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Create a new thread:\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 'thread_j4dc1TiHPfkviKUHNi4aAsA6',\n",
-       " 'created_at': 1736340398,\n",
-       " 'metadata': {},\n",
-       " 'object': 'thread',\n",
-       " 'tool_resources': {'code_interpreter': None, 'file_search': None}}",
-       " 'object': 'thread',\n",
-       " 'tool_resources': {'code_interpreter': None, 'file_search': None}}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "thread = client.beta.threads.create()\n",
-    "show_json(thread)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Then add the Message to the thread:\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 'msg_1q4Y7ZZ9gIcPoAKSx9UtrrKJ',\n",
-       " 'assistant_id': None,\n",
-       " 'attachments': [],\n",
-       " 'completed_at': None,\n",
-       " 'attachments': [],\n",
-       " 'completed_at': None,\n",
-       " 'content': [{'text': {'annotations': [],\n",
-       "    'value': 'I need to solve the equation `3x + 11 = 14`. Can you help me?'},\n",
-       "   'type': 'text'}],\n",
-       " 'created_at': 1736340400,\n",
-       " 'incomplete_at': None,\n",
-       " 'incomplete_details': None,\n",
-       " 'metadata': {},\n",
-       " 'object': 'thread.message',\n",
-       " 'role': 'user',\n",
-       " 'run_id': None,\n",
-       " 'status': None,\n",
-       " 'thread_id': 'thread_j4dc1TiHPfkviKUHNi4aAsA6'}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "message = client.beta.threads.messages.create(\n",
-    "    thread_id=thread.id,\n",
-    "    role=\"user\",\n",
-    "    content=\"I need to solve the equation `3x + 11 = 14`. Can you help me?\",\n",
-    ")\n",
-    "show_json(message)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "> **Note**\n",
-    "> Even though you're no longer sending the entire history each time, you will still be charged for the tokens of the entire conversation history with each Run.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Runs\n",
-    "\n",
-    "Notice how the Thread we created is **not** associated with the Assistant we created earlier! Threads exist independently from Assistants, which may be different from what you'd expect if you've used ChatGPT (where a thread is tied to a model/GPT).\n",
-    "\n",
-    "To get a completion from an Assistant for a given Thread, we must create a Run. Creating a Run will indicate to an Assistant it should look at the messages in the Thread and take action: either by adding a single response, or using tools.\n",
-    "\n",
-    "> **Note**\n",
-    "> Runs are a key difference between the Assistants API and Chat Completions API. While in Chat Completions the model will only ever respond with a single message, in the Assistants API a Run may result in an Assistant using one or multiple tools, and potentially adding multiple messages to the Thread.\n",
-    "\n",
-    "To get our Assistant to respond to the user, let's create the Run. As mentioned earlier, you must specify _both_ the Assistant and the Thread.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 'run_qVYsWok6OCjHxkajpIrdHuVP',\n",
-       " 'assistant_id': 'asst_qvXmYlZV8zhABI2RtPzDfV6z',\n",
-       " 'cancelled_at': None,\n",
-       " 'completed_at': None,\n",
-       " 'created_at': 1736340403,\n",
-       " 'expires_at': 1736341003,\n",
-       " 'failed_at': None,\n",
-       " 'incomplete_details': None,\n",
-       " 'incomplete_details': None,\n",
-       " 'instructions': 'You are a personal math tutor. Answer questions briefly, in a sentence or less.',\n",
-       " 'last_error': None,\n",
-       " 'max_completion_tokens': None,\n",
-       " 'max_prompt_tokens': None,\n",
-       " 'max_completion_tokens': None,\n",
-       " 'max_prompt_tokens': None,\n",
-       " 'metadata': {},\n",
-       " 'model': 'gpt-4o',\n",
-       " 'object': 'thread.run',\n",
-       " 'parallel_tool_calls': True,\n",
-       " 'parallel_tool_calls': True,\n",
-       " 'required_action': None,\n",
-       " 'response_format': 'auto',\n",
-       " 'response_format': 'auto',\n",
-       " 'started_at': None,\n",
-       " 'status': 'queued',\n",
-       " 'thread_id': 'thread_j4dc1TiHPfkviKUHNi4aAsA6',\n",
-       " 'tool_choice': 'auto',\n",
-       " 'tools': [],\n",
-       " 'truncation_strategy': {'type': 'auto', 'last_messages': None},\n",
-       " 'usage': None,\n",
-       " 'temperature': 1.0,\n",
-       " 'top_p': 1.0,\n",
-       " 'tool_resources': {}}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "run = client.beta.threads.runs.create(\n",
-    "    thread_id=thread.id,\n",
-    "    assistant_id=assistant.id,\n",
-    ")\n",
-    "show_json(run)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Unlike creating a completion in the Chat Completions API, **creating a Run is an asynchronous operation**. It will return immediately with the Run's metadata, which includes a `status` that will initially be set to `queued`. The `status` will be updated as the Assistant performs operations (like using tools and adding messages).\n",
-    "\n",
-    "To know when the Assistant has completed processing, we can poll the Run in a loop. (Support for streaming is coming soon!) While here we are only checking for a `queued` or `in_progress` status, in practice a Run may undergo a [variety of status changes](https://platform.openai.com/docs/api-reference/runs/object#runs/object-status) which you can choose to surface to the user. (These are called Steps, and will be covered later.)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import time\n",
-    "\n",
-    "def wait_on_run(run, thread):\n",
-    "    while run.status == \"queued\" or run.status == \"in_progress\":\n",
-    "        run = client.beta.threads.runs.retrieve(\n",
-    "            thread_id=thread.id,\n",
-    "            run_id=run.id,\n",
-    "        )\n",
-    "        time.sleep(0.5)\n",
-    "    return run"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 'run_qVYsWok6OCjHxkajpIrdHuVP',\n",
-       " 'assistant_id': 'asst_qvXmYlZV8zhABI2RtPzDfV6z',\n",
-       " 'cancelled_at': None,\n",
-       " 'completed_at': 1736340406,\n",
-       " 'created_at': 1736340403,\n",
-       " 'expires_at': None,\n",
-       " 'failed_at': None,\n",
-       " 'incomplete_details': None,\n",
-       " 'incomplete_details': None,\n",
-       " 'instructions': 'You are a personal math tutor. Answer questions briefly, in a sentence or less.',\n",
-       " 'last_error': None,\n",
-       " 'max_completion_tokens': None,\n",
-       " 'max_prompt_tokens': None,\n",
-       " 'max_completion_tokens': None,\n",
-       " 'max_prompt_tokens': None,\n",
-       " 'metadata': {},\n",
-       " 'model': 'gpt-4o',\n",
-       " 'object': 'thread.run',\n",
-       " 'parallel_tool_calls': True,\n",
-       " 'parallel_tool_calls': True,\n",
-       " 'required_action': None,\n",
-       " 'response_format': 'auto',\n",
-       " 'started_at': 1736340405,\n",
-       " 'status': 'completed',\n",
-       " 'thread_id': 'thread_j4dc1TiHPfkviKUHNi4aAsA6',\n",
-       " 'tool_choice': 'auto',\n",
-       " 'tools': [],\n",
-       " 'truncation_strategy': {'type': 'auto', 'last_messages': None},\n",
-       " 'usage': {'completion_tokens': 35,\n",
-       "  'prompt_tokens': 66,\n",
-       "  'total_tokens': 101,\n",
-       "  'prompt_token_details': {'cached_tokens': 0},\n",
-       "  'completion_tokens_details': {'reasoning_tokens': 0}},\n",
-       " 'temperature': 1.0,\n",
-       " 'top_p': 1.0,\n",
-       " 'tool_resources': {}}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "run = wait_on_run(run, thread)\n",
-    "show_json(run)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Messages\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now that the Run has completed, we can list the Messages in the Thread to see what got added by the Assistant.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'data': [{'id': 'msg_A5eAN6ZAJDmFBOYutEm5DFCy',\n",
-       "   'assistant_id': 'asst_qvXmYlZV8zhABI2RtPzDfV6z',\n",
-       "   'attachments': [],\n",
-       "   'completed_at': None,\n",
-       "   'content': [{'text': {'annotations': [],\n",
-       "      'value': 'Sure! Subtract 11 from both sides to get \\\\(3x = 3\\\\), then divide by 3 to find \\\\(x = 1\\\\).'},\n",
-       "     'type': 'text'}],\n",
-       "   'created_at': 1736340405,\n",
-       "   'incomplete_at': None,\n",
-       "   'incomplete_details': None,\n",
-       "   'metadata': {},\n",
-       "   'object': 'thread.message',\n",
-       "   'role': 'assistant',\n",
-       "   'run_id': 'run_qVYsWok6OCjHxkajpIrdHuVP',\n",
-       "   'status': None,\n",
-       "   'thread_id': 'thread_j4dc1TiHPfkviKUHNi4aAsA6'},\n",
-       "  {'id': 'msg_1q4Y7ZZ9gIcPoAKSx9UtrrKJ',\n",
-       "   'assistant_id': None,\n",
-       "   'attachments': [],\n",
-       "   'completed_at': None,\n",
-       "   'attachments': [],\n",
-       "   'completed_at': None,\n",
-       "   'content': [{'text': {'annotations': [],\n",
-       "      'value': 'I need to solve the equation `3x + 11 = 14`. Can you help me?'},\n",
-       "     'type': 'text'}],\n",
-       "   'created_at': 1736340400,\n",
-       "   'incomplete_at': None,\n",
-       "   'incomplete_details': None,\n",
-       "   'metadata': {},\n",
-       "   'object': 'thread.message',\n",
-       "   'role': 'user',\n",
-       "   'run_id': None,\n",
-       "   'status': None,\n",
-       "   'thread_id': 'thread_j4dc1TiHPfkviKUHNi4aAsA6'}],\n",
-       " 'object': 'list',\n",
-       " 'first_id': 'msg_A5eAN6ZAJDmFBOYutEm5DFCy',\n",
-       " 'last_id': 'msg_1q4Y7ZZ9gIcPoAKSx9UtrrKJ',\n",
-       " 'has_more': False}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "messages = client.beta.threads.messages.list(thread_id=thread.id)\n",
-    "show_json(messages)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As you can see, Messages are ordered in reverse-chronological order – this was done so the most recent results are always on the first `page` (since results can be paginated). Do keep a look out for this, since this is the opposite order to messages in the Chat Completions API.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's ask our Assistant to explain the result a bit further!\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'data': [{'id': 'msg_wSHHvaMnaWktZWsKs6gyoPUB',\n",
-       "   'assistant_id': 'asst_qvXmYlZV8zhABI2RtPzDfV6z',\n",
-       "   'attachments': [],\n",
-       "   'completed_at': None,\n",
-       "   'content': [{'text': {'annotations': [],\n",
-       "      'value': 'Certainly! To isolate \\\\(x\\\\), first subtract 11 from both sides of the equation \\\\(3x + 11 = 14\\\\), resulting in \\\\(3x = 3\\\\). Then, divide both sides by 3 to solve for \\\\(x\\\\), giving you \\\\(x = 1\\\\).'},\n",
-       "     'type': 'text'}],\n",
-       "   'created_at': 1736340414,\n",
-       "   'incomplete_at': None,\n",
-       "   'incomplete_details': None,\n",
-       "   'metadata': {},\n",
-       "   'object': 'thread.message',\n",
-       "   'role': 'assistant',\n",
-       "   'run_id': 'run_lJsumsDtPTmdG3Enx2CfYrrq',\n",
-       "   'status': None,\n",
-       "   'thread_id': 'thread_j4dc1TiHPfkviKUHNi4aAsA6'}],\n",
-       " 'object': 'list',\n",
-       " 'first_id': 'msg_wSHHvaMnaWktZWsKs6gyoPUB',\n",
-       " 'last_id': 'msg_wSHHvaMnaWktZWsKs6gyoPUB',\n",
-       " 'has_more': False}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Create a message to append to our thread\n",
-    "message = client.beta.threads.messages.create(\n",
-    "    thread_id=thread.id, role=\"user\", content=\"Could you explain this to me?\"\n",
-    ")\n",
-    "\n",
-    "# Execute our run\n",
-    "run = client.beta.threads.runs.create(\n",
-    "    thread_id=thread.id,\n",
-    "    assistant_id=assistant.id,\n",
-    ")\n",
-    "\n",
-    "# Wait for completion\n",
-    "wait_on_run(run, thread)\n",
-    "\n",
-    "# Retrieve all the messages added after our last user message\n",
-    "messages = client.beta.threads.messages.list(\n",
-    "    thread_id=thread.id, order=\"asc\", after=message.id\n",
-    ")\n",
-    "show_json(messages)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This may feel like a lot of steps to get a response back, especially for this simple example. However, you'll soon see how we can add very powerful functionality to our Assistant without changing much code at all!\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Example\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's take a look at how we could potentially put all of this together. Below is all the code you need to use an Assistant you've created.\n",
-    "\n",
-    "Since we've already created our Math Assistant, I've saved its ID in `MATH_ASSISTANT_ID`. I then defined two functions:\n",
-    "\n",
-    "- `submit_message`: create a Message on a Thread, then start (and return) a new Run\n",
-    "- `get_response`: returns the list of Messages in a Thread\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "from openai import OpenAI\n",
     "\n",
-    "MATH_ASSISTANT_ID = assistant.id  # or a hard-coded ID like \"asst-...\"\n",
     "\n",
-    "client = OpenAI(api_key=os.environ.get(\"OPENAI_API_KEY\", \"<your OpenAI API key if not set as env var>\"))\n",
+    "if not os.environ.get(\"OPENAI_API_KEY\"):\n",
+    "    raise RuntimeError(\"Set OPENAI_API_KEY before running this notebook.\")\n",
     "\n",
-    "def submit_message(assistant_id, thread, user_message):\n",
-    "    client.beta.threads.messages.create(\n",
-    "        thread_id=thread.id, role=\"user\", content=user_message\n",
-    "    )\n",
-    "    return client.beta.threads.runs.create(\n",
-    "        thread_id=thread.id,\n",
-    "        assistant_id=assistant_id,\n",
-    "    )\n",
+    "client = OpenAI()\n",
     "\n",
     "\n",
-    "def get_response(thread):\n",
-    "    return client.beta.threads.messages.list(thread_id=thread.id, order=\"asc\")"
-   ]
+    "def show_json(obj):\n",
+    "    if hasattr(obj, \"model_dump_json\"):\n",
+    "        display(json.loads(obj.model_dump_json()))\n",
+    "    else:\n",
+    "        display(obj)"
+   ],
+   "id": "cell-006"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "I've also defined a `create_thread_and_run` function that I can reuse (which is actually almost identical to the [`client.beta.threads.create_and_run`](https://platform.openai.com/docs/api-reference/runs/createThreadAndRun) compound function in our API ;) ). Finally, we can submit our mock user requests each to a new Thread.\n",
+    "## Complete Example with the Responses API\n",
     "\n",
-    "Notice how all of these API calls are asynchronous operations; this means we actually get async behavior in our code without the use of async libraries! (e.g. `asyncio`)\n"
-   ]
+    "### A basic response\n",
+    "\n",
+    "The Responses API lets you provide the model, instructions, and user input in one request."
+   ],
+   "id": "cell-007"
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def create_thread_and_run(user_input):\n",
-    "    thread = client.beta.threads.create()\n",
-    "    run = submit_message(MATH_ASSISTANT_ID, thread, user_input)\n",
-    "    return thread, run\n",
-    "\n",
-    "\n",
-    "# Emulating concurrent user requests\n",
-    "thread1, run1 = create_thread_and_run(\n",
-    "    \"I need to solve the equation `3x + 11 = 14`. Can you help me?\"\n",
+    "response = client.responses.create(\n",
+    "    model=\"gpt-4o\",\n",
+    "    instructions=\"You are a personal math tutor. Answer questions briefly, in a sentence or less.\",\n",
+    "    input=\"I need to solve the equation `3x + 11 = 14`. Can you help me?\",\n",
     ")\n",
-    "thread2, run2 = create_thread_and_run(\"Could you explain linear algebra to me?\")\n",
-    "thread3, run3 = create_thread_and_run(\"I don't like math. What can I do?\")\n",
     "\n",
-    "# Now all Runs are executing..."
-   ]
+    "print(response.output_text)\n",
+    "show_json(response)"
+   ],
+   "id": "cell-008"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once all Runs are going, we can wait on each and get the responses.\n"
-   ]
+    "### Conversation state\n",
+    "\n",
+    "The next request uses `previous_response_id`, so we can continue the conversation without constructing a separate thread. Instructions are request-scoped, so include them again on follow-up requests when they still apply."
+   ],
+   "id": "cell-009"
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "# Messages\n",
-      "user: I need to solve the equation `3x + 11 = 14`. Can you help me?\n",
-      "assistant: Sure! Subtract 11 from both sides to get \\(3x = 3\\), then divide by 3 to find \\(x = 1\\).\n",
-      "\n",
-      "# Messages\n",
-      "user: Could you explain linear algebra to me?\n",
-      "assistant: Linear algebra is the branch of mathematics concerning vector spaces, linear transformations, and systems of linear equations, often represented with matrices.\n",
-      "\n",
-      "# Messages\n",
-      "user: I don't like math. What can I do?\n",
-      "assistant: Try relating math to real-life interests or hobbies, practice with fun games or apps, and gradually build confidence with easier problems.\n",
-      "\n",
-      "# Messages\n",
-      "user: I don't like math. What can I do?\n",
-      "assistant: Try relating math to real-life interests or hobbies, practice with fun games or apps, and gradually build confidence with easier problems.\n",
-      "user: Thank you!\n",
-      "assistant: You're welcome! If you have any more questions, feel free to ask!\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import time\n",
+    "response = client.responses.create(\n",
+    "    model=\"gpt-4o\",\n",
+    "    instructions=\"You are a personal math tutor. Answer questions briefly, in a sentence or less.\",\n",
+    "    previous_response_id=response.id,\n",
+    "    input=\"Could you explain this to me?\",\n",
+    ")\n",
     "\n",
-    "# Pretty printing helper\n",
-    "def pretty_print(messages):\n",
-    "    print(\"# Messages\")\n",
-    "    for m in messages:\n",
-    "        print(f\"{m.role}: {m.content[0].text.value}\")\n",
-    "    print()\n",
-    "\n",
-    "\n",
-    "# Waiting in a loop\n",
-    "def wait_on_run(run, thread):\n",
-    "    while run.status == \"queued\" or run.status == \"in_progress\":\n",
-    "        run = client.beta.threads.runs.retrieve(\n",
-    "            thread_id=thread.id,\n",
-    "            run_id=run.id,\n",
-    "        )\n",
-    "        time.sleep(0.5)\n",
-    "    return run\n",
-    "\n",
-    "\n",
-    "# Wait for Run 1\n",
-    "run1 = wait_on_run(run1, thread1)\n",
-    "pretty_print(get_response(thread1))\n",
-    "\n",
-    "# Wait for Run 2\n",
-    "run2 = wait_on_run(run2, thread2)\n",
-    "pretty_print(get_response(thread2))\n",
-    "\n",
-    "# Wait for Run 3\n",
-    "run3 = wait_on_run(run3, thread3)\n",
-    "pretty_print(get_response(thread3))\n",
-    "\n",
-    "# Thank our assistant on Thread 3 :)\n",
-    "run4 = submit_message(MATH_ASSISTANT_ID, thread3, \"Thank you!\")\n",
-    "run4 = wait_on_run(run4, thread3)\n",
-    "pretty_print(get_response(thread3))"
-   ]
+    "print(response.output_text)"
+   ],
+   "id": "cell-010"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Et voilà!\n",
+    "> **Note**\n",
+    "> When you use `previous_response_id`, the previous response remains part of the context and is still billed as input."
+   ],
+   "id": "cell-011"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Output\n",
     "\n",
-    "You may have noticed that this code is not actually specific to our math Assistant at all... this code will work for any new Assistant you create simply by changing the Assistant ID! That is the power of the Assistants API.\n"
-   ]
+    "Read generated text from `output_text`. The complete structured output is available through `response.output` when you need annotations, tool calls, or other item-level details."
+   ],
+   "id": "cell-012"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(response.output_text)\n",
+    "\n",
+    "for item in response.output:\n",
+    "    print(item.type)"
+   ],
+   "id": "cell-013"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reusable helper\n",
+    "\n",
+    "The helper below keeps the response ID and returns the model's text. Omit `previous_response_id` for an independent request; pass it for a follow-up."
+   ],
+   "id": "cell-014"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ask_math_tutor(user_input, previous_response_id=None):\n",
+    "    request = {\n",
+    "        \"model\": \"gpt-4o\",\n",
+    "        \"instructions\": \"You are a personal math tutor. Answer questions briefly, in a sentence or less.\",\n",
+    "        \"input\": user_input,\n",
+    "    }\n",
+    "    if previous_response_id:\n",
+    "        request[\"previous_response_id\"] = previous_response_id\n",
+    "    return client.responses.create(**request)\n",
+    "\n",
+    "\n",
+    "independent_response = ask_math_tutor(\"Could you explain linear algebra to me?\")\n",
+    "print(independent_response.output_text)"
+   ],
+   "id": "cell-015"
   },
   {
    "cell_type": "markdown",
@@ -799,199 +216,49 @@
    "source": [
     "## Tools\n",
     "\n",
-    "A key feature of the Assistants API is the ability to equip our Assistants with Tools, like Code Interpreter, File Search, and custom Functions. Let's take a look at each.\n",
-    "\n",
+    "A key feature of the Responses API is the ability to expose hosted tools and custom functions in the same request. The following sections cover Code Interpreter, File Search, and Functions."
+   ],
+   "id": "cell-016"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Code Interpreter\n",
     "\n",
-    "Let's equip our Math Tutor with the [Code Interpreter](https://platform.openai.com/docs/assistants/tools/code-interpreter) tool, which we can do from the Dashboard...\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "![Enabling code interpreter](../images/assistants_overview_enable_code_interpreter.png)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "...or the API, using the Assistant ID.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 'asst_qvXmYlZV8zhABI2RtPzDfV6z',\n",
-       " 'created_at': 1736340398,\n",
-       " 'description': None,\n",
-       " 'instructions': 'You are a personal math tutor. Answer questions briefly, in a sentence or less.',\n",
-       " 'metadata': {},\n",
-       " 'model': 'gpt-4o',\n",
-       " 'name': 'Math Tutor',\n",
-       " 'object': 'assistant',\n",
-       " 'tools': [{'type': 'code_interpreter'}],\n",
-       " 'response_format': 'auto',\n",
-       " 'temperature': 1.0,\n",
-       " 'tool_resources': {'code_interpreter': {'file_ids': []}, 'file_search': None},\n",
-       " 'top_p': 1.0}",
-       " 'tools': [{'type': 'code_interpreter'}],\n",
-       " 'response_format': 'auto',\n",
-       " 'temperature': 1.0,\n",
-       " 'tool_resources': {'code_interpreter': {'file_ids': []}, 'file_search': None},\n",
-       " 'top_p': 1.0}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
+    "The [Code Interpreter](https://platform.openai.com/docs/guides/tools-code-interpreter) tool runs Python in a hosted container. Requesting `code_interpreter_call.outputs` makes generated logs and images available in the response object."
    ],
-   "source": [
-    "assistant = client.beta.assistants.update(\n",
-    "    MATH_ASSISTANT_ID,\n",
-    "    tools=[{\"type\": \"code_interpreter\"}],\n",
-    ")\n",
-    "show_json(assistant)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now, let's ask the Assistant to use its new tool.\n"
-   ]
+   "id": "cell-017"
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "# Messages\n",
-      "user: Generate the first 20 fibbonaci numbers with code.\n",
-      "assistant: The first 20 Fibonacci numbers are: 0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181.\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "thread, run = create_thread_and_run(\n",
-    "    \"Generate the first 20 fibbonaci numbers with code.\"\n",
-    ")\n",
-    "run = wait_on_run(run, thread)\n",
-    "pretty_print(get_response(thread))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And that's it! The Assistant used Code Interpreter in the background, and gave us a final response.\n",
-    "\n",
-    "For some use cases this may be enough – however, if we want more details on what precisely an Assistant is doing we can take a look at a Run's Steps.\n",
-    "\n",
-    "### Steps\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A Run is composed of one or more Steps. Like a Run, each Step has a `status` that you can query. This is useful for surfacing the progress of a Step to a user (e.g. a spinner while the Assistant is writing code or performing retrieval).\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_steps = client.beta.threads.runs.steps.list(\n",
-    "    thread_id=thread.id, run_id=run.id, order=\"asc\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's take a look at each Step's `step_details`.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'tool_calls': [{'id': 'call_E1EE1loDmcWoc7FpkOMKYj6n',\n",
-       "   'code_interpreter': {'input': 'def generate_fibonacci(n):\\n    fib_sequence = [0, 1]\\n    while len(fib_sequence) < n:\\n        next_value = fib_sequence[-1] + fib_sequence[-2]\\n        fib_sequence.append(next_value)\\n    return fib_sequence\\n\\n# Generate the first 20 Fibonacci numbers\\nfirst_20_fibonacci = generate_fibonacci(20)\\nfirst_20_fibonacci',\n",
-       "    'outputs': []},\n",
-       "   'type': 'code_interpreter'}],\n",
-       " 'type': 'tool_calls'}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "null\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'message_creation': {'message_id': 'msg_RzTnbBMmzDYHk79a0x9qM5uU'},\n",
-       " 'type': 'message_creation'}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "null\n"
-     ]
-    }
+    "response = client.responses.create(\n",
+    "    model=\"gpt-4o\",\n",
+    "    instructions=\"Use Python whenever it makes the calculation easier to verify.\",\n",
+    "    input=\"Generate the first 20 Fibonacci numbers with code.\",\n",
+    "    tools=[\n",
+    "        {\n",
+    "            \"type\": \"code_interpreter\",\n",
+    "            \"container\": {\"type\": \"auto\"},\n",
+    "        }\n",
+    "    ],\n",
+    "    include=[\"code_interpreter_call.outputs\"],\n",
+    ")\n",
+    "\n",
+    "print(response.output_text)\n",
+    "for item in response.output:\n",
+    "    if item.type == \"code_interpreter_call\":\n",
+    "        print(item.code)\n",
+    "        for output in item.outputs or []:\n",
+    "            print(output.type)\n",
+    "            if output.type == \"logs\":\n",
+    "                print(output.logs)"
    ],
-   "source": [
-    "for step in run_steps.data:\n",
-    "    step_details = step.step_details\n",
-    "    print(json.dumps(show_json(step_details), indent=4))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can see the `step_details` for two Steps:\n",
-    "\n",
-    "1. `tool_calls` (plural, since it could be more than one in a single Step)\n",
-    "2. `message_creation`\n",
-    "\n",
-    "The first Step is a `tool_calls`, specifically using the `code_interpreter` which contains:\n",
-    "\n",
-    "- `input`, which was the Python code generated before the tool was called, and\n",
-    "- `output`, which was the result of running the Code Interpreter.\n",
-    "\n",
-    "The second Step is a `message_creation`, which contains the `message` that was added to the Thread to communicate the results to the user.\n"
-   ]
+   "id": "cell-018"
   },
   {
    "cell_type": "markdown",
@@ -999,152 +266,73 @@
    "source": [
     "### File search\n",
     "\n",
-    "Another powerful tool in the Assistants API is [File search](https://platform.openai.com/docs/assistants/tools/file-search). This allows the uploading of files to the Assistant to be used as a knowledge base when answering questions.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "![Enabling retrieval](../images/assistants_overview_enable_retrieval.png)\n"
-   ]
+    "The [File search](https://platform.openai.com/docs/guides/tools-file-search) tool searches files attached to a vector store and grounds the response in the retrieved content."
+   ],
+   "id": "cell-019"
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "File added to vector store\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 'asst_qvXmYlZV8zhABI2RtPzDfV6z',\n",
-       " 'created_at': 1736340398,\n",
-       " 'description': None,\n",
-       " 'instructions': 'You are a personal math tutor. Answer questions briefly, in a sentence or less.',\n",
-       " 'metadata': {},\n",
-       " 'model': 'gpt-4o',\n",
-       " 'name': 'Math Tutor',\n",
-       " 'object': 'assistant',\n",
-       " 'tools': [{'type': 'code_interpreter'},\n",
-       "  {'type': 'file_search',\n",
-       "   'file_search': {'max_num_results': None,\n",
-       "    'ranking_options': {'score_threshold': 0.0,\n",
-       "     'ranker': 'default_2024_08_21'}}}],\n",
-       " 'response_format': 'auto',\n",
-       " 'temperature': 1.0,\n",
-       " 'tool_resources': {'code_interpreter': {'file_ids': ['file-GQFm2i7N8LrAQatefWKEsE']},\n",
-       "  'file_search': {'vector_store_ids': ['vs_dEArILZSJh7J799QACi3QhuU']}},\n",
-       " 'top_p': 1.0}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Upload the file\n",
-    "file = client.files.create(\n",
-    "    file=open(\n",
-    "        \"data/language_models_are_unsupervised_multitask_learners.pdf\",\n",
-    "        \"rb\",\n",
-    "    ),\n",
-    "    purpose=\"assistants\",\n",
-    ")\n",
+    "with open(\n",
+    "    \"data/language_models_are_unsupervised_multitask_learners.pdf\",\n",
+    "    \"rb\",\n",
+    ") as file_handle:\n",
+    "    file = client.files.create(file=file_handle, purpose=\"assistants\")\n",
     "\n",
-    "# Create a vector store\n",
-    "vector_store = client.beta.vector_stores.create(\n",
+    "vector_store = client.vector_stores.create(\n",
     "    name=\"language_models_are_unsupervised_multitask_learners\",\n",
     ")\n",
-    "\n",
-    "# Add the file to the vector store\n",
-    "vector_store_file = client.beta.vector_stores.files.create_and_poll(\n",
+    "vector_store_file = client.vector_stores.files.create_and_poll(\n",
     "    vector_store_id=vector_store.id,\n",
     "    file_id=file.id,\n",
     ")\n",
     "\n",
-    "# Confirm the file was added\n",
-    "while vector_store_file.status == \"in_progress\":\n",
-    "    time.sleep(1)\n",
-    "if vector_store_file.status == \"completed\":\n",
-    "    print(\"File added to vector store\")\n",
-    "elif vector_store_file.status == \"failed\":\n",
-    "    raise Exception(\"Failed to add file to vector store\")\n",
+    "if vector_store_file.status != \"completed\":\n",
+    "    raise RuntimeError(f\"File processing failed: {vector_store_file.status}\")\n",
     "\n",
-    "# Update Assistant\n",
-    "assistant = client.beta.assistants.update(\n",
-    "    MATH_ASSISTANT_ID,\n",
-    "    tools=[{\"type\": \"code_interpreter\"}, {\"type\": \"file_search\"}],\n",
-    "    tool_resources={\n",
-    "        \"file_search\":{\n",
-    "            \"vector_store_ids\": [vector_store.id]\n",
-    "        },\n",
-    "        \"code_interpreter\": {\n",
-    "            \"file_ids\": [file.id]\n",
+    "response = client.responses.create(\n",
+    "    model=\"gpt-4o-mini\",\n",
+    "    input=\"What are some cool math concepts behind this ML paper? Explain in two sentences.\",\n",
+    "    tools=[\n",
+    "        {\n",
+    "            \"type\": \"file_search\",\n",
+    "            \"vector_store_ids\": [vector_store.id],\n",
     "        }\n",
-    "    },\n",
+    "    ],\n",
     ")\n",
-    "show_json(assistant)"
-   ]
+    "\n",
+    "print(response.output_text)"
+   ],
+   "id": "cell-020"
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "# Messages\n",
-      "user: What are some cool math concepts behind this ML paper pdf? Explain in two sentences.\n",
-      "assistant: The paper explores the concept of multitask learning where a single model is used to perform various tasks, modeling the conditional distribution \\( p(\\text{output} | \\text{input, task}) \\), inspired by probabilistic approaches【6:10†source】. It also discusses the use of Transformer-based architectures and parallel corpus substitution in language models, enhancing their ability to generalize across domain tasks without explicit task-specific supervision【6:2†source】【6:5†source】.\n",
-      "\n"
-     ]
-    }
+   "outputs": [],
+   "source": [
+    "for item in response.output:\n",
+    "    if item.type != \"message\":\n",
+    "        continue\n",
+    "    for content in item.content:\n",
+    "        for annotation in content.annotations:\n",
+    "            if annotation.type == \"file_citation\":\n",
+    "                print(f\"Cited file: {annotation.filename} ({annotation.file_id})\")"
    ],
-   "source": [
-    "thread, run = create_thread_and_run(\n",
-    "    \"What are some cool math concepts behind this ML paper pdf? Explain in two sentences.\"\n",
-    ")\n",
-    "run = wait_on_run(run, thread)\n",
-    "pretty_print(get_response(thread))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "> **Note**\n",
-    "> There are more intricacies in File Search, like [Annotations](https://platform.openai.com/docs/assistants/how-it-works/managing-threads-and-messages), which may be covered in another cookbook.\n"
-   ]
+   "id": "cell-021"
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "VectorStoreDeleted(id='vs_dEArILZSJh7J799QACi3QhuU', deleted=True, object='vector_store.deleted')"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Delete the vector store\n",
-    "client.beta.vector_stores.delete(vector_store.id)\n"
-   ]
+    "client.vector_stores.delete(vector_store.id)"
+   ],
+   "id": "cell-022"
   },
   {
    "cell_type": "markdown",
@@ -1152,24 +340,13 @@
    "source": [
     "### Functions\n",
     "\n",
-    "As a final powerful tool for your Assistant, you can specify custom [Functions](https://platform.openai.com/docs/assistants/tools/function-calling) (much like the [Function Calling](https://platform.openai.com/docs/guides/function-calling) in the Chat Completions API). During a Run, the Assistant can then indicate it wants to call one or more functions you specified. You are then responsible for calling the Function, and providing the output back to the Assistant.\n",
-    "\n",
-    "Let's take a look at an example by defining a `display_quiz()` Function for our Math Tutor.\n",
-    "\n",
-    "This function will take a `title` and an array of `question`s, display the quiz, and get input from the user for each:\n",
-    "\n",
-    "- `title`\n",
-    "- `questions`\n",
-    "  - `question_text`\n",
-    "  - `question_type`: [`MULTIPLE_CHOICE`, `FREE_RESPONSE`]\n",
-    "  - `choices`: [\"choice 1\", \"choice 2\", ...]\n",
-    "\n",
-    "I'll mocking out responses with `get_mock_response...`. This is where you'd get the user's actual input.\n"
-   ]
+    "You can define custom [Functions](https://platform.openai.com/docs/guides/function-calling) alongside hosted tools. The model can return one or more `function_call` items; the application executes them and sends back `function_call_output` items."
+   ],
+   "id": "cell-023"
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1186,543 +363,128 @@
     "    print()\n",
     "    responses = []\n",
     "\n",
-    "    for q in questions:\n",
-    "        print(q[\"question_text\"])\n",
-    "        response = \"\"\n",
-    "\n",
-    "        # If multiple choice, print options\n",
-    "        if q[\"question_type\"] == \"MULTIPLE_CHOICE\":\n",
-    "            for i, choice in enumerate(q[\"choices\"]):\n",
-    "                print(f\"{i}. {choice}\")\n",
-    "            response = get_mock_response_from_user_multiple_choice()\n",
-    "\n",
-    "        # Otherwise, just get response\n",
-    "        elif q[\"question_type\"] == \"FREE_RESPONSE\":\n",
-    "            response = get_mock_response_from_user_free_response()\n",
-    "\n",
-    "        responses.append(response)\n",
+    "    for question in questions:\n",
+    "        print(question[\"question_text\"])\n",
+    "        if question[\"question_type\"] == \"MULTIPLE_CHOICE\":\n",
+    "            for index, choice in enumerate(question[\"choices\"]):\n",
+    "                print(f\"{index}. {choice}\")\n",
+    "            answer = get_mock_response_from_user_multiple_choice()\n",
+    "        else:\n",
+    "            answer = get_mock_response_from_user_free_response()\n",
+    "        responses.append(answer)\n",
     "        print()\n",
     "\n",
     "    return responses"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Here's what a sample quiz would look like:\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Quiz: Sample Quiz\n",
-      "\n",
-      "What is your name?\n",
-      "\n",
-      "What is your favorite color?\n",
-      "0. Red\n",
-      "1. Blue\n",
-      "2. Green\n",
-      "3. Yellow\n",
-      "\n",
-      "Responses: [\"I don't know.\", 'a']\n"
-     ]
-    }
    ],
-   "source": [
-    "responses = display_quiz(\n",
-    "    \"Sample Quiz\",\n",
-    "    [\n",
-    "        {\"question_text\": \"What is your name?\", \"question_type\": \"FREE_RESPONSE\"},\n",
-    "        {\n",
-    "            \"question_text\": \"What is your favorite color?\",\n",
-    "            \"question_type\": \"MULTIPLE_CHOICE\",\n",
-    "            \"choices\": [\"Red\", \"Blue\", \"Green\", \"Yellow\"],\n",
-    "        },\n",
-    "    ],\n",
-    ")\n",
-    "print(\"Responses:\", responses)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now, let's define the interface of this function in JSON format, so our Assistant can call it:\n"
-   ]
+   "id": "cell-024"
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "function_json = {\n",
+    "function_tool = {\n",
+    "    \"type\": \"function\",\n",
     "    \"name\": \"display_quiz\",\n",
-    "    \"description\": \"Displays a quiz to the student, and returns the student's response. A single quiz can have multiple questions.\",\n",
+    "    \"description\": \"Display a quiz to the student and return the student's responses.\",\n",
     "    \"parameters\": {\n",
     "        \"type\": \"object\",\n",
     "        \"properties\": {\n",
     "            \"title\": {\"type\": \"string\"},\n",
     "            \"questions\": {\n",
     "                \"type\": \"array\",\n",
-    "                \"description\": \"An array of questions, each with a title and potentially options (if multiple choice).\",\n",
     "                \"items\": {\n",
     "                    \"type\": \"object\",\n",
     "                    \"properties\": {\n",
     "                        \"question_text\": {\"type\": \"string\"},\n",
     "                        \"question_type\": {\n",
     "                            \"type\": \"string\",\n",
-    "                            \"enum\": [\"MULTIPLE_CHOICE\", \"FREE_RESPONSE\"]\n",
+    "                            \"enum\": [\"MULTIPLE_CHOICE\", \"FREE_RESPONSE\"],\n",
     "                        },\n",
-    "                        \"choices\": {\"type\": \"array\", \"items\": {\"type\": \"string\"}}\n",
+    "                        \"choices\": {\n",
+    "                            \"type\": \"array\",\n",
+    "                            \"items\": {\"type\": \"string\"},\n",
+    "                        },\n",
     "                    },\n",
-    "                    \"required\": [\"question_text\"]\n",
-    "                }\n",
-    "            }\n",
+    "                    \"required\": [\"question_text\", \"question_type\", \"choices\"],\n",
+    "                    \"additionalProperties\": False,\n",
+    "                },\n",
+    "            },\n",
     "        },\n",
-    "        \"required\": [\"title\", \"questions\"]\n",
-    "    }\n",
-    "}\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Once again, let's update our Assistant either through the Dashboard or the API.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "![Enabling custom function](../images/assistants_overview_enable_function.png)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "> **Note**\n",
-    "> Pasting the function JSON into the Dashboard was a bit finicky due to indentation, etc. I just asked ChatGPT to format my function the same as one of the examples on the Dashboard :).\n"
-   ]
+    "        \"required\": [\"title\", \"questions\"],\n",
+    "        \"additionalProperties\": False,\n",
+    "    },\n",
+    "    \"strict\": True,\n",
+    "}"
+   ],
+   "id": "cell-025"
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 'asst_qvXmYlZV8zhABI2RtPzDfV6z',\n",
-       " 'created_at': 1736340398,\n",
-       " 'description': None,\n",
-       " 'instructions': 'You are a personal math tutor. Answer questions briefly, in a sentence or less.',\n",
-       " 'metadata': {},\n",
-       " 'model': 'gpt-4o',\n",
-       " 'name': 'Math Tutor',\n",
-       " 'object': 'assistant',\n",
-       " 'tools': [{'type': 'code_interpreter'},\n",
-       "  {'type': 'file_search',\n",
-       "   'file_search': {'max_num_results': None,\n",
-       "    'ranking_options': {'score_threshold': 0.0,\n",
-       "     'ranker': 'default_2024_08_21'}}},\n",
-       "  {'function': {'name': 'display_quiz',\n",
-       "    'description': \"Displays a quiz to the student, and returns the student's response. A single quiz can have multiple questions.\",\n",
-       "    'description': \"Displays a quiz to the student, and returns the student's response. A single quiz can have multiple questions.\",\n",
-       "    'parameters': {'type': 'object',\n",
-       "     'properties': {'title': {'type': 'string'},\n",
-       "      'questions': {'type': 'array',\n",
-       "       'description': 'An array of questions, each with a title and potentially options (if multiple choice).',\n",
-       "       'items': {'type': 'object',\n",
-       "        'properties': {'question_text': {'type': 'string'},\n",
-       "         'question_type': {'type': 'string',\n",
-       "          'enum': ['MULTIPLE_CHOICE', 'FREE_RESPONSE']},\n",
-       "         'choices': {'type': 'array', 'items': {'type': 'string'}}},\n",
-       "        'required': ['question_text']}}},\n",
-       "     'required': ['title', 'questions']},\n",
-       "    'strict': False},\n",
-       "   'type': 'function'}],\n",
-       " 'response_format': 'auto',\n",
-       " 'temperature': 1.0,\n",
-       " 'tool_resources': {'code_interpreter': {'file_ids': ['file-GQFm2i7N8LrAQatefWKEsE']},\n",
-       "  'file_search': {'vector_store_ids': []}},\n",
-       " 'top_p': 1.0}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "assistant = client.beta.assistants.update(\n",
-    "    MATH_ASSISTANT_ID,\n",
-    "    tools=[\n",
-    "        {\"type\": \"code_interpreter\"},\n",
-    "        {\"type\": \"file_search\"},\n",
-    "        {\"type\": \"function\", \"function\": function_json},\n",
-    "    ],\n",
+    "quiz_response = client.responses.create(\n",
+    "    model=\"gpt-4o\",\n",
+    "    input=\"Make a quiz with two questions: one open ended and one multiple choice. Then give me feedback for the responses.\",\n",
+    "    tools=[function_tool],\n",
     ")\n",
-    "show_json(assistant)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And now, we ask for a quiz.\n"
-   ]
+    "\n",
+    "quiz_response.output"
+   ],
+   "id": "cell-026"
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'requires_action'"
-      ]
-     },
-     "execution_count": 39,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "thread, run = create_thread_and_run(\n",
-    "    \"Make a quiz with 2 questions: One open ended, one multiple choice. Then, give me feedback for the responses.\"\n",
+    "def invoke_functions(response):\n",
+    "    function_outputs = []\n",
+    "    for item in response.output:\n",
+    "        if item.type != \"function_call\":\n",
+    "            continue\n",
+    "        if item.name != \"display_quiz\":\n",
+    "            raise ValueError(f\"Unknown function: {item.name}\")\n",
+    "\n",
+    "        arguments = json.loads(item.arguments)\n",
+    "        responses = display_quiz(arguments[\"title\"], arguments[\"questions\"])\n",
+    "        function_outputs.append(\n",
+    "            {\n",
+    "                \"type\": \"function_call_output\",\n",
+    "                \"call_id\": item.call_id,\n",
+    "                \"output\": json.dumps(responses),\n",
+    "            }\n",
+    "        )\n",
+    "    return function_outputs\n",
+    "\n",
+    "\n",
+    "function_outputs = invoke_functions(quiz_response)\n",
+    "if not function_outputs:\n",
+    "    raise RuntimeError(\"The model did not request the display_quiz function.\")"
+   ],
+   "id": "cell-027"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "quiz_response = client.responses.create(\n",
+    "    model=\"gpt-4o\",\n",
+    "    instructions=\"You are a personal math tutor. Answer questions briefly, in a sentence or less.\",\n",
+    "    previous_response_id=quiz_response.id,\n",
+    "    input=function_outputs,\n",
+    "    tools=[function_tool],\n",
     ")\n",
-    "run = wait_on_run(run, thread)\n",
-    "run.status"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now, however, when we check the Run's `status` we see `requires_action`! Let's take a closer.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 40,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 'run_ekMRSI2h35asEzKirRf4BTwZ',\n",
-       " 'assistant_id': 'asst_qvXmYlZV8zhABI2RtPzDfV6z',\n",
-       " 'cancelled_at': None,\n",
-       " 'completed_at': None,\n",
-       " 'created_at': 1736341020,\n",
-       " 'expires_at': 1736341620,\n",
-       " 'failed_at': None,\n",
-       " 'incomplete_details': None,\n",
-       " 'incomplete_details': None,\n",
-       " 'instructions': 'You are a personal math tutor. Answer questions briefly, in a sentence or less.',\n",
-       " 'last_error': None,\n",
-       " 'max_completion_tokens': None,\n",
-       " 'max_prompt_tokens': None,\n",
-       " 'max_completion_tokens': None,\n",
-       " 'max_prompt_tokens': None,\n",
-       " 'metadata': {},\n",
-       " 'model': 'gpt-4o',\n",
-       " 'object': 'thread.run',\n",
-       " 'parallel_tool_calls': True,\n",
-       " 'required_action': {'submit_tool_outputs': {'tool_calls': [{'id': 'call_uvJEn0fxM4sgmzek8wahBGLi',\n",
-       "     'function': {'arguments': '{\"title\":\"Math Quiz\",\"questions\":[{\"question_text\":\"What is the derivative of the function f(x) = 3x^2 + 2x - 5?\",\"question_type\":\"FREE_RESPONSE\"},{\"question_text\":\"What is the value of \\\\\\\\( \\\\\\\\int_{0}^{1} 2x \\\\\\\\, dx \\\\\\\\)?\",\"question_type\":\"MULTIPLE_CHOICE\",\"choices\":[\"0\",\"1\",\"2\",\"3\"]}]}',\n",
-       "      'name': 'display_quiz'},\n",
-       "     'type': 'function'}]},\n",
-       "  'type': 'submit_tool_outputs'},\n",
-       " 'response_format': 'auto',\n",
-       " 'started_at': 1736341022,\n",
-       " 'status': 'requires_action',\n",
-       " 'thread_id': 'thread_8bK2PXfoeijEHBVEzYuJXt17',\n",
-       " 'tool_choice': 'auto',\n",
-       " 'tools': [{'type': 'code_interpreter'},\n",
-       "  {'type': 'file_search',\n",
-       "   'file_search': {'max_num_results': None,\n",
-       "    'ranking_options': {'score_threshold': 0.0,\n",
-       "     'ranker': 'default_2024_08_21'}}},\n",
-       "  {'function': {'name': 'display_quiz',\n",
-       "    'description': \"Displays a quiz to the student, and returns the student's response. A single quiz can have multiple questions.\",\n",
-       "    'description': \"Displays a quiz to the student, and returns the student's response. A single quiz can have multiple questions.\",\n",
-       "    'parameters': {'type': 'object',\n",
-       "     'properties': {'title': {'type': 'string'},\n",
-       "      'questions': {'type': 'array',\n",
-       "       'description': 'An array of questions, each with a title and potentially options (if multiple choice).',\n",
-       "       'items': {'type': 'object',\n",
-       "        'properties': {'question_text': {'type': 'string'},\n",
-       "         'question_type': {'type': 'string',\n",
-       "          'enum': ['MULTIPLE_CHOICE', 'FREE_RESPONSE']},\n",
-       "         'choices': {'type': 'array', 'items': {'type': 'string'}}},\n",
-       "        'required': ['question_text']}}},\n",
-       "     'required': ['title', 'questions']},\n",
-       "    'strict': False},\n",
-       "   'type': 'function'}],\n",
-       " 'truncation_strategy': {'type': 'auto', 'last_messages': None},\n",
-       " 'usage': None,\n",
-       " 'temperature': 1.0,\n",
-       " 'top_p': 1.0,\n",
-       " 'tool_resources': {}}",
-       "    'strict': False},\n",
-       "   'type': 'function'}],\n",
-       " 'truncation_strategy': {'type': 'auto', 'last_messages': None},\n",
-       " 'usage': None,\n",
-       " 'temperature': 1.0,\n",
-       " 'top_p': 1.0,\n",
-       " 'tool_resources': {}}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "show_json(run)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The `required_action` field indicates a Tool is waiting for us to run it and submit its output back to the Assistant. Specifically, the `display_quiz` function! Let's start by parsing the `name` and `arguments`.\n",
     "\n",
-    "> **Note**\n",
-    "> While in this case we know there is only one Tool call, in practice the Assistant may choose to call multiple tools.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 41,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Function Name: display_quiz\n",
-      "Function Arguments:\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'title': 'Math Quiz',\n",
-       " 'questions': [{'question_text': 'What is the derivative of the function f(x) = 3x^2 + 2x - 5?',\n",
-       "   'question_type': 'FREE_RESPONSE'},\n",
-       "  {'question_text': 'What is the value of \\\\( \\\\int_{0}^{1} 2x \\\\, dx \\\\)?',\n",
-       "   'question_type': 'MULTIPLE_CHOICE',\n",
-       "   'choices': ['0', '1', '2', '3']}]}"
-      ]
-     },
-     "execution_count": 41,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
+    "print(quiz_response.output_text)"
    ],
-   "source": [
-    "# Extract single tool call\n",
-    "tool_call = run.required_action.submit_tool_outputs.tool_calls[0]\n",
-    "name = tool_call.function.name\n",
-    "arguments = json.loads(tool_call.function.arguments)\n",
-    "\n",
-    "print(\"Function Name:\", name)\n",
-    "print(\"Function Arguments:\")\n",
-    "arguments"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now let's actually call our `display_quiz` function with the arguments provided by the Assistant:\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 42,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Quiz: Math Quiz\n",
-      "Quiz: Math Quiz\n",
-      "\n",
-      "What is the derivative of the function f(x) = 3x^2 + 2x - 5?\n",
-      "\n",
-      "What is the value of \\( \\int_{0}^{1} 2x \\, dx \\)?\n",
-      "0. 0\n",
-      "1. 1\n",
-      "2. 2\n",
-      "3. 3\n",
-      "\n",
-      "Responses: [\"I don't know.\", 'a']\n"
-     ]
-    }
-   ],
-   "source": [
-    "responses = display_quiz(arguments[\"title\"], arguments[\"questions\"])\n",
-    "print(\"Responses:\", responses)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Great! (Remember these responses are the one's we mocked earlier. In reality, we'd be getting input from the back from this function call.)\n",
-    "\n",
-    "Now that we have our responses, let's submit them back to the Assistant. We'll need the `tool_call` ID, found in the `tool_call` we parsed out earlier. We'll also need to encode our `list`of responses into a `str`.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 43,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 'run_ekMRSI2h35asEzKirRf4BTwZ',\n",
-       " 'assistant_id': 'asst_qvXmYlZV8zhABI2RtPzDfV6z',\n",
-       " 'cancelled_at': None,\n",
-       " 'completed_at': None,\n",
-       " 'created_at': 1736341020,\n",
-       " 'expires_at': 1736341620,\n",
-       " 'failed_at': None,\n",
-       " 'incomplete_details': None,\n",
-       " 'incomplete_details': None,\n",
-       " 'instructions': 'You are a personal math tutor. Answer questions briefly, in a sentence or less.',\n",
-       " 'last_error': None,\n",
-       " 'max_completion_tokens': None,\n",
-       " 'max_prompt_tokens': None,\n",
-       " 'max_completion_tokens': None,\n",
-       " 'max_prompt_tokens': None,\n",
-       " 'metadata': {},\n",
-       " 'model': 'gpt-4o',\n",
-       " 'object': 'thread.run',\n",
-       " 'parallel_tool_calls': True,\n",
-       " 'parallel_tool_calls': True,\n",
-       " 'required_action': None,\n",
-       " 'response_format': 'auto',\n",
-       " 'started_at': 1736341022,\n",
-       " 'status': 'queued',\n",
-       " 'thread_id': 'thread_8bK2PXfoeijEHBVEzYuJXt17',\n",
-       " 'tool_choice': 'auto',\n",
-       " 'tools': [{'type': 'code_interpreter'},\n",
-       "  {'type': 'file_search',\n",
-       "   'file_search': {'max_num_results': None,\n",
-       "    'ranking_options': {'score_threshold': 0.0,\n",
-       "     'ranker': 'default_2024_08_21'}}},\n",
-       "  {'function': {'name': 'display_quiz',\n",
-       "    'description': \"Displays a quiz to the student, and returns the student's response. A single quiz can have multiple questions.\",\n",
-       "    'description': \"Displays a quiz to the student, and returns the student's response. A single quiz can have multiple questions.\",\n",
-       "    'parameters': {'type': 'object',\n",
-       "     'properties': {'title': {'type': 'string'},\n",
-       "      'questions': {'type': 'array',\n",
-       "       'description': 'An array of questions, each with a title and potentially options (if multiple choice).',\n",
-       "       'items': {'type': 'object',\n",
-       "        'properties': {'question_text': {'type': 'string'},\n",
-       "         'question_type': {'type': 'string',\n",
-       "          'enum': ['MULTIPLE_CHOICE', 'FREE_RESPONSE']},\n",
-       "         'choices': {'type': 'array', 'items': {'type': 'string'}}},\n",
-       "        'required': ['question_text']}}},\n",
-       "     'required': ['title', 'questions']},\n",
-       "    'strict': False},\n",
-       "   'type': 'function'}],\n",
-       " 'truncation_strategy': {'type': 'auto', 'last_messages': None},\n",
-       " 'usage': None,\n",
-       " 'temperature': 1.0,\n",
-       " 'top_p': 1.0,\n",
-       " 'tool_resources': {}}",
-       "    'strict': False},\n",
-       "   'type': 'function'}],\n",
-       " 'truncation_strategy': {'type': 'auto', 'last_messages': None},\n",
-       " 'usage': None,\n",
-       " 'temperature': 1.0,\n",
-       " 'top_p': 1.0,\n",
-       " 'tool_resources': {}}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "run = client.beta.threads.runs.submit_tool_outputs(\n",
-    "    thread_id=thread.id,\n",
-    "    run_id=run.id,\n",
-    "    tool_outputs=tool_outputs\n",
-    ")\n",
-    "show_json(run)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can now wait for the Run to complete once again, and check our Thread!\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 44,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "# Messages\n",
-      "user: Make a quiz with 2 questions: One open ended, one multiple choice. Then, give me feedback for the responses.\n",
-      "assistant: Since no specific information was found in the uploaded file, I'll create a general math quiz for you:\n",
-      "\n",
-      "1. **Open-ended Question**: What is the derivative of the function \\( f(x) = 3x^2 + 2x - 5 \\)?\n",
-      "\n",
-      "2. **Multiple Choice Question**: What is the value of \\( \\int_{0}^{1} 2x \\, dx \\)?\n",
-      "    - A) 0\n",
-      "    - B) 1\n",
-      "    - C) 2\n",
-      "    - D) 3\n",
-      "\n",
-      "I will now present the quiz to you for response.\n",
-      "assistant: Here is the feedback for your responses:\n",
-      "\n",
-      "1. **Derivative Question**: \n",
-      "   - Your Response: \"I don't know.\"\n",
-      "   - Feedback: The derivative of \\( f(x) = 3x^2 + 2x - 5 \\) is \\( f'(x) = 6x + 2 \\).\n",
-      "\n",
-      "2. **Integration Question**: \n",
-      "   - Your Response: A) 0\n",
-      "   - Feedback: The correct answer is B) 1. The integration \\(\\int_{0}^{1} 2x \\, dx \\) evaluates to 1.\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "run = wait_on_run(run, thread)\n",
-    "pretty_print(get_response(thread))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Woohoo 🎉\n"
-   ]
+   "id": "cell-028"
   },
   {
    "cell_type": "markdown",
@@ -1730,18 +492,11 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "We covered a lot of ground in this notebook, give yourself a high-five! Hopefully you should now have a strong foundation to build powerful, stateful experiences with tools like Code Interpreter, Retrieval, and Functions!\n",
+    "We covered stateful Responses API conversations, Code Interpreter, File search, and custom Functions. These are the core building blocks for assistant-like applications without managing Assistants, Threads, and Runs separately.\n",
     "\n",
-    "There's a few sections we didn't cover for the sake of brevity, so here's a few resources to explore further:\n",
-    "\n",
-    "- [Annotations](https://platform.openai.com/docs/assistants/how-it-works/managing-threads-and-messages): parsing file citations\n",
-    "- [Files](https://platform.openai.com/docs/api-reference/assistants/file-object): Thread scoped vs Assistant scoped\n",
-    "- [Parallel Function Calls](https://platform.openai.com/docs/guides/function-calling/parallel-function-calling): calling multiple tools in a single Step\n",
-    "- Multi-Assistant Thread Runs: single Thread with Messages from multiple Assistants\n",
-    "- Streaming: coming soon!\n",
-    "\n",
-    "Now go off and build something ama[zing](https://www.youtube.com/watch?v=xvFZjo5PgG0&pp=ygUQcmljayByb2xsIG5vIGFkcw%3D%3D)!\n"
-   ]
+    "Explore the [Responses API guide](https://platform.openai.com/docs/guides/migrate-to-responses), [Code Interpreter](https://platform.openai.com/docs/guides/tools-code-interpreter), [File search](https://platform.openai.com/docs/guides/tools-file-search), and [Function calling](https://platform.openai.com/docs/guides/function-calling) documentation for more options."
+   ],
+   "id": "cell-029"
   }
  ],
  "metadata": {
@@ -1764,5 +519,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/examples/Creating_slides_with_Assistants_API_and_DALL-E3.ipynb
+++ b/examples/Creating_slides_with_Assistants_API_and_DALL-E3.ipynb
@@ -4,662 +4,311 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Creating slides with the Assistants API (GPT-4), and DALL·E-3\n",
+    "# Creating slides with the Responses API (GPT-4o), and DALL·E 3\n",
     "\n",
-    "This notebook illustrates the use of the new [Assistants API](https://platform.openai.com/docs/assistants/overview) (GPT-4), and DALL·E-3 in crafting informative and visually appealing slides. <br>\n",
-    "Creating slides is a pivotal aspect of many jobs, but can be laborious and time-consuming. Additionally, extracting insights from data and articulating them effectively on slides can be challenging. <br><br> This cookbook recipe will demonstrate how you can utilize the new Assistants API to facilitate the end to end slide creation process for you without you having to touch Microsoft PowerPoint or Google Slides, saving you valuable time and effort!"
-   ]
+    "This notebook illustrates how to use the [Responses API](https://platform.openai.com/docs/guides/migrate-to-responses) with Code Interpreter and the Images API to create an informative slide deck. The workflow analyzes financial data, generates a chart and insights, creates a title image, and asks Code Interpreter to assemble the final PPTX."
+   ],
+   "id": "cell-000"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 0. Setup"
-   ]
+   ],
+   "id": "cell-001"
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from IPython.display import display, Image\n",
+    "from IPython.display import display, Image as DisplayImage\n",
     "from openai import OpenAI\n",
+    "from pathlib import Path\n",
     "import os\n",
     "import pandas as pd\n",
-    "import json\n",
-    "import io\n",
-    "from PIL import Image\n",
     "import requests\n",
     "\n",
-    "client = OpenAI(api_key=os.environ.get(\"OPENAI_API_KEY\", \"<your OpenAI API key if not set as env var>\"))\n",
     "\n",
-    "#Lets import some helper functions for assistants from https://cookbook.openai.com/examples/assistants_api_overview_python\n",
-    "def show_json(obj):\n",
-    "    display(json.loads(obj.model_dump_json()))\n",
+    "if not os.environ.get(\"OPENAI_API_KEY\"):\n",
+    "    raise RuntimeError(\"Set OPENAI_API_KEY before running this notebook.\")\n",
     "\n",
-    "def submit_message(assistant_id, thread, user_message,file_ids=None):\n",
-    "    params = {\n",
-    "        'thread_id': thread.id,\n",
-    "        'role': 'user',\n",
-    "        'content': user_message,\n",
-    "    }\n",
-    "    if file_ids:\n",
-    "        params['file_ids']=file_ids\n",
-    "\n",
-    "    client.beta.threads.messages.create(\n",
-    "        **params\n",
-    ")\n",
-    "    return client.beta.threads.runs.create(\n",
-    "    thread_id=thread.id,\n",
-    "    assistant_id=assistant_id,\n",
-    ")\n",
-    "\n",
-    "def get_response(thread):\n",
-    "    return client.beta.threads.messages.list(thread_id=thread.id)\n"
-   ]
+    "client = OpenAI()"
+   ],
+   "id": "cell-002"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 1. Creating the content"
-   ]
+   ],
+   "id": "cell-003"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this recipe, we will be creating a brief fictional presentation for the quarterly financial review of our company, NotReal Corporation. We want to highlight some key trends we are seeing that are affecting the profitability of our company.<br> Let's say we have the some financial data at our disposal. Let's load in the data, and take a look..."
-   ]
+    "In this recipe, we will create a brief fictional presentation for the quarterly financial review of NotReal Corporation. We will highlight trends affecting profitability across distribution channels."
+   ],
+   "id": "cell-004"
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Year</th>\n",
-       "      <th>Quarter</th>\n",
-       "      <th>Distribution channel</th>\n",
-       "      <th>Revenue ($M)</th>\n",
-       "      <th>Costs ($M)</th>\n",
-       "      <th>Customer count</th>\n",
-       "      <th>Time</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>2021</td>\n",
-       "      <td>Q1</td>\n",
-       "      <td>Online Sales</td>\n",
-       "      <td>1.50</td>\n",
-       "      <td>1.301953</td>\n",
-       "      <td>150</td>\n",
-       "      <td>2021 Q1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2021</td>\n",
-       "      <td>Q1</td>\n",
-       "      <td>Direct Sales</td>\n",
-       "      <td>1.50</td>\n",
-       "      <td>1.380809</td>\n",
-       "      <td>151</td>\n",
-       "      <td>2021 Q1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2021</td>\n",
-       "      <td>Q1</td>\n",
-       "      <td>Retail Partners</td>\n",
-       "      <td>1.50</td>\n",
-       "      <td>1.348246</td>\n",
-       "      <td>152</td>\n",
-       "      <td>2021 Q1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>2021</td>\n",
-       "      <td>Q2</td>\n",
-       "      <td>Online Sales</td>\n",
-       "      <td>1.52</td>\n",
-       "      <td>1.308608</td>\n",
-       "      <td>152</td>\n",
-       "      <td>2021 Q2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>2021</td>\n",
-       "      <td>Q2</td>\n",
-       "      <td>Direct Sales</td>\n",
-       "      <td>1.52</td>\n",
-       "      <td>1.413305</td>\n",
-       "      <td>153</td>\n",
-       "      <td>2021 Q2</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Year Quarter Distribution channel  Revenue ($M)  Costs ($M)  \\\n",
-       "0  2021      Q1         Online Sales          1.50    1.301953   \n",
-       "1  2021      Q1         Direct Sales          1.50    1.380809   \n",
-       "2  2021      Q1      Retail Partners          1.50    1.348246   \n",
-       "3  2021      Q2         Online Sales          1.52    1.308608   \n",
-       "4  2021      Q2         Direct Sales          1.52    1.413305   \n",
-       "\n",
-       "   Customer count     Time  \n",
-       "0             150  2021 Q1  \n",
-       "1             151  2021 Q1  \n",
-       "2             152  2021 Q1  \n",
-       "3             152  2021 Q2  \n",
-       "4             153  2021 Q2  "
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "financial_data_path = 'data/NotRealCorp_financial_data.json'\n",
+    "financial_data_path = Path(\"data/NotRealCorp_financial_data.json\")\n",
     "financial_data = pd.read_json(financial_data_path)\n",
-    "financial_data.head(5)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As you can see, this data has quarterly revenue, costs and customer data across different distribution channels. Let's create an Assistant\n",
-    "that can act as a personal analyst and make a nice visualization for our PowerPoint!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "First, we need to upload our file so our Assistant can access it."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "file = client.files.create(\n",
-    "  file=open('data/NotRealCorp_financial_data.json',\"rb\"),\n",
-    "  purpose='assistants',\n",
-    ")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now, we're ready to create our Assistant. We can instruct our assistant to act as a data scientist, and take any queries we give it and run the necessary code to output the proper data visualization. The instructions parameter here is akin to system instructions in the Chat Completions API, and can help guide the assistant. We can also turn on the tool of Code Interpreter, so our Assistant will be able to code. Finally, we can specify any files we want to use, which in this case is just the `financial_data` file we created above."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "assistant = client.beta.assistants.create(\n",
-    "  instructions=\"You are a data scientist assistant. When given data and a query, write the proper code and create the proper visualization\",\n",
-    "  model=\"gpt-4-1106-preview\",\n",
-    "  tools=[{\"type\": \"code_interpreter\"}],\n",
-    "  file_ids=[file.id]\n",
-    ")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's create a thread now, and as our first request ask the Assistant to calculate quarterly profits, and then plot the profits by distribution channel over time. The assistant will automatically calculate the profit for each quarter, and also create a new column combining quarter and year, without us having to ask for that directly. We can also specify the colors of each line."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "thread = client.beta.threads.create(\n",
-    "  messages=[\n",
-    "    {\n",
-    "      \"role\": \"user\",\n",
-    "      \"content\": \"Calculate profit (revenue minus cost) by quarter and year, and visualize as a line plot across the distribution channels, where the colors of the lines are green, light red, and light blue\",\n",
-    "      \"file_ids\": [file.id]\n",
-    "    }\n",
-    "  ]\n",
-    ")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "No we can execute the run of our thread"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "run = client.beta.threads.runs.create(\n",
-    "    thread_id=thread.id,\n",
-    "    assistant_id=assistant.id,\n",
-    ")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can now start a loop that will check if the image has been created. Note: This may take a few minutes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "messages = client.beta.threads.messages.list(thread_id=thread.id)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Assistant still working...\n",
-      "Assistant still working...\n",
-      "Assistant still working...\n",
-      "Assistant still working...\n",
-      "Assistant still working...\n",
-      "Assistant still working...\n",
-      "Assistant still working...\n",
-      "Assistant still working...\n",
-      "Assistant still working...\n",
-      "Assistant still working...\n",
-      "Assistant still working...\n",
-      "Assistant still working...\n",
-      "Assistant still working...\n",
-      "Assistant still working...\n",
-      "Assistant still working...\n",
-      "Assistant still working...\n",
-      "Assistant still working...\n",
-      "Plot created!\n"
-     ]
-    }
+    "financial_data.head(5)"
    ],
-   "source": [
-    "import time\n",
-    "\n",
-    "while True:\n",
-    "    messages = client.beta.threads.messages.list(thread_id=thread.id)\n",
-    "    try:\n",
-    "        #See if image has been created\n",
-    "        messages.data[0].content[0].image_file\n",
-    "        #Sleep to make sure run has completed\n",
-    "        time.sleep(5)\n",
-    "        print('Plot created!')\n",
-    "        break\n",
-    "    except:\n",
-    "        time.sleep(10)\n",
-    "        print('Assistant still working...')\n"
-   ]
+   "id": "cell-005"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's see the messages the Assistant added."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[MessageContentImageFile(image_file=ImageFile(file_id='file-0rKABLygI02MgwwhpgWdRFY1'), type='image_file'),\n",
-       " MessageContentText(text=Text(annotations=[], value=\"The profit has been calculated for each distribution channel by quarter and year. Next, I'll create a line plot to visualize these profits. As specified, I will use green for the 'Online Sales', light red for 'Direct Sales', and light blue for 'Retail Partners' channels. Let's create the plot.\"), type='text'),\n",
-       " MessageContentText(text=Text(annotations=[], value=\"The JSON data has been successfully restructured into a tabular dataframe format. It includes the year, quarter, distribution channel, revenue, costs, customer count, and a combined 'Time' representation of 'Year Quarter'. Now, we have the necessary information to calculate the profit (revenue minus cost) by quarter and year.\\n\\nTo visualize the profit across the different distribution channels with a line plot, we will proceed with the following steps:\\n\\n1. Calculate the profit for each row in the dataframe.\\n2. Group the data by 'Time' (which is a combination of Year and Quarter) and 'Distribution channel'.\\n3. Aggregate the profit for each group.\\n4. Plot the aggregated profits as a line plot with the distribution channels represented in different colors as requested.\\n\\nLet's calculate the profit for each row and then continue with the visualization.\"), type='text'),\n",
-       " MessageContentText(text=Text(annotations=[], value='The structure of the JSON data shows that it is a dictionary with \"Year\", \"Quarter\", \"Distribution channel\", and potentially other keys that map to dictionaries containing the data. The keys of the inner dictionaries are indices, indicating that the data is tabular but has been converted into a JSON object.\\n\\nTo properly convert this data into a DataFrame, I will restructure the JSON data into a more typical list of dictionaries, where each dictionary represents a row in our target DataFrame. Subsequent to this restructuring, I can then load the data into a Pandas DataFrame. Let\\'s restructure and load the data.'), type='text'),\n",
-       " MessageContentText(text=Text(annotations=[], value=\"The JSON data has been incorrectly loaded into a single-row DataFrame with numerous columns representing each data point. This implies the JSON structure is not as straightforward as expected, and a direct conversion to a flat table is not possible without further processing.\\n\\nTo better understand the JSON structure and figure out how to properly normalize it into a table format, I will print out the raw JSON data structure. We will analyze its format and then determine the correct approach to extract the profit by quarter and year, as well as the distribution channel information. Let's take a look at the JSON structure.\"), type='text'),\n",
-       " MessageContentText(text=Text(annotations=[], value=\"It seems that the file content was successfully parsed as JSON, and thus, there was no exception raised. The variable `error_message` is not defined because the `except` block was not executed.\\n\\nI'll proceed with displaying the data that was parsed from JSON.\"), type='text'),\n",
-       " MessageContentText(text=Text(annotations=[], value=\"It appears that the content of the dataframe has been incorrectly parsed, resulting in an empty dataframe with a very long column name that seems to contain JSON data rather than typical CSV columns and rows.\\n\\nTo address this issue, I will take a different approach to reading the file. I will attempt to parse the content as JSON. If this is not successful, I'll adjust the loading strategy accordingly. Let's try to read the contents as JSON data first.\"), type='text'),\n",
-       " MessageContentText(text=Text(annotations=[], value=\"Before we can calculate profits and visualize the data as requested, I need to first examine the contents of the file that you have uploaded. Let's go ahead and read the file to understand its structure and the kind of data it contains. Once I have a clearer picture of the dataset, we can proceed with the profit calculations. I'll begin by loading the file into a dataframe and displaying the first few entries to see the data schema.\"), type='text'),\n",
-       " MessageContentText(text=Text(annotations=[], value='Calculate profit (revenue minus cost) by quarter and year, and visualize as a line plot across the distribution channels, where the colors of the lines are green, light red, and light blue'), type='text')]"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
+    "The data contains quarterly revenue, costs, and customer data across distribution channels. We will upload it as a file for the Responses API's Code Interpreter container."
    ],
-   "source": [
-    "messages = client.beta.threads.messages.list(thread_id=thread.id)\n",
-    "[message.content[0] for message in messages.data]\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can see that the last message (latest message is shown first) from the assistant contains the image file we are looking for. An interesting note here is that the Assistant was able to attempt several times to parse the JSON data, as the first parsing was unsuccessful, demonstrating the assistant's adaptability."
-   ]
+   "id": "cell-006"
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Quick helper function to convert our output file to a png\n",
-    "def convert_file_to_png(file_id, write_path):\n",
-    "    data = client.files.content(file_id)\n",
-    "    data_bytes = data.read()\n",
-    "    with open(write_path, \"wb\") as file:\n",
-    "        file.write(data_bytes)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_file_id = messages.data[0].content[0].image_file.file_id\n",
-    "image_path = \"../images/NotRealCorp_chart.png\"\n",
-    "convert_file_to_png(plot_file_id,image_path)\n",
+    "with financial_data_path.open(\"rb\") as file_handle:\n",
+    "    data_file = client.files.create(file=file_handle, purpose=\"assistants\")\n",
     "\n",
-    "#Upload\n",
-    "plot_file = client.files.create(\n",
-    "  file=open(image_path, \"rb\"),\n",
-    "  purpose='assistants'\n",
-    ")\n"
-   ]
+    "print(data_file.id)"
+   ],
+   "id": "cell-007"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's load in the plot!"
-   ]
+    "### Generate the chart\n",
+    "\n",
+    "Code Interpreter is configured per response with an automatic container. The request asks it to save the chart as a file so it can be downloaded from the container after the response completes."
+   ],
+   "id": "cell-008"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def download_container_file(response, filename, destination):\n",
+    "    container_calls = [\n",
+    "        item for item in response.output if item.type == \"code_interpreter_call\"\n",
+    "    ]\n",
+    "    if not container_calls:\n",
+    "        raise RuntimeError(\"The response did not include a Code Interpreter call.\")\n",
+    "\n",
+    "    container_id = container_calls[-1].container_id\n",
+    "    files = client.containers.files.list(container_id=container_id)\n",
+    "    matching_files = [\n",
+    "        file for file in files.data if Path(file.path).name == filename\n",
+    "    ]\n",
+    "    if not matching_files:\n",
+    "        raise FileNotFoundError(\n",
+    "            f\"Could not find {filename!r} in container {container_id}.\"\n",
+    "        )\n",
+    "\n",
+    "    content = client.containers.files.content.retrieve(\n",
+    "        matching_files[0].id,\n",
+    "        container_id=container_id,\n",
+    "    )\n",
+    "    destination = Path(destination)\n",
+    "    destination.parent.mkdir(parents=True, exist_ok=True)\n",
+    "    destination.write_bytes(content.read())\n",
+    "    return destination"
+   ],
+   "id": "cell-009"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_response = client.responses.create(\n",
+    "    model=\"gpt-4o\",\n",
+    "    instructions=(\n",
+    "        \"You are a data scientist assistant. Given the attached JSON data, \"\n",
+    "        \"write and run Python code to calculate profit as revenue minus cost by \"\n",
+    "        \"quarter and year, then create a line plot across the distribution channels. \"\n",
+    "        \"Use green, light red, and light blue lines. Save the final chart as \"\n",
+    "        \"NotRealCorp_chart.png in /mnt/data and display it.\"\n",
+    "    ),\n",
+    "    input=\"Calculate profit by quarter and year and visualize it across distribution channels.\",\n",
+    "    tools=[\n",
+    "        {\n",
+    "            \"type\": \"code_interpreter\",\n",
+    "            \"container\": {\"type\": \"auto\", \"file_ids\": [data_file.id]},\n",
+    "        }\n",
+    "    ],\n",
+    "    include=[\"code_interpreter_call.outputs\"],\n",
+    ")\n",
+    "\n",
+    "print(plot_response.output_text)\n",
+    "image_path = download_container_file(\n",
+    "    plot_response,\n",
+    "    \"NotRealCorp_chart.png\",\n",
+    "    \"../images/NotRealCorp_chart.png\",\n",
+    ")\n",
+    "display(DisplayImage(filename=str(image_path)))"
+   ],
+   "id": "cell-010"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![The Image](../images/NotRealCorp_chart.png)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Nice! So, with just one sentence, we were able to have our assistant use code interpreter to\n",
-    "calculate the profitability, and graph the three lineplots of the various distribution channels.<br><br>\n",
-    "Now we have a nice visual for our slide, but we want some insights to go along with it."
-   ]
+    "The chart is now available locally. The next two requests continue the same Responses API conversation by passing `previous_response_id`; no thread, assistant, or run object is needed."
+   ],
+   "id": "cell-011"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 2. Generating insights"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To get insights from our image, we simply need to add a new message to our thread. Our Assistant will know to use the message history to give us some concise takeaways from the visual provided. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Run(id='run_NWoygMcBfHUr58fCE4Cn6rxN', assistant_id='asst_3T362kLlTyAq0FUnkvjjQczO', cancelled_at=None, completed_at=None, created_at=1701827074, expires_at=1701827674, failed_at=None, file_ids=['file-piTokyHGllwGITzIpoG8dok3'], instructions='You are a data scientist assistant. When given data and a query, write the proper code and create the proper visualization', last_error=None, metadata={}, model='gpt-4-1106-preview', object='thread.run', required_action=None, started_at=None, status='queued', thread_id='thread_73TgtFoJMlEJvb13ngjTnAo3', tools=[ToolAssistantToolsCode(type='code_interpreter')])"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
    ],
-   "source": [
-    "submit_message(assistant.id,thread,\"Give me two medium length sentences (~20-30 words per sentence) of the \\\n",
-    "      most important insights from the plot you just created.\\\n",
-    "             These will be used for a slide deck, and they should be about the\\\n",
-    "                     'so what' behind the data.\"\n",
-    ")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now, once the run has completed, we can see the latest message"
-   ]
+   "id": "cell-012"
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The plot reveals a consistent upward trend in profits for all distribution channels, indicating successful business growth over time. Particularly, 'Online Sales' shows a notable increase, underscoring the importance of digital presence in revenue generation.\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Hard coded wait for a response, as the assistant may iterate on the bullets.\n",
-    "time.sleep(10)\n",
-    "response = get_response(thread)\n",
-    "bullet_points = response.data[0].content[0].text.value\n",
-    "print(bullet_points)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Cool! So our assistant was able to identify the noteworthy growth in Online Sales profit, and infer that this shows the importance of a large digital presence. Now let's get a compelling title for the slide."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Run(id='run_q6E85J31jCw3QkHpjJKl969P', assistant_id='asst_3T362kLlTyAq0FUnkvjjQczO', cancelled_at=None, completed_at=None, created_at=1701827084, expires_at=1701827684, failed_at=None, file_ids=['file-piTokyHGllwGITzIpoG8dok3'], instructions='You are a data scientist assistant. When given data and a query, write the proper code and create the proper visualization', last_error=None, metadata={}, model='gpt-4-1106-preview', object='thread.run', required_action=None, started_at=None, status='queued', thread_id='thread_73TgtFoJMlEJvb13ngjTnAo3', tools=[ToolAssistantToolsCode(type='code_interpreter')])"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "submit_message(assistant.id,thread,\"Given the plot and bullet points you created,\\\n",
-    " come up with a very brief title for a slide. It should reflect just the main insights you came up with.\"\n",
-    ")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And the title is:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\"Ascending Profits & Digital Dominance\"\n"
-     ]
-    }
-   ],
-   "source": [
-    "#Wait as assistant may take a few steps\n",
-    "time.sleep(10)\n",
-    "response = get_response(thread)\n",
-    "title = response.data[0].content[0].text.value\n",
-    "print(title)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3. DALL·E-3 title image"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Nice, now we have a title, a plot and two bullet points. We're almost ready to put this all on a slide, but as a final step, let's have DALL·E-3 come up with an image to use as the title slide of the presentation. <br><br>\n",
-    "*Note:* DALL·E-3 is not yet available within the assistants API but is coming soon! <br> <br>\n",
-    "We'll feed in a brief description of our company (NotRealCorp) and have DALL·E-3 do the rest!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "company_summary = \"NotReal Corp is a prominent hardware company that manufactures and sells processors, graphics cards and other essential computer hardware.\"\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "response = client.images.generate(\n",
-    "  model='dall-e-3',\n",
-    "  prompt=f\"given this company summary {company_summary}, create an inspirational \\\n",
-    "    photo showing the growth and path forward. This will be used at a quarterly\\\n",
-    "       financial planning meeting\",\n",
-    "       size=\"1024x1024\",\n",
-    "       quality=\"hd\",\n",
-    "       n=1\n",
+    "insights_response = client.responses.create(\n",
+    "    model=\"gpt-4o\",\n",
+    "    instructions=(\n",
+    "        \"You are a data scientist assistant. Base the insights on the financial chart \"\n",
+    "        \"created in the previous response and focus on implications for the slide deck.\"\n",
+    "    ),\n",
+    "    previous_response_id=plot_response.id,\n",
+    "    input=(\n",
+    "        \"Give me two medium-length sentences (about 20-30 words each) \"\n",
+    "        \"describing the most important insights from the plot. Focus on the \"\n",
+    "        \"'so what' behind the data for a slide deck.\"\n",
+    "    ),\n",
     ")\n",
-    "image_url = response.data[0].url\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Cool, now we can add this image to our thread. First, we can save the image locally, then upload it to the assistants API using the `File` upload endpoint. Let's also take a look at our image"
-   ]
+    "\n",
+    "bullet_points = insights_response.output_text\n",
+    "print(bullet_points)"
+   ],
+   "id": "cell-013"
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "dalle_img_path = '../images/dalle_image.png'\n",
-    "img = requests.get(image_url)\n",
+    "title_response = client.responses.create(\n",
+    "    model=\"gpt-4o\",\n",
+    "    instructions=\"You are a data scientist assistant. Return a very brief title based on the financial insights.\",\n",
+    "    previous_response_id=insights_response.id,\n",
+    "    input=\"Come up with a very brief title for a slide that reflects the main insights.\",\n",
+    ")\n",
     "\n",
-    "#Save locally\n",
-    "with open(dalle_img_path,'wb') as file:\n",
-    "  file.write(img.content)\n",
-    "\n",
-    "#Upload\n",
-    "dalle_file = client.files.create(\n",
-    "  file=open(dalle_img_path, \"rb\"),\n",
-    "  purpose='assistants'\n",
-    ")\n"
-   ]
+    "title = title_response.output_text\n",
+    "print(title)"
+   ],
+   "id": "cell-014"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "  \n",
-    "![Image](../images/dalle_image.png)"
-   ]
+    "## 3. DALL·E 3 title image"
+   ],
+   "id": "cell-015"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Image generation remains a separate Images API call. The generated image is then uploaded as a file for the final Code Interpreter response."
+   ],
+   "id": "cell-016"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "company_summary = (\n",
+    "    \"NotReal Corp is a prominent hardware company that manufactures and sells \"\n",
+    "    \"processors, graphics cards, and other essential computer hardware.\"\n",
+    ")\n",
+    "\n",
+    "image_response = client.images.generate(\n",
+    "    model=\"dall-e-3\",\n",
+    "    prompt=(\n",
+    "        f\"Given this company summary: {company_summary}, create an inspirational \"\n",
+    "        \"photo showing growth and a path forward. This will be used at a quarterly \"\n",
+    "        \"financial planning meeting.\"\n",
+    "    ),\n",
+    "    size=\"1024x1024\",\n",
+    "    quality=\"hd\",\n",
+    "    n=1,\n",
+    ")\n",
+    "\n",
+    "image_url = image_response.data[0].url\n",
+    "dalle_image_path = Path(\"../images/dalle_image.png\")\n",
+    "image_bytes = requests.get(image_url, timeout=60)\n",
+    "image_bytes.raise_for_status()\n",
+    "dalle_image_path.write_bytes(image_bytes.content)\n",
+    "display(DisplayImage(filename=str(dalle_image_path)))"
+   ],
+   "id": "cell-017"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with dalle_image_path.open(\"rb\") as file_handle:\n",
+    "    dalle_file = client.files.create(file=file_handle, purpose=\"assistants\")\n",
+    "\n",
+    "with image_path.open(\"rb\") as file_handle:\n",
+    "    plot_file = client.files.create(file=file_handle, purpose=\"assistants\")\n",
+    "\n",
+    "print(dalle_file.id, plot_file.id)"
+   ],
+   "id": "cell-018"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 4. Creating the slides"
-   ]
+   ],
+   "id": "cell-019"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now have all the content we need to create the slides. We could simply add a message asking for slides, but let's instead give the assistant a slide template to use with the `python-pptx` library. This will ensure we get a deck in the style we want. See the `Extensions` section at the end of the notebook for notes on creating the template."
-   ]
+    "We now have the data visualization, its insights, and a title image. The following templates are passed to Code Interpreter so it can create a two-slide PowerPoint deck with `python-pptx`."
+   ],
+   "id": "cell-020"
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -669,30 +318,24 @@
     "from pptx.enum.text import PP_PARAGRAPH_ALIGNMENT\n",
     "from pptx.dml.color import RGBColor\n",
     "\n",
-    "# Create a new presentation object\n",
     "prs = Presentation()\n",
-    "\n",
-    "# Add a blank slide layout\n",
     "blank_slide_layout = prs.slide_layouts[6]\n",
     "slide = prs.slides.add_slide(blank_slide_layout)\n",
     "\n",
-    "# Set the background color of the slide to black\n",
     "background = slide.background\n",
     "fill = background.fill\n",
     "fill.solid()\n",
     "fill.fore_color.rgb = RGBColor(0, 0, 0)\n",
     "\n",
-    "# Add image to the left side of the slide with a margin at the top and bottom\n",
     "left = Inches(0)\n",
     "top = Inches(0)\n",
     "height = prs.slide_height\n",
-    "width = prs.slide_width * 3/5\n",
-    "pic = slide.shapes.add_picture(image_path, left, top, width=width, height=height)\n",
+    "width = prs.slide_width * 3 / 5\n",
+    "slide.shapes.add_picture(image_path, left, top, width=width, height=height)\n",
     "\n",
-    "# Add title text box positioned higher\n",
-    "left = prs.slide_width * 3/5\n",
+    "left = prs.slide_width * 3 / 5\n",
     "top = Inches(2)\n",
-    "width = prs.slide_width * 2/5\n",
+    "width = prs.slide_width * 2 / 5\n",
     "height = Inches(1)\n",
     "title_box = slide.shapes.add_textbox(left, top, width, height)\n",
     "title_frame = title_box.text_frame\n",
@@ -703,10 +346,9 @@
     "title_p.font.color.rgb = RGBColor(255, 255, 255)\n",
     "title_p.alignment = PP_PARAGRAPH_ALIGNMENT.CENTER\n",
     "\n",
-    "# Add subtitle text box\n",
-    "left = prs.slide_width * 3/5\n",
+    "left = prs.slide_width * 3 / 5\n",
     "top = Inches(3)\n",
-    "width = prs.slide_width * 2/5\n",
+    "width = prs.slide_width * 2 / 5\n",
     "height = Inches(1)\n",
     "subtitle_box = slide.shapes.add_textbox(left, top, width, height)\n",
     "subtitle_frame = subtitle_box.text_frame\n",
@@ -723,32 +365,25 @@
     "from pptx.enum.text import PP_PARAGRAPH_ALIGNMENT\n",
     "from pptx.dml.color import RGBColor\n",
     "\n",
-    "# Create a new presentation object\n",
     "prs = Presentation()\n",
-    "\n",
-    "# Add a blank slide layout\n",
     "blank_slide_layout = prs.slide_layouts[6]\n",
     "slide = prs.slides.add_slide(blank_slide_layout)\n",
     "\n",
-    "# Set the background color of the slide to black\n",
     "background = slide.background\n",
     "fill = background.fill\n",
     "fill.solid()\n",
     "fill.fore_color.rgb = RGBColor(0, 0, 0)\n",
     "\n",
-    "# Define placeholders\n",
     "image_path = data_vis_img\n",
-    "title_text = \"Maximizing Profits: The Dominance of Online Sales & Direct Sales Optimization\"\n",
-    "bullet_points = \"• Online Sales consistently lead in profitability across quarters, indicating a strong digital market presence.\\n• Direct Sales show fluctuations, suggesting variable performance and the need for targeted improvements in that channel.\"\n",
+    "title_text = data_title\n",
+    "bullet_points = data_bullets\n",
     "\n",
-    "# Add image placeholder on the left side of the slide\n",
     "left = Inches(0.2)\n",
     "top = Inches(1.8)\n",
     "height = prs.slide_height - Inches(3)\n",
-    "width = prs.slide_width * 3/5\n",
-    "pic = slide.shapes.add_picture(image_path, left, top, width=width, height=height)\n",
+    "width = prs.slide_width * 3 / 5\n",
+    "slide.shapes.add_picture(image_path, left, top, width=width, height=height)\n",
     "\n",
-    "# Add title text spanning the whole width\n",
     "left = Inches(0)\n",
     "top = Inches(0)\n",
     "width = prs.slide_width\n",
@@ -763,10 +398,9 @@
     "title_p.font.color.rgb = RGBColor(255, 255, 255)\n",
     "title_p.alignment = PP_PARAGRAPH_ALIGNMENT.CENTER\n",
     "\n",
-    "# Add hardcoded \"Key Insights\" text and bullet points\n",
-    "left = prs.slide_width * 2/3\n",
+    "left = prs.slide_width * 2 / 3\n",
     "top = Inches(1.5)\n",
-    "width = prs.slide_width * 1/3\n",
+    "width = prs.slide_width * 1 / 3\n",
     "height = Inches(4.5)\n",
     "insights_box = slide.shapes.add_textbox(left, top, width, height)\n",
     "insights_frame = insights_box.text_frame\n",
@@ -778,195 +412,95 @@
     "insights_p.alignment = PP_PARAGRAPH_ALIGNMENT.LEFT\n",
     "insights_frame.add_paragraph()\n",
     "\n",
-    "\n",
     "bullet_p = insights_frame.add_paragraph()\n",
     "bullet_p.text = bullet_points\n",
     "bullet_p.font.size = Pt(12)\n",
     "bullet_p.font.color.rgb = RGBColor(255, 255, 255)\n",
     "bullet_p.line_spacing = 1.5\n",
     "\"\"\"\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's set a few variables for our slides. We want the company name, NotRealCorp, on the title slide, and the presentation should be titled 'Quarterly financial planning meeting, Q3, 2023'."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "\n",
     "title_text = \"NotRealCorp\"\n",
-    "subtitle_text = \"Quarterly financial planning meeting, Q3 2023\"\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And for the data slide, we have:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Here we have a template to create a Title Slide. The template below was created by uploading the image of a desirable title slide to GPT-V, and asking for the `python-pptx` code to create that template. The inputs to the template are the image_path, title_text, and subtitle_text."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Run(id='run_taLrnOnlDhoywgQFFBOLPlg0', assistant_id='asst_3T362kLlTyAq0FUnkvjjQczO', cancelled_at=None, completed_at=None, created_at=1701827118, expires_at=1701827718, failed_at=None, file_ids=['file-piTokyHGllwGITzIpoG8dok3'], instructions='You are a data scientist assistant. When given data and a query, write the proper code and create the proper visualization', last_error=None, metadata={}, model='gpt-4-1106-preview', object='thread.run', required_action=None, started_at=None, status='queued', thread_id='thread_73TgtFoJMlEJvb13ngjTnAo3', tools=[ToolAssistantToolsCode(type='code_interpreter')])"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
+    "subtitle_text = \"Quarterly financial planning meeting, Q3 2023\"\n",
+    "data_title = title\n",
+    "data_bullets = bullet_points\n",
+    "\n",
+    "ppt_response = client.responses.create(\n",
+    "    model=\"gpt-4o\",\n",
+    "    instructions=(\n",
+    "        \"You are a data scientist assistant. Use Code Interpreter to create a two-slide \"\n",
+    "        \"PPTX deck with python-pptx. Save the final file as created_slides.pptx in /mnt/data. \"\n",
+    "        \"The uploaded files are dalle_image.png and NotRealCorp_chart.png.\"\n",
+    "    ),\n",
+    "    input=f\"\"\"Create the two slides using the templates below.\n",
+    "\n",
+    "Title slide inputs:\n",
+    "- image_path: dalle_image.png\n",
+    "- title_text: {title_text}\n",
+    "- subtitle_text: {subtitle_text}\n",
+    "\n",
+    "Data slide inputs:\n",
+    "- data_vis_img: NotRealCorp_chart.png\n",
+    "- data_title: {data_title}\n",
+    "- data_bullets: {data_bullets}\n",
+    "\n",
+    "Title slide template:\n",
+    "{title_template}\n",
+    "\n",
+    "Data slide template:\n",
+    "{data_vis_template}\n",
+    "\n",
+    "Run the code, combine the slides into one presentation, and save it as /mnt/data/created_slides.pptx.\"\"\",\n",
+    "    tools=[\n",
+    "        {\n",
+    "            \"type\": \"code_interpreter\",\n",
+    "            \"container\": {\n",
+    "                \"type\": \"auto\",\n",
+    "                \"file_ids\": [dalle_file.id, plot_file.id],\n",
+    "            },\n",
+    "        }\n",
+    "    ],\n",
+    "    include=[\"code_interpreter_call.outputs\"],\n",
+    ")\n",
+    "\n",
+    "print(ppt_response.output_text)\n",
+    "pptx_path = download_container_file(\n",
+    "    ppt_response,\n",
+    "    \"created_slides.pptx\",\n",
+    "    \"data/created_slides.pptx\",\n",
+    ")\n",
+    "print(f\"Saved {pptx_path}\")"
    ],
-   "source": [
-    "submit_message(assistant.id,thread,f\"Use the included code template to create a PPTX slide that follows the template format, but uses the image, company name/title, and document name/subtitle included:\\\n",
-    "{title_template}. IMPORTANT: Use the image file included in this message as the image_path image in this first slide, and use the Company Name {title_text} as the title_text variable, and \\\n",
-    "  use the subtitle_text {subtitle_text} a the subtitle_text variable. \\\n",
-    "    NEST, create a SECOND slide using the following code template: {data_vis_template} to create a PPTX slide that follows the template format, but uses the company name/title, and document name/subtitle included:\\\n",
-    "{data_vis_template}. IMPORTANT: Use the line plot image, that is the second attached image in this message, that you created earlier in the thread as the data_vis_img image, and use the data visualization title that you created earlier for the variable title_text, and\\\n",
-    "  the bullet points of insights you created earlier for the bullet_points variable. Output these TWO SLIDES as a .pptx file. Make sure the output is two slides, with each slide matching the respective template given in this message.\",\n",
-    "              file_ids=[dalle_file.id, plot_file.id]\n",
-    ")\n"
-   ]
+   "id": "cell-021"
   },
   {
-   "cell_type": "code",
-   "execution_count": 22,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Assistant still working on PPTX...\n",
-      "Assistant still working on PPTX...\n",
-      "Assistant still working on PPTX...\n",
-      "Assistant still working on PPTX...\n",
-      "Assistant still working on PPTX...\n",
-      "Assistant still working on PPTX...\n",
-      "Assistant still working on PPTX...\n",
-      "Assistant still working on PPTX...\n",
-      "Assistant still working on PPTX...\n",
-      "Assistant still working on PPTX...\n",
-      "Successfully retrieved pptx_id: file-oa0i63qPH4IaJXYj90aA6L4Q\n"
-     ]
-    }
+   "source": [
+    "The final deck is saved as `data/created_slides.pptx`. The response is synchronous, so there is no fixed sleep or thread polling loop to race against Code Interpreter."
    ],
-   "source": [
-    "#May take 1-3 mins\n",
-    "while True:\n",
-    "    try:\n",
-    "        response = get_response(thread)\n",
-    "        pptx_id = response.data[0].content[0].text.annotations[0].file_path.file_id\n",
-    "        print(\"Successfully retrieved pptx_id:\", pptx_id)\n",
-    "        break\n",
-    "    except Exception as e:\n",
-    "        print(\"Assistant still working on PPTX...\")\n",
-    "        time.sleep(10)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pptx_id = response.data[0].content[0].text.annotations[0].file_path.file_id\n",
-    "ppt_file= client.files.content(pptx_id)\n",
-    "file_obj = io.BytesIO(ppt_file.read())\n",
-    "with open(\"data/created_slides.pptx\", \"wb\") as f:\n",
-    "    f.write(file_obj.getbuffer())\n"
-   ]
+   "id": "cell-022"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, we have a PPTX file saved with all of our created content!. <br>"
-   ]
+    "## 5. Conclusion\n",
+    "\n",
+    "The workflow uses the Responses API to analyze a file with Code Interpreter, continues the conversation with `previous_response_id`, generates a separate DALL·E 3 image, and uses another Code Interpreter container to assemble the final presentation."
+   ],
+   "id": "cell-023"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's look at the screenshots of the .pptx we just created using JUST the assistants API and DALL·E-3. We don't have a `seed` parameter yet in the Assistants API, so the DALL·E-3 image and wordings will be slightly different from what you see when you run this notebook, due to the non-determinism of LLMs, but the outputs should be directionally the same."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The title slide:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "![Title Slide](../images/title_slide.png)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And the data slide:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "![Data Slide](../images/data_vis_slide.png)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 5. Conclusion"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Woo! While these slides could use some formatting tweaks, we have made some great content using the Assistants API, GPT-4 and DALL·E-3. We were able to take a `.csv` file with financial data, and use our assistant to calculate profit by quarter across distribution channels, plot the results, identify insights and key takeaways from the visualization, and create a summary title. And, given just a description of our company, NotRealCorp, we used DALL·E-3 to make an awesome title image. <br><br>\n",
-    "While we are still a ways away from entirely automating this process without a human in the loop, hopefully this notebook can make the slide creation process a bit easier for you. More importantly, this notebook can ideally give you a glimpse into the potential of the assistants API! We're excited to see what you build."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 6. Extensions"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "- When  DALL·E-3 is incorporated in the Assistants API, we will have the ability to request the generated title image within the thread. \n",
-    "- GPT-4-Vision is not yet supported in the Assistants API, but could have been used to gather insights from the line plot image.\n",
-    "- GPT-4-Vision was used to generate the `python-pptx` template included in this recipe, so a potential extension project could be demonstrating best practices around converting images to slide templates."
-   ]
+    "## 6. Extensions\n",
+    "\n",
+    "- Use a newer image-generation model from the [Images API](https://platform.openai.com/docs/guides/images/image-generation) when you want its output format or editing features.\n",
+    "- Ask Code Interpreter to create additional charts or validate the slide deck before saving it.\n",
+    "- Pass explicit input items instead of `previous_response_id` when your application needs stateless conversation management."
+   ],
+   "id": "cell-024"
   }
  ],
  "metadata": {
@@ -989,5 +523,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary

- Migrate `Assistants_API_overview_python.ipynb` from Assistants, Threads, Runs, and Messages to the Responses API.
- Migrate `Creating_slides_with_Assistants_API_and_DALL-E3.ipynb` to Responses API Code Interpreter containers while preserving chart generation, insight extraction, image generation, and PPTX creation.
- Update the notebook explanations and links for current Responses API concepts.

## Motivation

The Assistants API is scheduled to shut down on August 26, 2026. These two cookbook examples currently rely on the deprecated beta Assistants API surface, so they will stop working unless they are updated. This addresses #2933.

## Validation

- `env -u VIRTUAL_ENV uv run --with nbformat python .github/scripts/check_notebooks.py`
- Parsed every Python code cell with `ast.parse` after removing notebook shell-magic lines.
- Verified the request shapes against the current OpenAI Python SDK using a mock HTTP transport; no live API calls or credentials were used.
- Ran `git diff --check`.

I did not execute the notebooks end-to-end because doing so requires an OpenAI API key and makes external API calls.

## Self-review

- [x] This updates existing content; no registry or author metadata change is needed.
- [x] The examples keep their original tool-use and slide-generation workflows.
- [x] Secrets remain environment-based.
- [x] The changed notebook Markdown was reviewed for stale Assistants API terminology and links.

## AI assistance

I used Codex to assist with the migration and reviewed the resulting notebook code, request shapes, and validation output.