### PR TITLE
Validate deployment manager startup port

### DIFF
--- a/examples/agents_sdk/deployment_manager/scripts/start_manager.py
+++ b/examples/agents_sdk/deployment_manager/scripts/start_manager.py
@@ -6,10 +6,20 @@ import subprocess
 from pathlib import Path
 
 
+def _valid_port(value: str) -> int:
+    try:
+        port = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("port must be an integer") from exc
+    if not 1 <= port <= 65535:
+        raise argparse.ArgumentTypeError("port must be between 1 and 65535")
+    return port
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", default="127.0.0.1")
-    parser.add_argument("--port", default="8732")
+    parser.add_argument("--port", type=_valid_port, default=8732)
     parser.add_argument("--log-file", required=True)
     parser.add_argument("--pid-file", required=True)
     args = parser.parse_args()

--- a/examples/agents_sdk/deployment_manager/tests/test_start_manager.py
+++ b/examples/agents_sdk/deployment_manager/tests/test_start_manager.py
@@ -1,0 +1,23 @@
+import argparse
+import importlib.util
+from pathlib import Path
+from unittest import TestCase
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "start_manager.py"
+SPEC = importlib.util.spec_from_file_location("start_manager_script", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+start_manager = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(start_manager)
+
+
+class StartManagerTests(TestCase):
+    def test_valid_port_accepts_tcp_boundaries(self) -> None:
+        self.assertEqual(start_manager._valid_port("1"), 1)
+        self.assertEqual(start_manager._valid_port("65535"), 65535)
+
+    def test_valid_port_rejects_out_of_range_and_non_numeric_values(self) -> None:
+        for value in ("0", "65536", "not-a-port"):
+            with self.subTest(value=value):
+                with self.assertRaises(argparse.ArgumentTypeError):
+                    start_manager._valid_port(value)


### PR DESCRIPTION
## Summary

- Validate the Deployment Manager startup port before spawning the background process.
- Accept only integer TCP ports in the range `1..65535`.
- Add focused regression tests for valid boundaries, out-of-range values, and non-numeric input.

## Motivation

`start_manager.py` currently accepts `--port` as an unconstrained string and passes it directly through the `PORT` environment variable. Values such as `0`, `65536`, or `not-a-port` therefore launch the background process first and only fail later inside the application/runtime path.

The startup script should reject an invalid listen port before creating a process or writing a PID file. This gives users an immediate CLI error and avoids unnecessary failed background launches.

## Validation

Added standard-library `unittest` coverage for:

- `1` and `65535` -> accepted
- `0` and `65536` -> rejected
- non-numeric input -> rejected

The patch changes only the startup script plus its focused test file. No network or OpenAI API calls are involved.

## Self-review

- [x] Change is limited to manager startup port validation.
- [x] Existing default port `8732` remains unchanged.
- [x] No dependencies, notebooks, registry entries, or documentation changes.
- [x] Added deterministic regression coverage.
- [x] Searched open PRs for an existing `start_manager` port-validation fix and found none.

Maintainers may modify the branch if needed.