### PR TITLE
Archive GPT-5 prompting guide

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -498,6 +498,7 @@
   path: examples/gpt-5/gpt-5_prompting_guide.ipynb
   slug: gpt-5-prompting-guide
   date: 2025-08-07
+  archived: true
   authors:
     - anoop-openai
     - julian-openai


### PR DESCRIPTION
## Summary

- Mark the GPT-5 prompting guide as archived in `registry.yaml`.
- Preserve the notebook and its metadata while removing the guide from active Cookbook discovery surfaces.

## Validation

- Parsed `registry.yaml` successfully with PyYAML.
- Confirmed exactly one GPT-5 prompting guide entry exists and has `archived: true`.
- `git diff --check` passes.

[→ Review this PR in ChatGPT](https://chatgpt.com/?surface=work&prompt=Walk%20me%20through%20https%3A%2F%2Fgithub.com%2Fopenai%2Fopenai-cookbook%2Fpull%2F2956)