### PR TITLE
Remove unreviewed AgentCore companion link

### DIFF
--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/README.md
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/README.md
@@ -226,6 +226,8 @@ The recorded August 10, 2026 validation returned `PASSED` for one bounded
 `0.002` test-USDC attempt. Any future live run requires a fresh review, approval,
 short-lived session, and testnet-only configuration.
 
+For product context, see AWS's
+[Agents that transact: Introducing Amazon Bedrock AgentCore Payments, built with Coinbase and Stripe](https://aws.amazon.com/blogs/machine-learning/agents-that-transact-introducing-amazon-bedrock-agentcore-payments-built-with-coinbase-and-stripe/).
 AWS documents the [x402 payment flow](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-how-it-works.html)
 and recommends [separate IAM roles for session administration and payment execution](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-iam-roles.html).
 Also review the current AWS guidance for

--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/README.md
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/README.md
@@ -235,7 +235,7 @@ and [bounded sessions](https://docs.aws.amazon.com/bedrock-agentcore/latest/devg
 
 ## Source and credit
 
-Nick's AWS [paid-research sample](https://github.com/awslabs/agentcore-samples/pull/1869)
+Nick's AWS paid-research sample
 provides a broader multi-agent live testnet reference. Its wallet-neutral setup
 and bounded-session exercise informed this example. No source code was copied.
 See `SOURCE_ATTRIBUTION.md` for the fixed revision and license.

--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/SOURCE_ATTRIBUTION.md
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/SOURCE_ATTRIBUTION.md
@@ -3,7 +3,6 @@
 ## AWS paid-research companion sample
 
 - Contributor: Nick (`mccartnick`), AWS Solutions Architect
-- Pull request: [AWS AgentCore paid-research sample PR #1869](https://github.com/awslabs/agentcore-samples/pull/1869)
 - Reviewed revision: `85aa4e5ca9a2d55ad7c412f2d015011095b2222d`
 - Review date: August 5, 2026
 - License: Apache-2.0

--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/controlled_agentic_commerce.ipynb
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/controlled_agentic_commerce.ipynb
@@ -754,6 +754,7 @@
         "\n",
         "- [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/)\n",
         "- [Use OpenAI models through Amazon Bedrock](https://developers.openai.com/api/docs/guides/amazon-bedrock)\n",
+        "- [AWS announcement: Agents that transact](https://aws.amazon.com/blogs/machine-learning/agents-that-transact-introducing-amazon-bedrock-agentcore-payments-built-with-coinbase-and-stripe/)\n",
         "- [How AgentCore Payments works](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-how-it-works.html)\n",
         "- [AgentCore Payments prerequisites](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-prerequisites.html)\n",
         "- [Create bounded payment sessions](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-create-session.html)\n",

--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/controlled_agentic_commerce.ipynb
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/controlled_agentic_commerce.ipynb
@@ -757,8 +757,7 @@
         "- [How AgentCore Payments works](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-how-it-works.html)\n",
         "- [AgentCore Payments prerequisites](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-prerequisites.html)\n",
         "- [Create bounded payment sessions](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-create-session.html)\n",
-        "- [Separate payment IAM roles](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-iam-roles.html)\n",
-        "- [AWS companion sample and source attribution](https://github.com/awslabs/agentcore-samples/pull/1869).\n"
+        "- [Separate payment IAM roles](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-iam-roles.html)\n"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- Remove direct links to the AWS AgentCore companion PR from the notebook, README, and source attribution.
- Add the public AWS AgentCore Payments announcement as product context.
- Preserve the existing non-code credit and fixed revision metadata.

## Why
The companion PR is still completing AWS review. The public Cookbook should not link to it until that review is complete. The public AWS blog provides approved messaging context in the meantime.

## Validation
- `env -u VIRTUAL_ENV uv run --with nbformat python .github/scripts/check_notebooks.py`
- `env -u VIRTUAL_ENV uv run --group dev pytest -q` (`142 passed`)
- `env -u VIRTUAL_ENV uv run --group dev ruff check src tests`
- `env -u VIRTUAL_ENV uv run --group dev ruff format --check src tests`
- `git diff --check`
- Confirmed the direct PR URL no longer appears in the example.
