### PR TITLE
Archive outdated GPT Image generation cookbook

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -3194,6 +3194,7 @@
   slug: generate-images-with-gpt-image
   description: Cookbook to generate and edit images with GPT Image capabilities.
   date: 2025-04-23
+  archived: true
   authors:
     - katiagg
   tags:


### PR DESCRIPTION
## Summary

Archive **Generate images with GPT Image** by setting `archived: true` in `registry.yaml`. The notebook remains available in the repository and archive.

## Motivation

- The Cookbook still hardcodes `gpt-image-1` across six generation and editing calls.
- Replacing it wholesale with `gpt-image-2` breaks its transparent-background example: live testing returned an opaque image when transparency was requested in the prompt, and explicit `background="transparent"` returned HTTP 400.
- The editorial evaluation found 15.7% of the prose required rewriting.

## Validation

- Parsed all 308 registry entries successfully with PyYAML.
- Confirmed the target entry appears exactly once and is marked archived.
- Confirmed `registry.yaml` is the only changed file.
- `git diff --check` passed.