### PR TITLE
Update image prompting guide for gpt-image-2-turbo and transparent PNG assets

### DIFF
--- a/authors.yaml
+++ b/authors.yaml
@@ -3,6 +3,11 @@
 # You can optionally customize how your information shows up cookbook.openai.com over here.
 # If your information is not present here, it will be pulled from your GitHub profile.
 
+the-OAI:
+  name: "Tiger He"
+  website: "https://www.linkedin.com/in/tiger-he-b71842164/"
+  avatar: "https://avatars.githubusercontent.com/u/286157113?v=4"
+
 neilh-oai:
   name: "Neil Hansaria"
   website: "https://www.linkedin.com/in/neilhansaria"

--- a/examples/multimodal/image-gen-models-prompting-guide.ipynb
+++ b/examples/multimodal/image-gen-models-prompting-guide.ipynb
@@ -28,12 +28,15 @@
     "- **High-fidelity photorealism** with natural lighting, accurate materials, and rich color rendering\n",
     "- **Flexible quality–latency tradeoffs**, allowing faster generation at lower settings while still exceeding the visual quality of prior-generation image models\n",
     "- **Robust facial and identity preservation** for edits, character consistency, and multi-step workflows\n",
+    "- **Transparent-background PNG assets** with `gpt-image-2` for reusable logos, product cutouts, stickers, and presentation graphics\n",
     "- **Reliable text rendering** with crisp lettering, consistent layout, and strong contrast inside images\n",
     "- **Complex structured visuals**, including infographics, diagrams, and multi-panel compositions\n",
     "- **Precise style control and style transfer** with minimal prompting, supporting everything from branded design systems to fine-art styles\n",
     "- **Strong real-world knowledge and reasoning**, enabling accurate depictions of objects, environments, and scenarios\n",
     "\n",
