### PR TITLE
Fix duplicate Tiger He author entry

### DIFF
--- a/authors.yaml
+++ b/authors.yaml
@@ -13,11 +13,6 @@ talaniz-oai:
   website: "https://github.com/talaniz-oai"
   avatar: "https://avatars.githubusercontent.com/u/293961948?v=4"
 
-the-OAI:
-  name: "Tiger He"
-  website: "https://www.linkedin.com/in/tiger-he-b71842164/"
-  avatar: "https://avatars.githubusercontent.com/u/286157113?v=4"
-
 neilh-oai:
   name: "Neil Hansaria"
   website: "https://www.linkedin.com/in/neilhansaria"


### PR DESCRIPTION
## Summary
Remove the duplicate `the-OAI` mapping from `authors.yaml`. Preserve the existing author metadata unchanged.

## Motivation
Both #2947 and #2966 added the same author entry. Their combined main branch fails strict YAML parsing during website build preparation.

## Validation
- [x] Parsed the full YAML and checked all mapping keys are unique (128 authors).
- [x] Verified Tiger He remains present.
- [x] Reviewed the five-line deletion and ran `git diff --check`.
- [x] Registry unchanged; no new content or author is introduced.

[→ Review this PR in ChatGPT](https://chatgpt.com/?surface=work&prompt=Walk%20me%20through%20https%3A%2F%2Fgithub.com%2Fopenai%2Fopenai-cookbook%2Fpull%2F2967)