### PR TITLE
docs: clarify ApprovalGrant authenticity and fail-closed behavior

### DIFF
--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/README.md
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/README.md
@@ -92,7 +92,8 @@ Requests above `approval_threshold` fail closed when no valid grant is
 available. A missing, expired, scope-mismatched, currency-mismatched, or
 over-limit grant is denied; there is no unattended fallback that silently
 authorizes the purchase. This is intentional for the example's safety model:
-if no authenticated human approval is available, the request remains denied.
+when the external approval or identity service has not authenticated a grant,
+the application must withhold it, so the request remains denied.
 
 ## Run the local notebook
 

--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/README.md
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/README.md
@@ -79,6 +79,21 @@ direct network environment; do not bypass a required corporate proxy.
 | AgentCore Payments | Payment-header generation inside a bounded session | Business authorization |
 | Testnet wallet provider | Delegated testnet signing | Model reasoning or approval policy |
 
+### Approval authenticity and unattended operation
+
+`ApprovalGrant` is an application-level contract, not proof of who approved a
+request. The policy engine validates the grant's request binding, amount,
+currency, and expiry, but this example does not authenticate `approved_by` or
+attach a digital signature. A production application must obtain the grant
+from an authenticated approval or identity service before passing it to the
+policy engine.
+
+Requests above `approval_threshold` fail closed when no valid grant is
+available. A missing, expired, scope-mismatched, currency-mismatched, or
+over-limit grant is denied; there is no unattended fallback that silently
+authorizes the purchase. This is intentional for the example's safety model:
+if no authenticated human approval is available, the request remains denied.
+
 ## Run the local notebook
 
 ```bash

--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/src/agentic_commerce/models.py
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/src/agentic_commerce/models.py
@@ -64,6 +64,15 @@ class PurchaseRequest(FrozenModel):
 
 
 class ApprovalGrant(FrozenModel):
+    """Application-level approval scoped to one purchase request.
+
+    This model records the approval data that the policy engine can validate:
+    request scope, maximum amount, currency, and expiry. It does not
+    authenticate ``approved_by`` or provide a cryptographic signature. A
+    production application must obtain and authenticate this grant through its
+    own identity or approval service before constructing the model.
+    """
+
     approval_id: str = Field(min_length=1)
     request_id: str = Field(min_length=1)
     resource_url: HttpUrl


### PR DESCRIPTION
## Summary

Closes #2951 by documenting the security boundary around `ApprovalGrant` and the behavior when no valid human approval is available.

## Changes

- Add a focused docstring to `ApprovalGrant` explaining that scope validation does not authenticate `approved_by` or provide a signature.
- Add a README section explaining that production deployments must obtain the grant through an authenticated approval or identity service.
- Document that requests above `approval_threshold` are denied when the grant is missing, expired, mismatched, or over-limit; there is no unattended fallback.

No authorization or payment logic changed.

## Verification

- `uv run --group dev pytest -q` (141 passed)
- `uv run --group dev ruff check src tests`
- `uv run --group dev ruff format --check src tests`

Assisted-by: ChatGPT 5.2