### PR TITLE
Document transparent backgrounds in the image prompting guide

### DIFF
--- a/authors.yaml
+++ b/authors.yaml
@@ -8,6 +8,11 @@ talaniz-oai:
   website: "https://github.com/talaniz-oai"
   avatar: "https://avatars.githubusercontent.com/u/293961948?v=4"
 
+the-OAI:
+  name: "Tiger He"
+  website: "https://www.linkedin.com/in/tiger-he-b71842164/"
+  avatar: "https://avatars.githubusercontent.com/u/286157113?v=4"
+
 neilh-oai:
   name: "Neil Hansaria"
   website: "https://www.linkedin.com/in/neilhansaria"

--- a/examples/multimodal/image-gen-models-prompting-guide.ipynb
+++ b/examples/multimodal/image-gen-models-prompting-guide.ipynb
@@ -28,6 +28,7 @@
     "- **High-fidelity photorealism** with natural lighting, accurate materials, and rich color rendering\n",
     "- **Flexible quality–latency tradeoffs**, allowing faster generation at lower settings while still exceeding the visual quality of prior-generation image models\n",
     "- **Robust facial and identity preservation** for edits, character consistency, and multi-step workflows\n",
+    "- **Transparent-background PNG assets** with `gpt-image-2` for reusable logos, product cutouts, stickers, and presentation graphics\n",
     "- **Reliable text rendering** with crisp lettering, consistent layout, and strong contrast inside images\n",
     "- **Complex structured visuals**, including infographics, diagrams, and multi-panel compositions\n",
     "- **Precise style control and style transfer** with minimal prompting, supporting everything from branded design systems to fine-art styles\n",
@@ -49,6 +50,7 @@
     "- supported `outputQuality` values\n",
     "- supported `input_fidelity` values\n",
     "- supported `size` / resolution behavior\n",
+    "- `background` and `output_format` requirements for transparent assets\n",
     "- recommended use cases by workflow\n",
     "\n",
     "## Model summary\n",
@@ -60,6 +62,17 @@
     "| `gpt-image-1.5` | `low`, `medium`, `high` | `low`, `high` | `1024x1024`, `1024x1536`, `1536x1024`, `auto` | Keep for existing validated workflows during migration. For new work, prefer `gpt-image-2`, especially when quality, editing reliability, or flexible sizing matter. |\n",
     "| `gpt-image-1` | `low`, `medium`, `high` | `low`, `high` | `1024x1024`, `1024x1536`, `1536x1024`, `auto` | Legacy compatibility only. If you are starting a new workflow or refreshing prompts, move to `gpt-image-2`; keep `gpt-image-1` only when you need short-term stability while validating the upgrade. |\n",
     "| `gpt-image-1-mini` | `low`, `medium`, `high` | `low`, `high` | `1024x1024`, `1024x1536`, `1536x1024`, `auto` | Use when cost and throughput are the main constraint: large batch variant generation, rapid ideation, previews, lightweight personalization, and draft assets that do not require the strongest generation or editing performance. |\n",
+    "\n",
+    "### Transparent backgrounds with `gpt-image-2`\n",
+    "\n",
+    "To generate or edit an image with a transparent background:\n",
+    "\n",
+    "- Set `background=\"transparent\"`.\n",
+    "- Set `output_format=\"png\"`. Transparent backgrounds are supported only with PNG output.\n",
+    "- Omit `output_compression`; transparent PNG output does not require a compression parameter.\n",
+    "- Explicitly request an isolated subject on a fully transparent background, with no scenery, solid backdrop, checkerboard, or unwanted shadows.\n",
+    "- For edits, explicitly preserve the transparent background in each prompt so later steps do not introduce a new background.\n",
+    "- Keep the returned image as a PNG and preserve its alpha channel throughout downstream processing.\n",
     "\n",
     "### `gpt-image-2` size options\n",
     "\n",
