### PR TITLE
Fix deployment manager env-var detection

### DIFF
--- a/examples/agents_sdk/deployment_manager/app/project_inspector.py
+++ b/examples/agents_sdk/deployment_manager/app/project_inspector.py
@@ -11,7 +11,7 @@ from .models import Project
 
 ENV_PATTERN = re.compile(r"os\.environ\.(?:get|__getitem__)\(\s*[\"']([A-Z0-9_]+)[\"']")
 ENV_SUBSCRIPT_PATTERN = re.compile(
-    r"os\.environ\[\s*[\"']([A-Z0-9_]+)[\"']\s*\]"
+    r"os\.environ\s*\[\s*[\"']([A-Z0-9_]+)[\"']\s*\]"
 )
 GETENV_PATTERN = re.compile(r"os\.getenv\(\s*[\"']([A-Z0-9_]+)[\"']")
 PORT_PATTERN = re.compile(r"os\.environ\.get\(\s*[\"']PORT[\"']\s*,\s*[\"'](\d+)[\"']")

--- a/examples/agents_sdk/deployment_manager/app/project_inspector.py
+++ b/examples/agents_sdk/deployment_manager/app/project_inspector.py
@@ -10,6 +10,9 @@ from .models import Project
 
 
 ENV_PATTERN = re.compile(r"os\.environ\.(?:get|__getitem__)\(\s*[\"']([A-Z0-9_]+)[\"']")
+ENV_SUBSCRIPT_PATTERN = re.compile(
+    r"os\.environ\[\s*[\"']([A-Z0-9_]+)[\"']\s*\]"
+)
 GETENV_PATTERN = re.compile(r"os\.getenv\(\s*[\"']([A-Z0-9_]+)[\"']")
 PORT_PATTERN = re.compile(r"os\.environ\.get\(\s*[\"']PORT[\"']\s*,\s*[\"'](\d+)[\"']")
 
@@ -39,6 +42,7 @@ def _find_env_vars(files: list[Path]) -> tuple[list[str], list[str]]:
     for path in files:
         text = _read(path)
         names.update(ENV_PATTERN.findall(text))
+        names.update(ENV_SUBSCRIPT_PATTERN.findall(text))
         names.update(GETENV_PATTERN.findall(text))
     optional = {"HOST", "PORT", "SANDBOX_BACKEND", "SANDBOX_IMAGE"}
     manager = {

--- a/examples/agents_sdk/deployment_manager/tests/test_project_inspector.py
+++ b/examples/agents_sdk/deployment_manager/tests/test_project_inspector.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from app.project_inspector import inspect_project
+
+
+class ProjectInspectorTests(TestCase):
+    def test_detects_required_os_environ_subscript(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            project_path = Path(temp_dir)
+            (project_path / "main.py").write_text(
+                "import os\n"
+                "service_token = os.environ[\"SERVICE_TOKEN\"]\n"
+                "service_region = os.environ['SERVICE_REGION']\n",
+                encoding="utf-8",
+            )
+
+            project = inspect_project(str(project_path))
+
+        self.assertEqual(
+            project.required_env,
+            ["SERVICE_REGION", "SERVICE_TOKEN"],
+        )


### PR DESCRIPTION
## Summary

- Detect required environment variables accessed with the standard `os.environ["KEY"]` subscript syntax.
- Preserve the existing handling for `os.environ.get(...)`, `os.environ.__getitem__(...)`, and `os.getenv(...)`.
- Add a regression test covering both single- and double-quoted `os.environ[...]` access.

## Motivation

`project_inspector.py` scans project entrypoints to populate `Project.required_env`, but its existing regexes do not match normal subscript access such as:

```python
service_token = os.environ["SERVICE_TOKEN"]
```

That syntax raises at runtime when the variable is absent, so the deployment manager should report it as a required environment variable. Missing it can produce an incomplete deployment requirements summary before launch.

## Validation

Ran the added regression test with the standard library test runner:

```text
python -m unittest discover -s tests -v

test_detects_required_os_environ_subscript ... ok

Ran 1 test in 0.001s
OK
```

Also checked the new regex against double quotes, single quotes, and valid whitespace before the subscript.

## Self-review

- [x] Change is limited to environment-variable discovery.
- [x] No dependency or runtime API changes.
- [x] Existing optional/manager environment filtering remains unchanged.
- [x] Added regression coverage for the previously missed syntax.
- [x] Searched open PRs for an existing deployment-manager environment-scanner fix and found none.

Maintainers may modify the branch if needed.