### PR TITLE
Validate deployment manager port ranges

### DIFF
--- a/examples/agents_sdk/deployment_manager/app/models.py
+++ b/examples/agents_sdk/deployment_manager/app/models.py
@@ -18,7 +18,7 @@ class CreateDeploymentRequest(BaseModel):
     project_id: str
     name: str | None = None
     target: Literal["local-process", "local-docker"] = "local-docker"
-    port: int | None = None
+    port: int | None = Field(default=None, ge=1, le=65535)
     sandbox_backend: str = "docker"
 
 
@@ -31,7 +31,7 @@ class Project(BaseModel):
     executor_entrypoint: str | None = None
     run_command: list[str] = Field(default_factory=list)
     app_url: str | None = None
-    port: int = 8421
+    port: int = Field(default=8421, ge=1, le=65535)
     package_manager: str = "uv"
     dependencies: list[str] = Field(default_factory=list)
     required_env: list[str] = Field(default_factory=list)
@@ -49,7 +49,7 @@ class Deployment(BaseModel):
     name: str
     target: Literal["local-process", "local-docker"]
     status: Literal["draft", "starting", "running", "stopped", "failed"] = "draft"
-    port: int = 8421
+    port: int = Field(default=8421, ge=1, le=65535)
     sandbox_backend: str = "docker"
     requires_docker_socket: bool = False
     process_pid: int | None = None

--- a/examples/agents_sdk/deployment_manager/tests/test_models.py
+++ b/examples/agents_sdk/deployment_manager/tests/test_models.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import unittest
+
+from pydantic import ValidationError
+
+from app.models import CreateDeploymentRequest, Deployment, Project
+
+
+class PortValidationTests(unittest.TestCase):
+    def test_rejects_ports_outside_tcp_range(self) -> None:
+        for port in (-1, 0, 65536, 70000):
+            with self.subTest(port=port), self.assertRaises(ValidationError):
+                CreateDeploymentRequest(project_id="project-1", port=port)
+
+            with self.subTest(project_port=port), self.assertRaises(ValidationError):
+                Project(id="project-1", name="demo", path="/tmp/demo", port=port)
+
+            with self.subTest(deployment_port=port), self.assertRaises(ValidationError):
+                Deployment(
+                    id="dep-1",
+                    project_id="project-1",
+                    name="demo",
+                    target="local-process",
+                    port=port,
+                )
+
+    def test_accepts_tcp_port_boundaries(self) -> None:
+        for port in (1, 65535):
+            with self.subTest(port=port):
+                request = CreateDeploymentRequest(project_id="project-1", port=port)
+                self.assertEqual(request.port, port)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Reject deployment ports below `1` or above `65535` at the Pydantic model boundary.
- Apply the same TCP port constraint to imported projects, deployment creation requests, and stored deployment records.
- Add regression tests for invalid values and the valid boundary ports.

## Motivation

`CreateDeploymentRequest.port`, `Project.port`, and `Deployment.port` currently accept any integer. Values such as `0`, `-1`, or `70000` can therefore reach socket checks, application startup, and Docker `-p` arguments before failing later with less useful runtime errors.

Validating the TCP port range when the model is created keeps invalid deployment configuration out of the runtime path and gives the API an immediate validation error.

## Validation

Ran the added tests locally:

```text
test_accepts_tcp_port_boundaries ... ok
test_rejects_ports_outside_tcp_range ... ok

Ran 2 tests in 0.001s
OK
```

The tests cover `-1`, `0`, `65536`, and `70000`, plus the valid boundaries `1` and `65535`.

## Self-review

- [x] Change is limited to port validation in the deployment-manager models.
- [x] No runtime behavior changes for valid ports.
- [x] No new dependencies.
- [x] Added regression coverage.
- [x] Searched open PRs for an existing deployment-manager port validation fix and found none.

Maintainers may modify the branch if needed.