### PR TITLE
Harden deployment manager health probe

### DIFF
--- a/examples/agents_sdk/deployment_manager/scripts/local_deploy.py
+++ b/examples/agents_sdk/deployment_manager/scripts/local_deploy.py
@@ -192,10 +192,19 @@ def wait_for_app(app_url: str) -> None:
 
 def api_ok(manager_url: str) -> bool:
     try:
-        payload = get_json(manager_url, "/api/health")
-    except urllib.error.URLError:
+        payload = json.loads(
+            request(f"{manager_url}/api/health", timeout=1).decode("utf-8")
+        )
+    except (
+        urllib.error.URLError,
+        TimeoutError,
+        http.client.HTTPException,
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ):
         return False
-    return payload.get("ok") == "true"
+    return isinstance(payload, dict) and payload.get("ok") == "true"
 
 
 def get_json(base_url: str, path: str) -> dict[str, Any]:

--- a/examples/agents_sdk/deployment_manager/tests/test_local_deploy.py
+++ b/examples/agents_sdk/deployment_manager/tests/test_local_deploy.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from scripts.local_deploy import api_ok
+
+
+class ManagerHealthProbeTests(unittest.TestCase):
+    @patch("scripts.local_deploy.request", return_value=b'{"ok":"true"}')
+    def test_api_ok_uses_short_probe_timeout(self, request_mock) -> None:
+        self.assertTrue(api_ok("http://127.0.0.1:8732"))
+        request_mock.assert_called_once_with(
+            "http://127.0.0.1:8732/api/health", timeout=1
+        )
+
+    @patch("scripts.local_deploy.request", side_effect=TimeoutError)
+    def test_api_ok_returns_false_on_timeout(self, _request_mock) -> None:
+        self.assertFalse(api_ok("http://127.0.0.1:8732"))
+
+    @patch("scripts.local_deploy.request", return_value=b"not-json")
+    def test_api_ok_returns_false_on_invalid_json(self, _request_mock) -> None:
+        self.assertFalse(api_ok("http://127.0.0.1:8732"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Make the deployment CLI health probe return `False` for timeouts, malformed JSON, invalid UTF-8, and other normal connection failures instead of raising.
- Use a 1-second timeout for `/api/health` probes so startup/retry checks do not inherit the general 10-second request timeout.
- Add regression tests for healthy, timed-out, and malformed responses.

## Motivation

`local_deploy.py` uses `api_ok()` both before starting the manager and while waiting for it to become healthy. The current implementation only catches `URLError`, while JSON decoding failures and socket timeouts can escape and terminate the deployment command. It also uses the generic 10-second request timeout for a lightweight readiness probe.

A health probe should be a bounded Boolean check. Unhealthy or malformed responses should cause the existing startup/retry path to continue rather than crash the CLI.

## Validation

Validated the three regression cases locally:

```text
healthy response -> True
TimeoutError -> False
invalid JSON -> False
```

The healthy-path test also verifies that `/api/health` is called with `timeout=1`.

## Self-review

- [x] Change is limited to manager health probing.
- [x] Normal API requests retain their existing timeout behavior.
- [x] No new dependencies.
- [x] Added regression coverage for the new failure handling.
- [x] Searched open PRs for an existing `local_deploy` health-probe fix and found none.

Maintainers may modify the branch if needed.