### PR TITLE
Fix typo in image generation prompting guide

### DIFF
--- a/examples/multimodal/image-gen-models-prompting-guide.ipynb
+++ b/examples/multimodal/image-gen-models-prompting-guide.ipynb
@@ -202,7 +202,7 @@
     "## 4. Use Cases — Generate (text → image)\n",
     "\n",
     "## 4.1 Infographics\n",
-    "Use infographics to explain structured information for a specific audience: students, executives, customers, or the general public. Examples include explainers, posters, labeled diagrams, timelines, and “visual wiki” assets. For dense layouts or heavy in-image text, it's recommedned to set output generation quality to \"high\"."
+    "Use infographics to explain structured information for a specific audience: students, executives, customers, or the general public. Examples include explainers, posters, labeled diagrams, timelines, and “visual wiki” assets. For dense layouts or heavy in-image text, it's recommended to set output generation quality to \"high\"."
    ]
   },
   {


### PR DESCRIPTION
## Summary

- correct `recommedned` to `recommended` in the infographics guidance

## Why

The misspelling is visible on the published developer cookbook page.

## Impact

Documentation-only correction; no runtime behavior changes.

## Validation

- confirmed the typo occurs exactly once in the source notebook
- confirmed the updated notebook remains valid JSON
- confirmed the branch changes only the target notebook (1 addition, 1 deletion)