@@ -123,6 +136,8 @@
     "\n",
     "* **Constraints (what to change vs preserve):** State exclusions and invariants explicitly (e.g., “no watermark,” “no extra text,” “no logos/trademarks,” “preserve identity/geometry/layout/brand elements”). For edits, use “change only X” + “keep everything else the same,” and repeat the preserve list on each iteration to reduce drift. If the edit should be surgical, also say not to alter saturation, contrast, layout, arrows, labels, camera angle, or surrounding objects.\n",
     "\n",
+    "* **Transparent backgrounds:** For `gpt-image-2`, pair `background=\"transparent\"` with `output_format=\"png\"` and describe the subject as isolated on a fully transparent background. Explicitly exclude scenery, solid backdrops, checkerboards, and unwanted shadows. For edits, repeat “preserve the transparent background” so the workflow does not introduce or preserve an opaque scene. Do not add `output_compression`.\n",
+    "\n",
     "* **Text in images:** Put literal text in **quotes** or **ALL CAPS** and specify typography details (font style, size, color, placement) as constraints. For tricky words (brand names, uncommon spellings), spell them out letter-by-letter to improve character accuracy. Use `medium` or `high` quality for small text, dense information panels, and multi-font layouts.\n",
     "\n",
     "* **Multi-image inputs:** Reference each input by **index and description** (“Image 1: product photo… Image 2: style reference…”) and describe how they interact (“apply Image 2’s style to Image 1”). When compositing, be explicit about which elements move where (“put the bird from Image 1 on the elephant in Image 2”).\n",
@@ -142,7 +157,7 @@
     "- creates `output_images/` in the images folder. \n",
     "- adds a small helper to save base64 images\n",
     "\n",
