### PR TITLE
fix(agentcore-payments): require timezone-aware policy deadlines

### DIFF
--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/src/agentic_commerce/models.py
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/src/agentic_commerce/models.py
@@ -39,7 +39,7 @@ class AuditEventType(StrEnum):
 
 class AuditEvent(FrozenModel):
     sequence: int = Field(ge=1)
-    occurred_at: datetime
+    occurred_at: AwareDatetime
     request_id: str
     event_type: AuditEventType
     detail: dict[str, Any] = Field(default_factory=dict)
@@ -53,7 +53,7 @@ class CommercePolicy(FrozenModel):
     approval_threshold: Decimal = Field(ge=0)
     currency: Literal["USDC"] = "USDC"
     network: Literal["eip155:84532"] = "eip155:84532"
-    session_expires_at: datetime
+    session_expires_at: AwareDatetime
 
 
 class PurchaseRequest(FrozenModel):
@@ -71,8 +71,8 @@ class ApprovalGrant(FrozenModel):
     maximum_amount: Decimal = Field(gt=0)
     currency: Literal["USDC"] = "USDC"
     approved_by: str = Field(min_length=1)
-    approved_at: datetime
-    expires_at: datetime
+    approved_at: AwareDatetime
+    expires_at: AwareDatetime
 
 
 class ResourceInfo(FrozenModel):

--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/tests/test_local_flow.py
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/tests/test_local_flow.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import httpx
 import pytest
+from pydantic import ValidationError
 
 from agentic_commerce.application import CommerceApplication
 from agentic_commerce.codec import encode_model
@@ -24,6 +25,7 @@ from agentic_commerce.merchant import (
 )
 from agentic_commerce.models import (
     ApprovalGrant,
+    AuditEvent,
     AuditEventType,
     CommercePolicy,
     PurchaseRequest,
@@ -397,6 +399,64 @@ def test_merchant_rejects_unrecognized_proof() -> None:
     assert PAYMENT_REQUIRED_HEADER in response.headers
     assert merchant.invalid_proof_count == 1
     assert payments.charge_count == 0
+
+
+def test_policy_rejects_naive_session_expiry() -> None:
+    """Deadlines the engine compares against `datetime.now(UTC)` must be aware.
+
+    A naive value used to validate here and then raise `TypeError: can't compare
+    offset-naive and offset-aware datetimes` from inside `PolicyEngine.preflight`,
+    with nothing in the traceback naming the field that was wrong.
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        CommercePolicy(
+            allowed_merchants=frozenset({"merchant.invalid"}),
+            allowed_purposes=frozenset({"supplier_due_diligence"}),
+            per_request_limit=Decimal("0.50"),
+            per_run_limit=Decimal("1.00"),
+            approval_threshold=Decimal("0.10"),
+            session_expires_at=NOW.replace(tzinfo=None) + timedelta(minutes=15),
+        )
+
+    assert exc_info.value.errors()[0]["type"] == "timezone_aware"
+    assert exc_info.value.errors()[0]["loc"] == ("session_expires_at",)
+
+
+def test_approval_grant_rejects_naive_expiry() -> None:
+    """The grant expiry is only compared above the approval threshold.
+
+    A naive value therefore left every cheap purchase working and failed only on
+    the expensive ones that actually require a human in the loop.
+    """
+    purchase = request()
+    with pytest.raises(ValidationError) as exc_info:
+        ApprovalGrant(
+            approval_id=f"approval-{purchase.request_id}",
+            request_id=purchase.request_id,
+            resource_url=purchase.resource_url,
+            purpose=purchase.purpose,
+            maximum_amount=Decimal("0.25"),
+            approved_by="synthetic-reviewer",
+            approved_at=NOW,
+            expires_at=NOW.replace(tzinfo=None) + timedelta(minutes=10),
+        )
+
+    assert exc_info.value.errors()[0]["type"] == "timezone_aware"
+    assert exc_info.value.errors()[0]["loc"] == ("expires_at",)
+
+
+def test_audit_event_rejects_naive_timestamp() -> None:
+    """An audit trail is evidence; an unqualified local timestamp is not."""
+    with pytest.raises(ValidationError) as exc_info:
+        AuditEvent(
+            sequence=1,
+            occurred_at=NOW.replace(tzinfo=None),
+            request_id="request-001",
+            event_type=AuditEventType.PAYMENT_ATTEMPTED,
+        )
+
+    assert exc_info.value.errors()[0]["type"] == "timezone_aware"
+    assert exc_info.value.errors()[0]["loc"] == ("occurred_at",)
 
 
 def test_agents_tool_has_prebound_authority_and_expected_name() -> None:


### PR DESCRIPTION
## Problem

In `controlled_agentic_commerce_with_agentcore_payments`, `PolicyEngine` compares three application-owned deadlines against `datetime.now(UTC)`:

| model field | compared at |
|---|---|
| `CommercePolicy.session_expires_at` | `policy.py:50` |
| `ApprovalGrant.expires_at` | `policy.py:195` |
| `AuditEvent.occurred_at` | serialized into the audit trail |

All three were typed as plain `datetime`, so a naive value validates cleanly and then blows up later:

```python
policy = CommercePolicy(
    ...,
    session_expires_at=datetime.now() + timedelta(hours=1),   # no tzinfo
)
PolicyEngine(policy).preflight(request)
# TypeError: can't compare offset-naive and offset-aware datetimes
```

The `TypeError` surfaces from inside `preflight()`, and nothing in the traceback names the field that was actually wrong.

`ApprovalGrant.expires_at` is the worst of the three, because it is only reached when `amount > approval_threshold`. A naive grant leaves every cheap purchase working and fails only on the expensive ones that require a human in the loop — the path you would least like to discover this on.

## Why this is a mismatch with the rest of the module

The codebase has already taken a clear position on this everywhere it touches protocol data:

- `PaymentRequirementExtra.issued_at` / `.expires_at` are `AwareDatetime`.
- `agentcore_payments.py:718` explicitly rejects a merchant challenge expiry whose `tzinfo is None`, as `payment_challenge_expiry_invalid` — *before* comparing it.

The application-owned models simply didn't get the same treatment.

## Fix

Type the four fields as `AwareDatetime`. The error moves to construction, where pydantic names the field:

```
1 validation error for CommercePolicy
session_expires_at
  Input should have timezone info [type=timezone_aware, ...]
```

**This is a no-op for correct usage.** Every existing construction site already passes aware datetimes (`demo.py`, `agentcore_runtime.py`, and all of `tests/`), which is why the suite is unchanged.

## Tests

Three regression tests in `tests/test_local_flow.py`, one per field. Reverting `models.py` alone fails all three with `DID NOT RAISE ValidationError`.

## Verification

| check | before | after |
|---|---|---|
| `uv run pytest` | 141 passed | **144 passed** |
| `uv run ruff check .` | All checks passed! | All checks passed! |
| `uv run ruff format --check .` | 31 files already formatted | 31 files already formatted |