### PR TITLE
Keep realtime PCM16 chunks sample-aligned

### DIFF
--- a/examples/evals/realtime_evals/shared/realtime_harness_utils.py
+++ b/examples/evals/realtime_evals/shared/realtime_harness_utils.py
@@ -56,9 +56,10 @@ def audio_format_config(audio_format: str, sample_rate_hz: int) -> Dict[str, Any
 def compute_bytes_per_chunk(
     sample_rate_hz: int, chunk_ms: int, bytes_per_sample: int
 ) -> int:
-    # Ensure we always send at least one byte even for tiny chunk sizes.
-    computed = int(sample_rate_hz * (chunk_ms / 1000.0) * bytes_per_sample)
-    return max(1, computed)
+    # Keep chunk boundaries on complete samples so multi-byte formats such as
+    # PCM16 are never split between append events.
+    samples_per_chunk = max(1, int(sample_rate_hz * (chunk_ms / 1000.0)))
+    return samples_per_chunk * bytes_per_sample
 
 
 def chunk_audio_bytes(audio_bytes: bytes, bytes_per_chunk: int) -> List[bytes]:

--- a/examples/evals/realtime_evals/tests/test_audio_chunk_alignment.py
+++ b/examples/evals/realtime_evals/tests/test_audio_chunk_alignment.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from shared.realtime_harness_utils import compute_bytes_per_chunk
+
+
+def test_pcm16_chunk_size_stays_sample_aligned() -> None:
+    bytes_per_chunk = compute_bytes_per_chunk(
+        sample_rate_hz=44_100,
+        chunk_ms=15,
+        bytes_per_sample=2,
+    )
+
+    assert bytes_per_chunk == 1_322
+    assert bytes_per_chunk % 2 == 0
+
+
+def test_single_byte_formats_keep_expected_chunk_size() -> None:
+    assert compute_bytes_per_chunk(8_000, 15, 1) == 120


### PR DESCRIPTION
## Summary

- Compute realtime audio chunk sizes in whole samples instead of truncating the final byte count.
- Prevent multi-byte formats such as PCM16 from splitting one sample across adjacent append events.
- Add a regression case for 44.1 kHz audio with 15 ms chunks, where the previous calculation produced an odd 1,323-byte PCM16 chunk.

## Motivation

`compute_bytes_per_chunk()` currently calculates the total byte count and truncates that value directly. For PCM16, some valid sample-rate/chunk-duration combinations therefore produce an odd number of bytes. A 44.1 kHz, 15 ms chunk is one example:

```text
44,100 * 0.015 * 2 = 1,323 bytes
```

PCM16 samples are two bytes each, so a 1,323-byte boundary splits a sample across two Realtime `input_audio_buffer.append` events.

Computing the number of complete samples first and then multiplying by the sample width preserves sample boundaries while leaving single-byte formats unchanged.

## Validation

Focused regression checks:

```text
44.1 kHz, 15 ms, PCM16 -> 1,322 bytes and divisible by 2
8 kHz, 15 ms, 1-byte format -> 120 bytes
```

The implementation changes four lines in the shared helper and adds a small pure-function test file. No API calls are required.

## Self-review

- [x] Patch is limited to realtime chunk-size calculation.
- [x] Existing 1-byte G.711 chunk sizing is unchanged.
- [x] No dependencies, notebooks, registry entries, or docs changed.
- [x] Added deterministic regression coverage.
- [x] Searched open PRs for an existing PCM16 chunk-alignment fix and found none.

Maintainers may modify the branch if needed.