### PR TITLE
Reject fractional integers in realtime eval output validation

### DIFF
--- a/examples/evals/realtime_evals/shared/scripts/validate_eval_output.py
+++ b/examples/evals/realtime_evals/shared/scripts/validate_eval_output.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from numbers import Integral
 from pathlib import Path
 from typing import Mapping
 
@@ -58,10 +59,23 @@ def _string_value(
     return value
 
 
+def _integer_value(value: object) -> int:
+    if isinstance(value, bool):
+        raise ValueError("boolean is not an integer field value")
+    if isinstance(value, Integral):
+        return int(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(value.strip())
+        except ValueError as exc:
+            raise ValueError("string does not contain an integer") from exc
+    raise ValueError("value is not an integer")
+
+
 def _required_intish(summary: Mapping[str, object], key: str, summary_path: Path) -> int:
     try:
-        return int(summary.get(key, 0))
-    except (TypeError, ValueError) as exc:
+        return _integer_value(summary.get(key))
+    except ValueError as exc:
         raise ValueError(f"`{key}` must be an integer in {summary_path}.") from exc
 
 
@@ -229,8 +243,8 @@ def _validate_run_results(results: pd.DataFrame, results_path: Path) -> None:
         row_number = row_index + 2
         row_status = str(row.get("status", "")).strip()
         try:
-            int(row.get("turn_index", ""))
-        except (TypeError, ValueError) as exc:
+            _integer_value(row.get("turn_index", ""))
+        except ValueError as exc:
             raise ValueError(
                 f"`turn_index` in results row {row_number} must be an integer."
             ) from exc

--- a/examples/evals/realtime_evals/tests/test_output_integer_validation.py
+++ b/examples/evals/realtime_evals/tests/test_output_integer_validation.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from shared.scripts.validate_eval_output import _required_intish, _validate_run_results
+
+
+def test_summary_integer_field_rejects_fractional_float(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="sample_rate_hz.*must be an integer"):
+        _required_intish(
+            {"sample_rate_hz": 24_000.5},
+            "sample_rate_hz",
+            tmp_path / "summary.json",
+        )
+
+
+def test_summary_integer_field_accepts_integer_string(tmp_path: Path) -> None:
+    assert (
+        _required_intish(
+            {"sample_rate_hz": "24000"},
+            "sample_rate_hz",
+            tmp_path / "summary.json",
+        )
+        == 24_000
+    )
+
+
+def test_run_turn_index_rejects_fractional_float(tmp_path: Path) -> None:
+    results = pd.DataFrame(
+        [
+            {
+                "simulation_id": "sim-1",
+                "assistant_model": "assistant-model",
+                "simulator_model": "simulator-model",
+                "turn_index": 1.5,
+                "user_text": "hello",
+                "assistant_text": "hi",
+                "tool_calls": "[]",
+                "tool_outputs": "[]",
+                "user_audio_path": "",
+                "assistant_audio_path": "",
+                "event_log_path": "",
+                "status": "failed",
+            }
+        ]
+    )
+
+    with pytest.raises(ValueError, match="turn_index.*must be an integer"):
+        _validate_run_results(results, tmp_path / "results.csv")


### PR DESCRIPTION
## Summary

- Stop coercing arbitrary numeric values with `int(...)` when validating integer fields in realtime eval output.
- Reject fractional floats and booleans for integer metadata while retaining integer and integer-string compatibility.
- Apply the same strict check to `turn_index` rows.
- Add focused regression tests.

## Motivation

The output validator currently uses `int(value)` for fields that are required to be integers. In Python, that silently truncates floats:

```python
int(24000.5) == 24000
int(1.5) == 1
```

As a result, malformed `summary.json` metadata such as a fractional sample rate, and malformed `results.csv` rows with a fractional turn index, can pass validation after being changed to a different value.

A validator should reject malformed data rather than normalize it silently. This patch accepts actual integral values and integer strings, but fails closed on fractional floats and booleans.

## Validation

Added regression coverage for:

- `sample_rate_hz=24000.5` -> rejected
- `sample_rate_hz="24000"` -> accepted as `24000`
- `turn_index=1.5` -> rejected

No API calls or external services are involved.

## Self-review

- [x] Change is limited to realtime eval output integer validation.
- [x] Existing integer-string compatibility is preserved.
- [x] No notebook, dependency, registry, or documentation changes.
- [x] Added deterministic regression coverage.
- [x] Searched open PRs for an existing strict-integer output validation fix and found none.

Maintainers may modify the branch if needed.