### PR TITLE
Remove duplicate agentic commerce authors

### DIFF
--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/controlled_agentic_commerce.ipynb
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/controlled_agentic_commerce.ipynb
@@ -7,8 +7,6 @@
       "source": [
         "# Build an AI agent that can pay for APIs using AgentCore Payments\n",
         "\n",
-        "**Authors:** Deepak Jain and Sid Rampally\n",
-        "\n",
         "AI agents often need information from external services to complete a task. A procurement agent might check a supplier against a sanctions database, retrieve a current risk report, or use a paid search API. When those services charge for each request, the application needs clear rules for which purchases the agent can request and who approves the spending.\n",
         "\n",
         "Agentic commerce describes workflows in which an agent can request a paid resource while application code retains authority over payment. Amazon Bedrock AgentCore Payments provides infrastructure for bounded payment sessions, and the OpenAI Agents SDK lets a model request an application-defined tool. The application checks the merchant, purpose, amount, and approval before a payment can occur.\n",

--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/tests/test_publication_contract.py
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/tests/test_publication_contract.py
@@ -57,6 +57,7 @@ def test_notebook_has_publishable_boundaries_and_diagrams() -> None:
     assert "### Using the Responses API directly" in source
     assert "responses_client.responses.create" in source
     assert '"function_call_output"' in source
+    assert "**Authors:** Deepak Jain and Sid Rampally" not in source
     assert "AgentCore Runtime is not used by this notebook" in source
     assert "RUN_AGENTCORE_E2E" in source
     assert "run_managed_e2e" in source

--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/tests/test_publication_contract.py
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/tests/test_publication_contract.py
@@ -57,7 +57,6 @@ def test_notebook_has_publishable_boundaries_and_diagrams() -> None:
     assert "### Using the Responses API directly" in source
     assert "responses_client.responses.create" in source
     assert '"function_call_output"' in source
-    assert "**Authors:** Deepak Jain and Sid Rampally" in source
     assert "AgentCore Runtime is not used by this notebook" in source
     assert "RUN_AGENTCORE_E2E" in source
     assert "run_managed_e2e" in source


### PR DESCRIPTION
## Summary
- Remove the duplicate author line from the controlled agentic-commerce notebook.
- Keep author attribution in the Cookbook registry-generated header.
- Update the publication contract test to match the intended page rendering.

## Why
The Cookbook page already renders Deepak Jain and Sid Rampally from registry metadata. The notebook repeated the same names at the start of the content.

## Validation
- `env -u VIRTUAL_ENV uv run --with nbformat python .github/scripts/check_notebooks.py`
- `env -u VIRTUAL_ENV uv run --group dev pytest -q` (`142 passed`)
- `env -u VIRTUAL_ENV uv run --group dev ruff check src tests`
- `env -u VIRTUAL_ENV uv run --group dev ruff format --check src tests`
- `git diff --check`