-    "Put any reference images used for edits into `input_images/` (or update the paths in the examples)."
+    "Put any reference images used for edits into `input_images/` (or update the paths in the examples). When saving transparent outputs, keep the `.png` extension and preserve the returned image bytes; converting an RGBA image to RGB discards its transparent background."
    ]
   },
   {
@@ -377,7 +392,7 @@
    "source": [
     "## 4.5 Logo Generation\n",
     "\n",
-    "Strong logo generation comes from clear brand constraints and simplicity. Describe the brand’s personality and use case, then ask for a clean, original mark with strong shape, balanced negative space, and scalability across sizes.\n",
+    "Strong logo generation comes from clear brand constraints and simplicity. Describe the brand’s personality and use case, then ask for a clean, original mark with strong shape, balanced negative space, and scalability across sizes. Use a transparent-background PNG when the logo needs to be reused across different website, campaign, or presentation backgrounds.\n",
     "\n",
     "You can specify parameter \"n\" to denote the number of variations you would like to generate. "
    ]
@@ -393,7 +408,7 @@
     "Create an original, non-infringing logo for a company called Field & Flour, a local bakery. \n",
     "The logo should feel warm, simple, and timeless. Use clean, vector-like shapes, a strong silhouette, and balanced negative space. \n",
     "Favor simplicity over detail so it reads clearly at small and large sizes. Flat design, minimal strokes, no gradients unless essential. \n",
-    "Plain background. Deliver a single centered logo with generous padding. No watermark.\n",
+    "Fully transparent background. Deliver a single centered logo with generous padding, clean alpha edges, and no solid backdrop, scenery, checkerboard, or watermark.\n",
     "\"\"\"\n",
     "\n",
     "result = client.images.generate(\n",
@@ -401,7 +416,9 @@
     "    prompt=prompt,\n",
     "    size=\"1024x1536\",\n",
     "    quality=\"medium\",\n",
-    "    n=4     # Generate 4 versions of the logo\n",
+    "    background=\"transparent\",\n",
+    "    output_format=\"png\",\n",
+    "    n=4,    # Generate 4 versions of the logo\n",
     ")\n",
     "\n",
     "# Save all 4 images to separate files\n",
@@ -874,7 +891,7 @@
    "id": "d7b4f901",
    "metadata": {},
    "source": [
-    "## 5.4 Product Mockups (clean background + label integrity)\n"
+    "## 5.4 Product Mockups (transparent background + label integrity)\n"
    ]
   },
   {
@@ -882,7 +899,7 @@
    "id": "d42c73d0",
    "metadata": {},
    "source": [
-    "Product extraction and mockup prep is commonly used for catalogs, marketplaces, and design systems. Success depends on edge quality (clean silhouette, no fringing/halos) and label integrity (text stays sharp and unchanged). For `gpt-image-2`, keep the output background opaque and use a downstream background-removal step if you need a final transparent asset. If you want realism without re-styling, ask for only light polishing and optionally a subtle contact shadow on a plain background."
+    "Product extraction and mockup prep is commonly used for catalogs, marketplaces, and design systems. Success depends on edge quality (clean silhouette, no fringing/halos) and label integrity (text stays sharp and unchanged). With `gpt-image-2`, request `background=\"transparent\"` and `output_format=\"png\"` to create a reusable product cutout directly. Ask for an isolated subject, preserve the existing product geometry and label, and omit solid backdrops, checkerboards, and unnecessary shadows. No `output_compression` parameter is needed."
    ]
   },
   {
@@ -893,11 +910,11 @@
    "outputs": [],
    "source": [
     "prompt = \"\"\"\n",
-    "Extract the product from the input image and place it on a plain white opaque background.\n",
+    "Extract the product from the input image and isolate it on a fully transparent background.\n",
     "Output: centered product, crisp silhouette, no halos/fringing.\n",
     "Preserve product geometry and label legibility exactly.\n",
-    "Add only light polishing and a subtle realistic contact shadow.\n",
-    "Do not restyle the product; only remove background and lightly polish.\n",
+    "Add only light polishing. Do not add a solid backdrop, checkerboard, scenery, or shadow.\n",
+    "Do not restyle the product; remove the background and preserve clean alpha transparency.\n",
     "\"\"\"\n",
     "\n",
     "result = client.images.edit(\n",
@@ -908,7 +925,8 @@
     "    prompt=prompt,\n",
     "    size=\"1024x1536\",\n",
     "    quality=\"medium\",\n",
-    "    background=\"opaque\",\n",
+    "    background=\"transparent\",\n",
+    "    output_format=\"png\",\n",
     ")\n",
     "\n",
     "save_image(result, \"extract_product_gpt-image-2.png\")"

--- a/examples/multimodal/image-gen-models-prompting-guide.ipynb
+++ b/examples/multimodal/image-gen-models-prompting-guide.ipynb
@@ -28,7 +28,7 @@
     "- **High-fidelity photorealism** with natural lighting, accurate materials, and rich color rendering\n",
     "- **Flexible quality–latency tradeoffs**, allowing faster generation at lower settings while still exceeding the visual quality of prior-generation image models\n",
     "- **Robust facial and identity preservation** for edits, character consistency, and multi-step workflows\n",
-    "- **Transparent-background PNG assets** with `gpt-image-2` for reusable logos, product cutouts, stickers, and presentation graphics\n",
+    "- **Transparent-background PNG and WebP assets (preview)** with `gpt-image-2` for reusable logos, product cutouts, stickers, and presentation graphics\n",
     "- **Reliable text rendering** with crisp lettering, consistent layout, and strong contrast inside images\n",
     "- **Complex structured visuals**, including infographics, diagrams, and multi-panel compositions\n",
     "- **Precise style control and style transfer** with minimal prompting, supporting everything from branded design systems to fine-art styles\n",
@@ -63,16 +63,16 @@
     "| `gpt-image-1` | `low`, `medium`, `high` | `low`, `high` | `1024x1024`, `1024x1536`, `1536x1024`, `auto` | Legacy compatibility only. If you are starting a new workflow or refreshing prompts, move to `gpt-image-2`; keep `gpt-image-1` only when you need short-term stability while validating the upgrade. |\n",
     "| `gpt-image-1-mini` | `low`, `medium`, `high` | `low`, `high` | `1024x1024`, `1024x1536`, `1536x1024`, `auto` | Use when cost and throughput are the main constraint: large batch variant generation, rapid ideation, previews, lightweight personalization, and draft assets that do not require the strongest generation or editing performance. |\n",
     "\n",
-    "### Transparent backgrounds with `gpt-image-2`\n",
+    "### Transparent backgrounds with `gpt-image-2` (preview)\n",
     "\n",
-    "To generate or edit an image with a transparent background:\n",
+    "Transparent backgrounds are available in preview for `gpt-image-2`. To generate or edit an image with a transparent background:\n",
     "\n",
     "- Set `background=\"transparent\"`.\n",
-    "- Set `output_format=\"png\"`. Transparent backgrounds are supported only with PNG output.\n",
-    "- Omit `output_compression`; transparent PNG output does not require a compression parameter.\n",
+    "- Set `output_format=\"png\"` (the default) or `output_format=\"webp\"`. Both support transparency; `jpeg` does not.\n",
+    "- Omit `output_compression` for PNG output. WebP supports optional compression.\n",
     "- Explicitly request an isolated subject on a fully transparent background, with no scenery, solid backdrop, checkerboard, or unwanted shadows.\n",
     "- For edits, explicitly preserve the transparent background in each prompt so later steps do not introduce a new background.\n",
-    "- Keep the returned image as a PNG and preserve its alpha channel throughout downstream processing.\n",
+    "- Keep the returned image as a PNG or WebP file and preserve its alpha channel throughout downstream processing.\n",
     "\n",
     "### `gpt-image-2` size options\n",
     "\n",
@@ -136,7 +136,7 @@
     "\n",
     "* **Constraints (what to change vs preserve):** State exclusions and invariants explicitly (e.g., “no watermark,” “no extra text,” “no logos/trademarks,” “preserve identity/geometry/layout/brand elements”). For edits, use “change only X” + “keep everything else the same,” and repeat the preserve list on each iteration to reduce drift. If the edit should be surgical, also say not to alter saturation, contrast, layout, arrows, labels, camera angle, or surrounding objects.\n",
     "\n",
-    "* **Transparent backgrounds:** For `gpt-image-2`, pair `background=\"transparent\"` with `output_format=\"png\"` and describe the subject as isolated on a fully transparent background. Explicitly exclude scenery, solid backdrops, checkerboards, and unwanted shadows. For edits, repeat “preserve the transparent background” so the workflow does not introduce or preserve an opaque scene. Do not add `output_compression`.\n",
+    "* **Transparent backgrounds:** For `gpt-image-2`, transparency is available in preview. Pair `background=\"transparent\"` with `output_format=\"png\"` (the default) or `output_format=\"webp\"`; `jpeg` does not support transparency. Describe the subject as isolated on a fully transparent background and explicitly exclude scenery, solid backdrops, checkerboards, and unwanted shadows. For edits, repeat “preserve the transparent background” so the workflow does not introduce or preserve an opaque scene. Omit `output_compression` for PNG; WebP supports optional compression.\n",
     "\n",
     "* **Text in images:** Put literal text in **quotes** or **ALL CAPS** and specify typography details (font style, size, color, placement) as constraints. For tricky words (brand names, uncommon spellings), spell them out letter-by-letter to improve character accuracy. Use `medium` or `high` quality for small text, dense information panels, and multi-font layouts.\n",
     "\n",
@@ -157,7 +157,7 @@
     "- creates `output_images/` in the images folder. \n",
     "- adds a small helper to save base64 images\n",
     "\n",
-    "Put any reference images used for edits into `input_images/` (or update the paths in the examples). When saving transparent outputs, keep the `.png` extension and preserve the returned image bytes; converting an RGBA image to RGB discards its transparent background."
+    "Put any reference images used for edits into `input_images/` (or update the paths in the examples). When saving transparent outputs, use a `.png` or `.webp` extension matching the selected output format and preserve the returned image bytes; converting an RGBA image to RGB discards its transparent background."
    ]
   },
   {
@@ -392,7 +392,7 @@
    "source": [
     "## 4.5 Logo Generation\n",
     "\n",
-    "Strong logo generation comes from clear brand constraints and simplicity. Describe the brand’s personality and use case, then ask for a clean, original mark with strong shape, balanced negative space, and scalability across sizes. Use a transparent-background PNG when the logo needs to be reused across different website, campaign, or presentation backgrounds.\n",
+    "Strong logo generation comes from clear brand constraints and simplicity. Describe the brand’s personality and use case, then ask for a clean, original mark with strong shape, balanced negative space, and scalability across sizes. Use a transparent-background PNG or WebP file when the logo needs to be reused across different website, campaign, or presentation backgrounds.\n",
     "\n",
     "You can specify parameter \"n\" to denote the number of variations you would like to generate. "
    ]
@@ -899,7 +899,7 @@
    "id": "d42c73d0",
    "metadata": {},
    "source": [
-    "Product extraction and mockup prep is commonly used for catalogs, marketplaces, and design systems. Success depends on edge quality (clean silhouette, no fringing/halos) and label integrity (text stays sharp and unchanged). With `gpt-image-2`, request `background=\"transparent\"` and `output_format=\"png\"` to create a reusable product cutout directly. Ask for an isolated subject, preserve the existing product geometry and label, and omit solid backdrops, checkerboards, and unnecessary shadows. No `output_compression` parameter is needed."
+    "Product extraction and mockup prep is commonly used for catalogs, marketplaces, and design systems. Success depends on edge quality (clean silhouette, no fringing/halos) and label integrity (text stays sharp and unchanged). Transparent backgrounds are available in preview for `gpt-image-2`; request `background=\"transparent\"` with `output_format=\"png\"` (the default) or `output_format=\"webp\"` to create a reusable product cutout directly. `jpeg` does not support transparent backgrounds. Ask for an isolated subject, preserve the existing product geometry and label, and omit solid backdrops, checkerboards, and unnecessary shadows. Omit `output_compression` for PNG output; WebP supports optional compression."
    ]
   },
   {

--- a/registry.yaml
+++ b/registry.yaml
@@ -3566,6 +3566,7 @@
   authors:
     - msingh-openai
     - emreokcular
+    - the-OAI
   tags:
     - images
     - vision


### PR DESCRIPTION
## Summary

- Document transparent-background image generation and editing as a preview capability for `gpt-image-2`.
- Explain that transparent output requires `background="transparent"` with `png` (the default) or `webp`; `jpeg` does not support transparency.
- Clarify that `output_compression` should be omitted for PNG, while WebP supports optional compression.
- Cover alpha-channel preservation and prompting techniques for isolated subjects and subsequent edits.
- Update the existing logo-generation and product-extraction examples to return reusable transparent image assets.
- Add Tiger He to the existing guide's contributor list and author metadata.

## Motivation

The current guide recommends opaque output and a separate background-removal step. Update that guidance to reflect direct transparent PNG or WebP generation and editing, while keeping the existing model-selection guidance unchanged.

## Validation

- Based on the latest `main`, including the current prompting-guide updates.
- Ran `env -u VIRTUAL_ENV uv run --with nbformat python .github/scripts/check_notebooks.py`.
- Validated all 98 notebook cells and parsed every Python code cell.
- Confirmed only the two intended executable examples changed.
- Verified the PNG examples set `background="transparent"` and `output_format="png"` without `output_compression`.
- Confirmed the guide labels transparency as preview, documents PNG and WebP support, excludes JPEG, and explains format-specific compression.
- Validated `authors.yaml` and `registry.yaml`, and verified the contributor avatar returns HTTP 200 as `image/png`.
- Ran `git diff --check` and reviewed all changed notebook Markdown.
- Confirmed the change does not introduce any new model names or internal checkpoint identifiers.

## Publication checklist

- [x] Updated the existing guide's `registry.yaml` author list and added its contributor profile in `authors.yaml`.
- [x] Reviewed relevance, uniqueness, spelling, clarity, correctness, and completeness.
- [x] Preserved existing notebook outputs, execution counts, cell order, metadata, and model guidance.