### PR TITLE
Require file paths in realtime eval input validation

### DIFF
--- a/examples/evals/realtime_evals/shared/scripts/validate_eval_input.py
+++ b/examples/evals/realtime_evals/shared/scripts/validate_eval_input.py
@@ -105,8 +105,8 @@ def validate_walk_input(data_path: Path) -> None:
                 f"`audio_path` in row {row_index + 2} of {data_path} must be non-empty."
             )
         audio_path = resolve_path(audio_path_value, data_path.parent)
-        if not audio_path.exists():
-            raise ValueError(f"Audio file does not exist: {audio_path}")
+        if not audio_path.is_file():
+            raise ValueError(f"Audio path is not a file: {audio_path}")
         read_ulaw_wav(audio_path, EXPECTED_WALK_SAMPLE_RATE_HZ)
 
 
@@ -145,8 +145,8 @@ def _validate_run_simulation_file(
         ),
         ROOT_DIR,
     )
-    if not prompt_path.exists():
-        raise ValueError(f"Assistant system prompt file does not exist: {prompt_path}")
+    if not prompt_path.is_file():
+        raise ValueError(f"Assistant system prompt path is not a file: {prompt_path}")
 
     tools_path = resolve_path(
         _require_non_empty_string(
@@ -156,8 +156,8 @@ def _validate_run_simulation_file(
         ),
         ROOT_DIR,
     )
-    if not tools_path.exists():
-        raise ValueError(f"Assistant tools file does not exist: {tools_path}")
+    if not tools_path.is_file():
+        raise ValueError(f"Assistant tools path is not a file: {tools_path}")
 
     simulator_config = _coerce_mapping(
         simulation.get("simulator", {}),
@@ -258,9 +258,9 @@ def validate_run_input(data_path: Path) -> None:
     for row_index, row in simulation_index.iterrows():
         simulation_id = str(row["simulation_id"]).strip()
         simulation_path = resolve_path(str(row["simulation_path"]), data_path.parent)
-        if not simulation_path.exists():
+        if not simulation_path.is_file():
             raise ValueError(
-                f"`simulation_path` in row {row_index + 2} of {data_path} does not exist: "
+                f"`simulation_path` in row {row_index + 2} of {data_path} is not a file: "
                 f"{simulation_path}"
             )
         _validate_run_simulation_file(

--- a/examples/evals/realtime_evals/tests/test_input_file_validation.py
+++ b/examples/evals/realtime_evals/tests/test_input_file_validation.py
@@ -1,0 +1,110 @@
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from shared.scripts import validate_eval_input as validator
+
+
+def _write_simulation(
+    path: Path,
+    *,
+    prompt_path: str,
+    tools_path: str,
+) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "simulation_id": "sim-1",
+                "scenario": "Synthetic validation scenario",
+                "assistant": {
+                    "system_prompt_file": prompt_path,
+                    "tools_file": tools_path,
+                },
+                "simulator": {"system_prompt": "Act as the synthetic user."},
+                "audio": {},
+                "turns": {"fixed_first_user_turn": "Hello"},
+                "tool_mocks": [],
+                "expected_tool_call": {},
+                "graders": {"turn_level": [], "trace_level": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_run_input_rejects_simulation_directory(tmp_path: Path) -> None:
+    simulation_dir = tmp_path / "simulation-dir"
+    simulation_dir.mkdir()
+    index_path = tmp_path / "simulations.csv"
+    pd.DataFrame(
+        [{"simulation_id": "sim-1", "simulation_path": "simulation-dir"}]
+    ).to_csv(index_path, index=False)
+
+    with pytest.raises(ValueError, match="simulation_path.*is not a file"):
+        validator.validate_run_input(index_path)
+
+
+def test_simulation_rejects_prompt_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(validator, "ROOT_DIR", tmp_path)
+    prompt_dir = tmp_path / "prompt-dir"
+    prompt_dir.mkdir()
+    (tmp_path / "tools.json").write_text("[]", encoding="utf-8")
+    simulation_path = tmp_path / "simulation.json"
+    _write_simulation(
+        simulation_path,
+        prompt_path="prompt-dir",
+        tools_path="tools.json",
+    )
+
+    with pytest.raises(ValueError, match="system prompt path is not a file"):
+        validator._validate_run_simulation_file(
+            simulation_path,
+            expected_simulation_id="sim-1",
+        )
+
+
+def test_simulation_rejects_tools_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(validator, "ROOT_DIR", tmp_path)
+    (tmp_path / "prompt.txt").write_text("System prompt", encoding="utf-8")
+    tools_dir = tmp_path / "tools-dir"
+    tools_dir.mkdir()
+    simulation_path = tmp_path / "simulation.json"
+    _write_simulation(
+        simulation_path,
+        prompt_path="prompt.txt",
+        tools_path="tools-dir",
+    )
+
+    with pytest.raises(ValueError, match="tools path is not a file"):
+        validator._validate_run_simulation_file(
+            simulation_path,
+            expected_simulation_id="sim-1",
+        )
+
+
+def test_walk_input_rejects_audio_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    audio_dir = tmp_path / "audio-dir"
+    audio_dir.mkdir()
+    monkeypatch.setattr(
+        validator,
+        "load_walk_dataset",
+        lambda _: pd.DataFrame(
+            [{"audio_path": str(audio_dir), "gt_tool_call_arg": ""}]
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Audio path is not a file"):
+        validator.validate_walk_input(tmp_path / "data.csv")


### PR DESCRIPTION
## Summary

- Require realtime eval input paths that are read as files to actually be files, not merely existing filesystem entries.
- Apply the check to walk-harness audio, run simulation JSON, assistant system prompts, and assistant tool definitions.
- Add focused regression tests for directory-valued paths.

## Motivation

The input validator currently uses `Path.exists()` for several paths that the harness later opens as files. A directory therefore passes validation and fails later in `read_text()`, `json.loads()`, WAV reading, or another file operation.

For example, a simulation entry can point `assistant.system_prompt_file` at an existing directory and pass the validator even though the harness cannot read it as a prompt file.

The validator should catch that contract violation itself and report the offending field before execution begins.

## Validation

Added deterministic tests covering directories supplied as:

- `simulation_path`
- `assistant.system_prompt_file`
- `assistant.tools_file`
- walk-harness `audio_path`

Each now fails with an explicit "is not a file" validation error.

## Self-review

- [x] Change is limited to realtime eval input path validation.
- [x] Existing valid file paths keep the same behavior.
- [x] No dependencies, notebooks, registry entries, or docs changed.
- [x] Added regression coverage for every changed path check.
- [x] Searched open PRs for an existing file-vs-directory validation fix and found none.

Maintainers may modify the branch if needed.