### PR TITLE
Archive three GPT-5 and Responses API cookbooks

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -512,6 +512,7 @@
   path: examples/gpt-5/gpt-5_frontend.ipynb
   slug: gpt-5-frontend
   date: 2025-08-07
+  archived: true
   authors:
     - WJPBProjects
     - anoop-openai

--- a/registry.yaml
+++ b/registry.yaml
@@ -3110,6 +3110,7 @@
   slug: file-search-responses
   description: Cookbook to search PDFs with the Responses API file search tool.
   date: 2025-03-11
+  archived: true
   authors:
     - pap-openai
   tags:

--- a/registry.yaml
+++ b/registry.yaml
@@ -958,6 +958,7 @@
   path: examples/responses_api/responses_example.ipynb
   slug: responses-example
   date: 2025-03-11
+  archived: true
   authors:
     - billchen-openai
   tags:


### PR DESCRIPTION
## Summary

Archive three Cookbook entries by setting `archived: true` in `registry.yaml`:

- **Frontend coding with GPT-5**: 35.3% editorial rewrite.
- **Web Search and States with Responses API**: 23.4% editorial rewrite.
- **Doing RAG on PDFs using File Search in the Responses API**: 18.3% editorial rewrite.

The notebooks remain in the repository and available through the archive.

## Validation

- Parsed all 308 registry entries successfully with PyYAML.
- Confirmed all three target entries appear exactly once and are marked archived.
- Confirmed the PR changes only `registry.yaml`.
- `git diff --check` passed.