### PR TITLE
Fail deployment starts that never become ready

### DIFF
--- a/examples/agents_sdk/deployment_manager/app/runner.py
+++ b/examples/agents_sdk/deployment_manager/app/runner.py
@@ -227,7 +227,14 @@ def start_local_process(
                 or "process exited before listening"
             )
         time.sleep(0.25)
-    return deployment
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    raise RuntimeError(
+        read_log(str(log_path), limit=12000)
+        or f"process did not listen on port {deployment.port} before startup timeout"
+    )
 
 
 def start_local_docker(
@@ -364,7 +371,12 @@ def start_local_docker(
                 or "container exited before listening"
             )
         time.sleep(0.25)
-    return deployment
+    failure_log = read_deployment_log(deployment, limit=12000)
+    _remove_managed_container(deployment.container_id, deployment.id)
+    raise RuntimeError(
+        failure_log
+        or f"container did not listen on port {deployment.port} before startup timeout"
+    )
 
 
 def stop_local_process(deployment: Deployment) -> Deployment:

--- a/examples/agents_sdk/deployment_manager/tests/test_runner.py
+++ b/examples/agents_sdk/deployment_manager/tests/test_runner.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from app.models import Deployment, Project
+from app.runner import start_local_docker, start_local_process
+
+
+class RunnerReadinessTests(unittest.TestCase):
+    def _project(self, path: str) -> Project:
+        return Project(
+            id="project-1",
+            name="demo",
+            path=path,
+            run_command=["python", "main.py"],
+        )
+
+    def test_local_process_timeout_fails_and_terminates_process(self) -> None:
+        process = Mock(pid=4321)
+        process.poll.return_value = None
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch(
+            "app.runner._port_is_open", return_value=False
+        ), patch("app.runner.subprocess.Popen", return_value=process), patch(
+            "app.runner.time.sleep"
+        ), patch("app.runner.os.killpg") as killpg:
+            deployment = Deployment(
+                id="dep-1",
+                project_id="project-1",
+                name="demo",
+                target="local-process",
+                port=8123,
+            )
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "process did not listen on port 8123 before startup timeout",
+            ):
+                start_local_process(Path(tmpdir), self._project(tmpdir), deployment)
+
+        killpg.assert_called_once_with(4321, 15)
+
+    def test_local_docker_timeout_fails_and_removes_container(self) -> None:
+        build = subprocess.CompletedProcess(["docker"], 0, stdout="", stderr="")
+        run = subprocess.CompletedProcess(
+            ["docker"], 0, stdout="container-id\n", stderr=""
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch(
+            "app.runner._port_is_open", return_value=False
+        ), patch("app.runner.ensure_dockerfile", return_value=Path(tmpdir) / "Dockerfile"), patch(
+            "app.runner._docker_output", side_effect=[build, run]
+        ), patch("app.runner._container_is_running", return_value=True), patch(
+            "app.runner.read_deployment_log", return_value=""
+        ), patch("app.runner._remove_managed_container") as remove_container, patch(
+            "app.runner.time.sleep"
+        ):
+            deployment = Deployment(
+                id="dep-2",
+                project_id="project-1",
+                name="demo",
+                target="local-docker",
+                port=8124,
+            )
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "container did not listen on port 8124 before startup timeout",
+            ):
+                start_local_docker(Path(tmpdir), self._project(tmpdir), deployment)
+
+        remove_container.assert_any_call("container-id", "dep-2")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Treat a local process as failed if it stays alive but never opens its configured port within the startup window.
- Treat a Docker deployment as failed if the container stays alive but never opens its configured port within the startup window.
- Clean up the still-running process/container before propagating the startup failure.
- Add regression tests for both execution paths.

## Motivation

Both startup functions currently return the deployment after their readiness loops expire, even when the application never starts listening. Because the deployment is already marked `running`, the API can report a successful deployment whose application endpoint is unreachable.

A process or container remaining alive is not sufficient evidence that the managed application is ready. The existing caller already converts `RuntimeError` into `status="failed"`, so these timeout paths should fail explicitly instead of returning a false success.

## Validation

Ran the added standard-library tests locally with the branch logic:

```text
test_local_docker_timeout_fails_and_removes_container ... ok
test_local_process_timeout_fails_and_terminates_process ... ok

Ran 2 tests in 0.005s
OK
```

The tests verify that a never-ready process raises and receives `SIGTERM`, and that a never-ready container raises and is removed.

## Self-review

- [x] Change is limited to deployment readiness timeout handling.
- [x] Existing successful and early-exit paths are unchanged.
- [x] No new dependencies.
- [x] Added regression coverage for local-process and local-docker targets.
- [x] Searched open PRs for a deployment-manager readiness timeout fix and found none.

Maintainers may modify the branch if needed.