### PR TITLE
Reject inexact synthetic commerce prices

### DIFF
--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/src/agentic_commerce/merchant.py
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/src/agentic_commerce/merchant.py
@@ -22,6 +22,16 @@ PAYMENT_SIGNATURE_HEADER = "PAYMENT-SIGNATURE"
 PAYMENT_RESPONSE_HEADER = "PAYMENT-RESPONSE"
 
 RESOURCE_URL = "https://merchant.invalid/reports/SYNTH-SUPPLIER-RISK-001"
+USDC_ATOMIC_UNITS = Decimal(1_000_000)
+
+
+def _atomic_usdc_amount(price: Decimal) -> str:
+    if price <= 0:
+        raise ValueError("price must be positive")
+    atomic_amount = price * USDC_ATOMIC_UNITS
+    if atomic_amount != atomic_amount.to_integral_value():
+        raise ValueError("price must use at most 6 decimal places")
+    return str(int(atomic_amount))
 
 
 class SyntheticMerchant:
@@ -42,7 +52,7 @@ class SyntheticMerchant:
         self.malformed_challenge = malformed_challenge
         issued_at = now or datetime.now(UTC)
         expires_at = issued_at + timedelta(minutes=5)
-        amount = str(int(price * Decimal(1_000_000)))
+        amount = _atomic_usdc_amount(price)
 
         self.requirement = PaymentRequirement(
             amount=amount,

--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/tests/test_merchant_price_precision.py
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/tests/test_merchant_price_precision.py
@@ -1,0 +1,35 @@
+from decimal import Decimal
+
+import pytest
+
+from agentic_commerce.merchant import SyntheticMerchant
+from agentic_commerce.payments import LocalPaymentProcessor
+
+
+def test_synthetic_merchant_preserves_exact_usdc_atomic_amounts() -> None:
+    one_atomic_unit = SyntheticMerchant(
+        LocalPaymentProcessor(),
+        price=Decimal("0.000001"),
+    )
+    normal_price = SyntheticMerchant(
+        LocalPaymentProcessor(),
+        price=Decimal("0.25"),
+    )
+
+    assert one_atomic_unit.requirement.amount == "1"
+    assert normal_price.requirement.amount == "250000"
+
+
+@pytest.mark.parametrize("price", [Decimal("0"), Decimal("-0.01")])
+def test_synthetic_merchant_rejects_non_positive_prices(price: Decimal) -> None:
+    with pytest.raises(ValueError, match="price must be positive"):
+        SyntheticMerchant(LocalPaymentProcessor(), price=price)
+
+
+@pytest.mark.parametrize(
+    "price",
+    [Decimal("0.0000009"), Decimal("0.1234567")],
+)
+def test_synthetic_merchant_rejects_fractional_atomic_units(price: Decimal) -> None:
+    with pytest.raises(ValueError, match="at most 6 decimal places"):
+        SyntheticMerchant(LocalPaymentProcessor(), price=price)


### PR DESCRIPTION
## Summary

- Validate synthetic USDC prices before converting them to atomic units.
- Reject non-positive prices.
- Reject values that cannot be represented exactly with six USDC decimal places instead of silently truncating them.
- Add focused regression tests for exact, zero/negative, and over-precision values.

## Motivation

`SyntheticMerchant` currently converts a `Decimal` price with:

```python
str(int(price * Decimal(1_000_000)))
```

That silently truncates fractional atomic units. For example, `Decimal("0.0000009")` becomes `0`, creating a zero-value challenge, while `Decimal("0.1234567")` is rounded down to a different economic value.

This controlled-commerce example should fail closed rather than change a configured payment amount during conversion. The patch requires a positive price that maps exactly to USDC's six-decimal atomic representation.

## Validation

Added deterministic tests covering:

- `0.000001` -> `1` atomic unit
- `0.25` -> `250000` atomic units
- zero and negative prices -> rejected
- `0.0000009` and `0.1234567` -> rejected rather than truncated

No live merchant, wallet, network, or AgentCore calls are involved.

## Self-review

- [x] Change is limited to synthetic merchant price conversion.
- [x] Existing exactly representable positive prices preserve their behavior.
- [x] No dependencies, notebooks, registry entries, or documentation changes.
- [x] Added deterministic regression coverage.
- [x] Searched open PRs for an existing merchant price-precision fix and found none.

Maintainers may modify the branch if needed.