### PR TITLE
Narrow AgentCore Payments Cookbook title

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -60,7 +60,7 @@
     - bedrock
     - security
 
-- title: Controlled Agentic Commerce with AgentCore Payments
+- title: Controlled agentic micropayments with stablecoins and AgentCore Payments
   path: examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/controlled_agentic_commerce.ipynb
   slug: controlled-agentic-commerce-agentcore-payments
   description: Build a controlled agentic-commerce workflow with the OpenAI Agents SDK, x402, application-owned payment authority, deterministic validation, and an optional gated Amazon Bedrock AgentCore Payments testnet path.


### PR DESCRIPTION
## Summary

- Narrow the public Cookbook title from general agentic commerce to controlled agentic micropayments.
- Keep the notebook, URL, scope, and claim boundaries unchanged.

## Motivation

The example covers a controlled x402 micropayment workflow with testnet stablecoins and AgentCore Payments. The previous title sounded broader than the implementation.

## Validation

- `registry.yaml` parses successfully.
- `git diff --check` passes.
- No notebook code, outputs, URL, slug, or claim changes.