### PR TITLE
Reject future-issued commerce challenges

### DIFF
--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/src/agentic_commerce/policy.py
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/src/agentic_commerce/policy.py
@@ -92,6 +92,7 @@ class PolicyEngine:
             currency=requirement.currency,
             amount=amount,
             approval=approval,
+            issued_at=requirement.extra.issued_at,
             expires_at=requirement.expires_at,
             now=now,
         )
@@ -105,6 +106,7 @@ class PolicyEngine:
         currency: str,
         amount: Decimal,
         approval: ApprovalGrant | None,
+        issued_at: datetime | None = None,
         expires_at: datetime | None = None,
         now: datetime | None = None,
     ) -> AuthorizationDecision:
@@ -129,6 +131,11 @@ class PolicyEngine:
             return self._deny(
                 "currency_not_allowed",
                 "The payment currency is outside the configured policy.",
+            )
+        if issued_at is not None and now < issued_at:
+            return self._deny(
+                "challenge_not_yet_valid",
+                "The merchant payment challenge is not yet valid.",
             )
         if expires_at is not None and now >= expires_at:
             return self._deny(

--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/tests/test_policy_challenge_time.py
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/tests/test_policy_challenge_time.py
@@ -1,0 +1,57 @@
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from agentic_commerce.models import CommercePolicy, PurchaseRequest
+from agentic_commerce.policy import PolicyEngine
+
+NOW = datetime(2026, 8, 21, 8, 0, tzinfo=UTC)
+
+
+def _engine() -> PolicyEngine:
+    return PolicyEngine(
+        CommercePolicy(
+            allowed_merchants=frozenset({"merchant.invalid"}),
+            allowed_purposes=frozenset({"supplier_due_diligence"}),
+            per_request_limit=Decimal("0.50"),
+            per_run_limit=Decimal("1.00"),
+            approval_threshold=Decimal("0.10"),
+            session_expires_at=NOW + timedelta(minutes=15),
+        )
+    )
+
+
+def _request() -> PurchaseRequest:
+    return PurchaseRequest(
+        request_id="request-001",
+        resource_url="https://merchant.invalid/report",
+        purpose="supplier_due_diligence",
+        idempotency_key="purchase-001",
+    )
+
+
+def _authorize(issued_at: datetime):
+    return _engine().authorize_challenge(
+        _request(),
+        merchant_domain="merchant.invalid",
+        network="eip155:84532",
+        currency="USDC",
+        amount=Decimal("0.05"),
+        approval=None,
+        issued_at=issued_at,
+        expires_at=NOW + timedelta(minutes=5),
+        now=NOW,
+    )
+
+
+def test_future_issued_challenge_is_denied() -> None:
+    decision = _authorize(NOW + timedelta(seconds=1))
+
+    assert decision.allowed is False
+    assert decision.code == "challenge_not_yet_valid"
+
+
+def test_challenge_becomes_valid_at_issued_at() -> None:
+    decision = _authorize(NOW)
+
+    assert decision.allowed is True
+    assert decision.code == "authorized"


### PR DESCRIPTION
## Summary

- Treat x402 challenges whose optional `issuedAt` timestamp is later than the authorization clock as not yet valid.
- Pass the validated local challenge `issuedAt` value into the shared policy authorization path.
- Preserve the existing expiry, merchant, network, currency, amount, budget, and approval checks.
- Add regression coverage for a future-issued challenge and the exact issuance boundary.

## Motivation

The local x402 challenge contract already validates `issuedAt` as a timezone-aware timestamp, but `PolicyEngine` only enforces the upper time bound (`expiresAt`). A merchant challenge can therefore state that it was issued in the future and still be authorized immediately.

When `issuedAt` is present, the authorization interval should not begin before that timestamp. Failing closed here keeps the deterministic policy layer aligned with the challenge metadata it already parses and validates.

## Validation

Added deterministic tests covering:

- `issued_at > now` -> denied with `challenge_not_yet_valid`
- `issued_at == now` -> authorization remains valid

The implementation is limited to seven added lines in `policy.py` plus the focused test file. No live merchant, wallet, network, or AgentCore calls are involved.

I could not execute the repository's full `uv` test environment from this connector-backed session, so upstream CI remains the execution check for this PR.

## Self-review

- [x] Change is limited to challenge issuance-time validation.
- [x] Existing expiry and policy boundaries remain unchanged.
- [x] `issuedAt` remains optional; challenges without it preserve current behavior.
- [x] No dependency, notebook, registry, or documentation changes.
- [x] Searched open PRs for an existing future-issued challenge fix and found none.

Maintainers may modify the branch if needed.