### PR TITLE
Clarify Cookbook developer audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
  
 > ✨ Navigate at [cookbook.openai.com](https://cookbook.openai.com)
 
-Example code and guides for accomplishing common tasks with the [OpenAI API](https://platform.openai.com/docs/introduction). To run these examples, you'll need an OpenAI account and associated API key ([create a free account here](https://platform.openai.com/signup)). Set an environment variable called `OPENAI_API_KEY` with your API key. Alternatively, in most IDEs such as Visual Studio Code, you can create an `.env` file at the root of your repo containing `OPENAI_API_KEY=<your API key>`, which will be picked up by the notebooks.
+Developer examples and implementation guides for accomplishing common tasks with the [OpenAI API](https://developers.openai.com/api/docs). This repository is intended primarily for developers building applications with OpenAI models, APIs, SDKs, and related tooling.
+
+To run these examples, you'll need an OpenAI account and associated API key ([create a free account here](https://platform.openai.com/signup)). Set an environment variable called `OPENAI_API_KEY` with your API key. Alternatively, in most IDEs such as Visual Studio Code, you can create an `.env` file at the root of your repo containing `OPENAI_API_KEY=<your API key>`, which will be picked up by the notebooks.
 
 Most code examples are written in Python, though the concepts can be applied in any language.
 


### PR DESCRIPTION
## Summary

- Clarify near the top of the README that the Cookbook is primarily for developers building with OpenAI models, APIs, SDKs, and related tooling.
- Update the API documentation link to the current `developers.openai.com/api/docs` destination.
- Keep the existing repository name, scope, examples, and setup instructions unchanged.

## Motivation

The repository is already developer-focused, but the current top-level wording can be clearer about the intended audience. This takes the minimal README-only option proposed in #2708 rather than renaming the repository or changing its content scope.

Closes #2708.

## Validation

- Reviewed the rendered Markdown structure and kept the existing logo, navigation, setup, resources, and license sections intact.
- Verified the current OpenAI API documentation destination resolves at `https://developers.openai.com/api/docs`.
- Diff is limited to `README.md` with 3 additions and 1 deletion.

## Self-review

- [x] Relevance: clarifies the existing API/developer scope without broadening the repository.
- [x] Uniqueness: checked for an open PR addressing #2708 and found none.
- [x] Spelling and grammar reviewed.
- [x] No code, examples, registry entries, authors, assets, or behavior changed.
- [x] Maintainers may modify the branch if needed.

The repository's `docs-editor` skill is not exposed in this environment, so I performed a manual editorial review of the four-line README diff.