### PR TITLE
Validate commerce settlement network

### DIFF
--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/src/agentic_commerce/application.py
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/src/agentic_commerce/application.py
@@ -150,6 +150,7 @@ class CommerceApplication:
         if (
             not settlement.success
             or settlement.transaction != authorization.receipt.transaction
+            or settlement.network != authorization.receipt.network
         ):
             raise ProtocolError(
                 "settlement_receipt_mismatch",

--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/tests/test_settlement_network.py
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/tests/test_settlement_network.py
@@ -1,0 +1,64 @@
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from agentic_commerce.application import CommerceApplication
+from agentic_commerce.errors import ProtocolError
+from agentic_commerce.merchant import RESOURCE_URL, SyntheticMerchant
+from agentic_commerce.models import ApprovalGrant, CommercePolicy, PurchaseRequest
+from agentic_commerce.payments import LocalPaymentProcessor
+from agentic_commerce.policy import PolicyEngine
+
+NOW = datetime(2026, 8, 21, 8, 0, tzinfo=UTC)
+
+
+def test_settlement_network_must_match_local_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payments = LocalPaymentProcessor()
+    merchant = SyntheticMerchant(payments, price=Decimal("0.25"), now=NOW)
+    policy = PolicyEngine(
+        CommercePolicy(
+            allowed_merchants=frozenset({"merchant.invalid"}),
+            allowed_purposes=frozenset({"supplier_due_diligence"}),
+            per_request_limit=Decimal("0.50"),
+            per_run_limit=Decimal("1.00"),
+            approval_threshold=Decimal("0.10"),
+            session_expires_at=NOW + timedelta(minutes=15),
+        )
+    )
+    app = CommerceApplication(
+        client=merchant.client(),
+        policy=policy,
+        payments=payments,
+    )
+    request = PurchaseRequest(
+        request_id="request-001",
+        resource_url=RESOURCE_URL,
+        purpose="supplier_due_diligence",
+        idempotency_key="purchase-001",
+    )
+    approval = ApprovalGrant(
+        approval_id="approval-001",
+        request_id=request.request_id,
+        resource_url=request.resource_url,
+        purpose=request.purpose,
+        maximum_amount=Decimal("0.25"),
+        approved_by="synthetic-reviewer",
+        approved_at=NOW,
+        expires_at=NOW + timedelta(minutes=10),
+    )
+
+    original_verify = payments.verify
+
+    def verify_with_wrong_network(proof_header: str, requirement):
+        settlement = original_verify(proof_header, requirement)
+        return settlement.model_copy(update={"network": "eip155:1"})
+
+    monkeypatch.setattr(payments, "verify", verify_with_wrong_network)
+
+    with pytest.raises(ProtocolError) as exc_info:
+        app.purchase(request, approval=approval, now=NOW)
+
+    assert exc_info.value.code == "settlement_receipt_mismatch"


### PR DESCRIPTION
## Summary

- Require the `PAYMENT-RESPONSE` network to match the network recorded in the local payment receipt.
- Keep the existing settlement success and transaction-ID checks unchanged.
- Add a regression test that returns the correct transaction on the wrong network and verifies the application fails closed.

## Motivation

The local controlled-commerce flow currently accepts a settlement response when `success=true` and the transaction ID matches the local receipt. `SettlementResponse` also carries a network, but that field is not compared with the authorized receipt.

A merchant response that reports the correct transaction identifier on a different network should not satisfy the receipt-integrity check. Binding the settlement response to the receipt's network keeps the returned evidence aligned with the network that application policy authorized.

## Validation

Added a deterministic regression test that:

- completes the normal local proof flow,
- changes only the returned settlement network,
- preserves the expected transaction ID,
- verifies the application raises `settlement_receipt_mismatch`.

The implementation diff is one added condition in `application.py` plus the focused test file. No live network, wallet, or AgentCore calls are involved.

I could not execute the repository's full `uv` test environment from this connector-backed session, so upstream CI remains the execution check for this PR.

## Self-review

- [x] Change is limited to settlement-to-receipt integrity validation.
- [x] Existing success and transaction checks remain intact.
- [x] No dependency, notebook, registry, or documentation changes.
- [x] Added deterministic negative-path coverage.
- [x] Searched open PRs for an existing settlement-network fix and found none.

Maintainers may modify the branch if needed.