### PR TITLE
Archive two GitHub Cookbook examples

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -2960,6 +2960,7 @@
     - gpt-actions-library
     - chatgpt
     - chatgpt-productivity
+  archived: true
 
 - title: Custom LLM as a Judge to Detect Hallucinations with Braintrust
   path: examples/Custom-LLM-as-a-Judge.ipynb
@@ -3068,6 +3069,7 @@
     - reasoning
     - completions
     - security
+  archived: true
 
 - title: How to evaluate LLMs for SQL generation
   path: examples/evaluation/How_to_evaluate_LLMs_for_SQL_generation.ipynb


### PR DESCRIPTION
## Summary

Archive exactly two existing Cookbook examples by adding `archived: true` to their existing `registry.yaml` entries:

- GPT Actions library - GitHub (`gpt-action-github`)
- Reasoning over Code Quality and Security in GitHub Pull Requests (`code-quality-and-security-scan-with-github-actions`)

Both source Markdown files remain unchanged and available through the Cookbook archive.

## Motivation

Remove these two examples from primary Cookbook listings while preserving their existing content and archive access.

## Validation

- Parsed and validated all 308 registry entries against their required fields, allowed properties, and supported value types.
- Compared the updated registry against `origin/main` and verified exactly these two existing entries change, with `archived: true` as their only metadata change.
- Confirmed both Markdown source files remain byte-for-byte unchanged.
- Verified the primary listing loses exactly these two entries and the archive gains exactly these two entries.
- `git diff --check` passes; the complete change is one file with two insertions and no deletions.
- No notebook files were changed.
