### PR TITLE
Clarify transparent image assets preview status

### DIFF
--- a/examples/multimodal/transparent-image-assets-for-campaigns-and-presentations.ipynb
+++ b/examples/multimodal/transparent-image-assets-for-campaigns-and-presentations.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Generate Transparent Image Assets for Campaigns and Presentations\n",
     "\n",
-    "A great image should work on any background. Transparent image assets make it easy to reuse the same visuals across campaigns, websites, presentations, and product catalogs without white boxes or manual background removal.\n",
+    "A great image should work on any background. Transparent image assets (in preview) make it easy to reuse the same visuals across campaigns, websites, presentations, and product catalogs without white boxes or manual background removal.\n",
     "\n",
     "This cookbook covers four customer use cases:\n",
     "\n",
@@ -567,9 +567,7 @@
     "\n",
     "The sample webpage combines the three assets on a colored template and lets visitors switch the background while keeping the same PNGs in place.\n",
     "\n",
-    "![Simple design-template website showing a transparent app icon, strawberry sticker, and botanical decoration reused on a colored canvas](images/transparent-image-assets/design-template-studio.png)\n",
-    "\n",
-    "[Open the self-contained HTML demo](transparent-design-template-demo.html)."
+    "![Simple design-template website showing a transparent app icon, strawberry sticker, and botanical decoration reused on a colored canvas](images/transparent-image-assets/design-template-studio.png)"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Add “(in preview)” to the opening explanation of transparent image assets.
- Remove the self-contained HTML demo link while preserving the screenshot and walkthrough.

## Motivation
Make the preview status clear and remove the unwanted demo link.

## Validation
- [x] All changed notebooks pass the repository notebook validator.
- [x] Reviewed the exact Markdown-only diff; no code cells changed.
- [x] Registry and authors metadata are unchanged; no new content is introduced.

[→ Review this PR in ChatGPT](https://chatgpt.com/?surface=work&prompt=Walk%20me%20through%20https%3A%2F%2Fgithub.com%2Fopenai%2Fopenai-cookbook%2Fpull%2F2968)