### PR TITLE
Reject future-dated commerce approvals

### DIFF
--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/src/agentic_commerce/policy.py
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/src/agentic_commerce/policy.py
@@ -192,6 +192,12 @@ class PolicyEngine:
                 "A human approval grant is required above the threshold.",
                 requires_human_approval=True,
             )
+        if now < approval.approved_at:
+            return self._deny(
+                "approval_not_yet_valid",
+                "The human approval grant is not yet valid.",
+                requires_human_approval=True,
+            )
         if now >= approval.expires_at:
             return self._deny(
                 "approval_expired",

--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/tests/test_policy_approval_time.py
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/tests/test_policy_approval_time.py
@@ -1,0 +1,71 @@
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from agentic_commerce.models import ApprovalGrant, CommercePolicy, PurchaseRequest
+from agentic_commerce.policy import PolicyEngine
+
+NOW = datetime(2026, 8, 21, 8, 0, tzinfo=UTC)
+
+
+def _policy() -> PolicyEngine:
+    return PolicyEngine(
+        CommercePolicy(
+            allowed_merchants=frozenset({"merchant.invalid"}),
+            allowed_purposes=frozenset({"supplier_due_diligence"}),
+            per_request_limit=Decimal("0.50"),
+            per_run_limit=Decimal("1.00"),
+            approval_threshold=Decimal("0.10"),
+            session_expires_at=NOW + timedelta(minutes=15),
+        )
+    )
+
+
+def _request() -> PurchaseRequest:
+    return PurchaseRequest(
+        request_id="request-001",
+        resource_url="https://merchant.invalid/report",
+        purpose="supplier_due_diligence",
+        idempotency_key="purchase-001",
+    )
+
+
+def _approval(request: PurchaseRequest, *, approved_at: datetime) -> ApprovalGrant:
+    return ApprovalGrant(
+        approval_id="approval-001",
+        request_id=request.request_id,
+        resource_url=request.resource_url,
+        purpose=request.purpose,
+        maximum_amount=Decimal("0.25"),
+        approved_by="synthetic-reviewer",
+        approved_at=approved_at,
+        expires_at=NOW + timedelta(minutes=10),
+    )
+
+
+def _authorize(approved_at: datetime):
+    request = _request()
+    return _policy().authorize_challenge(
+        request,
+        merchant_domain="merchant.invalid",
+        network="eip155:84532",
+        currency="USDC",
+        amount=Decimal("0.25"),
+        approval=_approval(request, approved_at=approved_at),
+        expires_at=NOW + timedelta(minutes=5),
+        now=NOW,
+    )
+
+
+def test_future_dated_approval_is_denied() -> None:
+    decision = _authorize(NOW + timedelta(seconds=1))
+
+    assert decision.allowed is False
+    assert decision.code == "approval_not_yet_valid"
+    assert decision.requires_human_approval is True
+
+
+def test_approval_becomes_valid_at_approved_at() -> None:
+    decision = _authorize(NOW)
+
+    assert decision.allowed is True
+    assert decision.code == "authorized"


### PR DESCRIPTION
## Summary

- Reject human approval grants whose `approved_at` timestamp is later than the authorization time.
- Preserve the existing expiration, scope, currency, and amount checks.
- Add focused regression coverage for a future-dated grant and the exact `approved_at` boundary.

## Motivation

The controlled-commerce example treats `ApprovalGrant` as time-bounded authority, but the current validator only checks the upper bound (`expires_at`). A grant dated in the future can therefore authorize a purchase before the recorded human approval time.

The valid interval should begin at `approved_at` and end before `expires_at`. Failing closed on a future-dated grant keeps the application-owned authorization boundary consistent for both the local synthetic flow and the AgentCore path, which share `PolicyEngine`.

## Validation

Added focused tests covering:

- `approved_at > now` -> denied with `approval_not_yet_valid`
- `approved_at == now` -> authorization remains valid

The diff is limited to the shared policy validator and one regression-test file. No network, payment-provider, wallet, or live AgentCore calls are involved.

I could not execute the repository's full `uv` test environment from this connector-backed session, so upstream CI remains the execution check for this PR.

## Self-review

- [x] Change is limited to human-approval validity timing.
- [x] Existing expiration, request binding, currency, and amount checks remain unchanged.
- [x] No dependency, notebook, registry, or documentation changes.
- [x] Added deterministic regression coverage for both sides of the new boundary.
- [x] Searched open PRs for an existing future-approval timestamp fix and found none.

Maintainers may modify the branch if needed.