### PR TITLE
Remove unused pprint import from agentic governance cookbook

### DIFF
--- a/examples/partners/agentic_governance_guide/agentic_governance_cookbook.ipynb
+++ b/examples/partners/agentic_governance_guide/agentic_governance_cookbook.ipynb
@@ -550,7 +550,6 @@
     }
    ],
    "source": [
-    "import pprint\n",
     "from agents import Runner\n",
     "\n",
     "# Test: Deal screening query (should hand off to DealScreeningAgent)\n",


### PR DESCRIPTION
## Summary

Removes a single unused `import pprint` from
`examples/partners/agentic_governance_guide/agentic_governance_cookbook.ipynb`.

The import sits in the first `Runner.run` test cell alongside
`from agents import Runner`, but `pprint` is never called anywhere in the
notebook. Every result is printed via `print(...)`.

Diff is one deleted line. No code cells, outputs, execution counts, cell order,
or notebook metadata were changed.

## Motivation

This is a dead import, and readers might assume they need it. Readers rightly assume that every import in an example is required in order to run it.

## For new content

N/A — this is a cleanup to an existing notebook, not new content.