-    "This guide highlights prompting patterns, best practices, and example prompts drawn from real production use cases for `gpt-image-2`. It is our most capable image model, with stronger image quality, improved editing performance, and broader support for production workflows. The `low` quality setting is especially strong for latency-sensitive use cases, while `medium` and `high` remain good fits when maximum fidelity matters. \n"
+    "This guide highlights prompting patterns, best practices, and example prompts drawn from real production use cases for `gpt-image-2`. It is our most capable image model, with stronger image quality, improved editing performance, and broader support for production workflows. The `low` quality setting is especially strong for latency-sensitive use cases, while `medium` and `high` remain good fits when maximum fidelity matters. \n",
+    "\n",
+    "The guide also covers `gpt-image-2-turbo`, a smaller image model that delivers on-par capabilities as `gpt-image-2` for lower-latency, high-throughput generation and editing. Use it for rapid ideation, previews, creative variations, and lightweight personalization, and compare its supported quality settings when a workflow needs additional detail.\n"
    ]
   },
   {
@@ -49,6 +52,7 @@
     "- supported `outputQuality` values\n",
     "- supported `input_fidelity` values\n",
     "- supported `size` / resolution behavior\n",
+    "- `background` and `output_format` requirements for transparent assets\n",
     "- recommended use cases by workflow\n",
     "\n",
     "## Model summary\n",
@@ -57,9 +61,21 @@
     "| Model | `outputQuality` | `input_fidelity` | Resolutions | Recommended use |\n",
     "| --- | --- | --- | --- | --- |\n",
     "| `gpt-image-2` | `low`, `medium`, `high` | Disabled. `input_fidelity` does not work for this model because output is already high fidelity by default | Any resolution that satisfies the constraints below | Recommended default for new builds. Use for highest-quality generation and editing, text-heavy images, photorealism, compositing, identity-sensitive edits, and workflows where fewer retries matter more than the lowest possible cost. |\n",
+    "| `gpt-image-2-turbo` | `low`, `medium`, `high`, `xhigh`, `max`, `auto` | Disabled. `input_fidelity` is not supported for this model | Any resolution that satisfies the constraints below | Use for lower-latency, high-throughput generation and editing, rapid ideation, previews, creative variations, and lightweight personalization. |\n",
     "| `gpt-image-1.5` | `low`, `medium`, `high` | `low`, `high` | `1024x1024`, `1024x1536`, `1536x1024`, `auto` | Keep for existing validated workflows during migration. For new work, prefer `gpt-image-2`, especially when quality, editing reliability, or flexible sizing matter. |\n",
     "| `gpt-image-1` | `low`, `medium`, `high` | `low`, `high` | `1024x1024`, `1024x1536`, `1536x1024`, `auto` | Legacy compatibility only. If you are starting a new workflow or refreshing prompts, move to `gpt-image-2`; keep `gpt-image-1` only when you need short-term stability while validating the upgrade. |\n",
     "| `gpt-image-1-mini` | `low`, `medium`, `high` | `low`, `high` | `1024x1024`, `1024x1536`, `1536x1024`, `auto` | Use when cost and throughput are the main constraint: large batch variant generation, rapid ideation, previews, lightweight personalization, and draft assets that do not require the strongest generation or editing performance. |\n",
+    "\n",
+    "### Transparent backgrounds with `gpt-image-2`\n",
+    "\n",
+    "To generate or edit an image with a transparent background:\n",
+    "\n",
+    "- Set `background=\"transparent\"`.\n",
+    "- Set `output_format=\"png\"`. Transparent backgrounds are supported only with PNG output.\n",
+    "- Omit `output_compression`; transparent PNG output does not require a compression parameter.\n",
+    "- Explicitly request an isolated subject on a fully transparent background, with no scenery, solid backdrop, checkerboard, or unwanted shadows.\n",
+    "- For edits, explicitly preserve the transparent background in each prompt so later steps do not introduce a new background.\n",
+    "- Keep the returned image as a PNG and preserve its alpha channel throughout downstream processing.\n",
     "\n",
     "### `gpt-image-2` size options\n",
     "\n",
@@ -73,7 +89,7 @@
     "\n",
     "If the output image exceeds `2560x1440` pixels (`3,686,400` total pixels), commonly referred to as 2K, treat it as experimental because results can be more variable above this size.\n",
     "\n",
-    "### Popular `gpt-image-2` sizes\n",
+    "### `gpt-image-2` and `gpt-image-2-turbo` size options\n",
     "\n",
     "These are useful reference points that fit the constraints above:\n",
     "\n",
@@ -82,6 +98,7 @@
     "| HD portrait | `1024x1536` | Standard portrait option |\n",
     "| HD landscape | `1536x1024` | Standard landscape option |\n",
     "| Square | `1024x1024` | Good general-purpose default |\n",
+    "| 2K square | `2048x2048` | Higher-resolution square option |\n",
     "| 2K / QHD | `2560x1440` | Popular widescreen format and recommended upper reliability boundary for `gpt-image-2` |\n",
     "| 4K / UHD | `3840x2160` | Experimental upper-end target. If the max-edge rule is enforced literally as `< 3840`, round down to the nearest valid size such as `3824x2144` |\n",
     "\n",
@@ -90,6 +107,7 @@
     "- Choose `gpt-image-2` as the default for most production workflows. It is the strongest overall model and the right upgrade target for teams currently using `gpt-image-1.5` or `gpt-image-1` for high-quality outputs.\n",
     "- Choose `gpt-image-2` with quality: low when speed and unit economics dominate the decision. This setting has good quality for a lot of use cases and it a strong fit for high-volume generation and experimentation. You can also try `gpt-image-1-mini` for these use cases, but we have seen quality: low works just as well.\n",
     "- Keep `gpt-image-1.5` or `gpt-image-1` only for backward compatibility while you validate prompt migrations, regression-test outputs, or maintain older workflows that are not yet ready to move.\n",
+    "- Choose `gpt-image-2-turbo` for lower-latency generation and editing, rapid creative iteration, high-volume previews, and batch variations. Compare `low`, `medium`, `high`, `xhigh`, and `max` based on the fidelity needed for the workflow.\n",
     "\n",
     "### Recommended upgrade path from `gpt-image-1.5` and `gpt-image-1`\n",
     "\n",
@@ -97,7 +115,8 @@
     "\n",
     "- Upgrade to `gpt-image-2` for customer-facing assets, photorealistic generation, editing-heavy flows, brand-sensitive creative, text-in-image work, and any workflow where better first-pass quality reduces manual review or reruns.\n",
     "- Consider `gpt-image-1-mini` instead of legacy models only when the main goal is lowering cost for large batches of exploratory or lower-stakes images.\n",
-    "- During migration, keep prompts largely the same at first, then retune only after you have compared output quality, latency, and retry rates on your real workload."
+    "- During migration, keep prompts largely the same at first, then retune only after you have compared output quality, latency, and retry rates on your real workload.\n",
+    "- Evaluate `gpt-image-2-turbo` as an upgrade for preview generation, high-volume image creation, and existing mini-model workflows."
    ]
   },
   {
@@ -123,6 +142,8 @@
     "\n",
     "* **Constraints (what to change vs preserve):** State exclusions and invariants explicitly (e.g., “no watermark,” “no extra text,” “no logos/trademarks,” “preserve identity/geometry/layout/brand elements”). For edits, use “change only X” + “keep everything else the same,” and repeat the preserve list on each iteration to reduce drift. If the edit should be surgical, also say not to alter saturation, contrast, layout, arrows, labels, camera angle, or surrounding objects.\n",
     "\n",
+    "* **Transparent backgrounds:** For `gpt-image-2`, pair `background=\"transparent\"` with `output_format=\"png\"` and describe the subject as isolated on a fully transparent background. Explicitly exclude scenery, solid backdrops, checkerboards, and unwanted shadows. For edits, repeat “preserve the transparent background” so the workflow does not introduce or preserve an opaque scene. Do not add `output_compression`.\n",
+    "\n",
     "* **Text in images:** Put literal text in **quotes** or **ALL CAPS** and specify typography details (font style, size, color, placement) as constraints. For tricky words (brand names, uncommon spellings), spell them out letter-by-letter to improve character accuracy. Use `medium` or `high` quality for small text, dense information panels, and multi-font layouts.\n",
     "\n",
     "* **Multi-image inputs:** Reference each input by **index and description** (“Image 1: product photo… Image 2: style reference…”) and describe how they interact (“apply Image 2’s style to Image 1”). When compositing, be explicit about which elements move where (“put the bird from Image 1 on the elephant in Image 2”).\n",
@@ -142,7 +163,7 @@
     "- creates `output_images/` in the images folder. \n",
     "- adds a small helper to save base64 images\n",
     "\n",
-    "Put any reference images used for edits into `input_images/` (or update the paths in the examples)."
+    "Put any reference images used for edits into `input_images/` (or update the paths in the examples). When saving transparent outputs, keep the `.png` extension and preserve the returned image bytes; converting an RGBA image to RGB discards its transparent background."
    ]
   },
   {
@@ -377,7 +398,7 @@
    "source": [
     "## 4.5 Logo Generation\n",
     "\n",
-    "Strong logo generation comes from clear brand constraints and simplicity. Describe the brand’s personality and use case, then ask for a clean, original mark with strong shape, balanced negative space, and scalability across sizes.\n",
+    "Strong logo generation comes from clear brand constraints and simplicity. Describe the brand’s personality and use case, then ask for a clean, original mark with strong shape, balanced negative space, and scalability across sizes. Use a transparent-background PNG when the logo needs to be reused across different website, campaign, or presentation backgrounds.\n",
     "\n",
     "You can specify parameter \"n\" to denote the number of variations you would like to generate. "
    ]
@@ -393,7 +414,7 @@
     "Create an original, non-infringing logo for a company called Field & Flour, a local bakery. \n",
     "The logo should feel warm, simple, and timeless. Use clean, vector-like shapes, a strong silhouette, and balanced negative space. \n",
     "Favor simplicity over detail so it reads clearly at small and large sizes. Flat design, minimal strokes, no gradients unless essential. \n",
-    "Plain background. Deliver a single centered logo with generous padding. No watermark.\n",
+    "Fully transparent background. Deliver a single centered logo with generous padding, clean alpha edges, and no solid backdrop, scenery, checkerboard, or watermark.\n",
     "\"\"\"\n",
     "\n",
     "result = client.images.generate(\n",
@@ -401,7 +422,9 @@
     "    prompt=prompt,\n",
     "    size=\"1024x1536\",\n",
     "    quality=\"medium\",\n",
-    "    n=4     # Generate 4 versions of the logo\n",
+    "    background=\"transparent\",\n",
+    "    output_format=\"png\",\n",
+    "    n=4,    # Generate 4 versions of the logo\n",
     ")\n",
     "\n",
     "# Save all 4 images to separate files\n",
@@ -874,7 +897,7 @@
    "id": "d7b4f901",
    "metadata": {},
    "source": [
-    "## 5.4 Product Mockups (clean background + label integrity)\n"
+    "## 5.4 Product Mockups (transparent background + label integrity)\n"
    ]
   },
   {
@@ -882,7 +905,7 @@
    "id": "d42c73d0",
    "metadata": {},
    "source": [
-    "Product extraction and mockup prep is commonly used for catalogs, marketplaces, and design systems. Success depends on edge quality (clean silhouette, no fringing/halos) and label integrity (text stays sharp and unchanged). For `gpt-image-2`, keep the output background opaque and use a downstream background-removal step if you need a final transparent asset. If you want realism without re-styling, ask for only light polishing and optionally a subtle contact shadow on a plain background."
+    "Product extraction and mockup prep is commonly used for catalogs, marketplaces, and design systems. Success depends on edge quality (clean silhouette, no fringing/halos) and label integrity (text stays sharp and unchanged). With `gpt-image-2`, request `background=\"transparent\"` and `output_format=\"png\"` to create a reusable product cutout directly. Ask for an isolated subject, preserve the existing product geometry and label, and omit solid backdrops, checkerboards, and unnecessary shadows. No `output_compression` parameter is needed."
    ]
   },
   {
@@ -893,11 +916,11 @@
    "outputs": [],
    "source": [
     "prompt = \"\"\"\n",
-    "Extract the product from the input image and place it on a plain white opaque background.\n",
+    "Extract the product from the input image and isolate it on a fully transparent background.\n",
     "Output: centered product, crisp silhouette, no halos/fringing.\n",
     "Preserve product geometry and label legibility exactly.\n",
-    "Add only light polishing and a subtle realistic contact shadow.\n",
-    "Do not restyle the product; only remove background and lightly polish.\n",
+    "Add only light polishing. Do not add a solid backdrop, checkerboard, scenery, or shadow.\n",
+    "Do not restyle the product; remove the background and preserve clean alpha transparency.\n",
     "\"\"\"\n",
     "\n",
     "result = client.images.edit(\n",
@@ -908,7 +931,8 @@
     "    prompt=prompt,\n",
     "    size=\"1024x1536\",\n",
     "    quality=\"medium\",\n",
-    "    background=\"opaque\",\n",
+    "    background=\"transparent\",\n",
+    "    output_format=\"png\",\n",
     ")\n",
     "\n",
     "save_image(result, \"extract_product_gpt-image-2.png\")"

--- a/registry.yaml
+++ b/registry.yaml
@@ -3535,6 +3535,7 @@
   authors:
     - msingh-openai
     - emreokcular
+    - the-OAI
   tags:
     - images
     - vision


### PR DESCRIPTION
## Summary

- Update the existing image-generation prompting guide to cover `gpt-image-2-turbo` and its supported quality settings.
- Document transparent-background generation and editing for `gpt-image-2` using `background="transparent"` and `output_format="png"`, without `output_compression`.
- Update the existing logo-generation and product-extraction examples to produce reusable transparent PNG assets.
- Add Tiger He as a contributor to the existing guide while preserving its current authors.
- Add Tiger He's author profile, LinkedIn website, and validated GitHub avatar.

## Motivation

Keep the existing production image-model prompting guide current while documenting transparent PNG workflows, the turbo model, and the contributors responsible for the update.

## Validation

- Ran the repository notebook validator: `env -u VIRTUAL_ENV uv run --with nbformat python .github/scripts/check_notebooks.py`.
- Validated the notebook structure and all 98 cells; parsed every Python code cell successfully.
- Confirmed only the two intended executable examples changed, with transparent PNG output and no `output_compression`.
- Parsed `authors.yaml` and `registry.yaml` and verified all guide author references resolve.
- Verified Tiger He's GitHub avatar responds with HTTP 200 and `image/png`.
- Ran `git diff --check` and reviewed all changed notebook Markdown.
- Confirmed no internal alpha checkpoint identifiers appear in the changes.

## Publication checklist

- [x] Updated the guide's existing `registry.yaml` entry and added the contributor profile in `authors.yaml`.
- [x] Reviewed relevance, uniqueness, spelling, clarity, correctness, and completeness.
- [x] Preserved existing notebook outputs, execution counts, cell order, and metadata.