### PR TITLE
Fix repeated tool-call grading in realtime evals

### DIFF
--- a/examples/evals/realtime_evals/shared/graders.py
+++ b/examples/evals/realtime_evals/shared/graders.py
@@ -10,6 +10,7 @@ Design notes:
   core named graders in `DEFAULT_GRADER_FUNCTIONS`.
 """
 
+from collections import Counter
 import json
 import re
 import tempfile
@@ -324,7 +325,7 @@ def check_tool_call_names_correct(
     tool_calls: Sequence[ToolCallRecord | Mapping[str, Any]],
     expected_tool_names: Sequence[str],
 ) -> tuple[bool, str]:
-    """Deterministically verify that the set of called tool names matches."""
+    """Deterministically verify that the called tool-name multiset matches."""
 
     expected_names = [name.strip() for name in expected_tool_names if name.strip()]
     actual_names = [_tool_call_name(tool_call) for tool_call in tool_calls]
@@ -333,7 +334,7 @@ def check_tool_call_names_correct(
         return True, ""
     if not actual_names:
         return False, f"No tool calls found. Expected {expected_names}."
-    if set(actual_names) != set(expected_names):
+    if Counter(actual_names) != Counter(expected_names):
         return (
             False,
             f"Tool calls do not match. Expected {expected_names}, got {actual_names}.",
@@ -346,20 +347,24 @@ def check_tool_args_correct(
     expected_tool_name: str,
     expected_args: Mapping[str, Any],
 ) -> tuple[bool, str]:
-    """Deterministically verify that a named tool call includes expected args."""
+    """Verify that at least one named tool call includes the expected args."""
 
+    first_actual_args: Dict[str, Any] | None = None
     for tool_call in tool_calls:
         if _tool_call_name(tool_call) != expected_tool_name:
             continue
         actual_args = _tool_call_arguments(tool_call)
+        if first_actual_args is None:
+            first_actual_args = actual_args
         if expected_args_subset(dict(expected_args), actual_args):
             return True, ""
+
+    if first_actual_args is not None:
         return (
             False,
             f"Arguments for {expected_tool_name} did not match. "
-            f"Expected subset {dict(expected_args)}, got {actual_args}.",
+            f"Expected subset {dict(expected_args)}, got {first_actual_args}.",
         )
-
     return False, f"Expected tool call {expected_tool_name} was not found."
 
 
@@ -699,10 +704,17 @@ def compute_tool_call_grade(
     )
 
     matching_call = None
+    first_named_call = None
     for tool_call in tool_calls:
-        if _tool_call_name(tool_call) == expected_tool_name:
+        if _tool_call_name(tool_call) != expected_tool_name:
+            continue
+        if first_named_call is None:
+            first_named_call = tool_call
+        if expected_args_subset(expected_args, _tool_call_arguments(tool_call)):
             matching_call = tool_call
             break
+    if matching_call is None:
+        matching_call = first_named_call
 
     if matching_call is None:
         first_call = tool_calls[0] if tool_calls else {}

--- a/examples/evals/realtime_evals/tests/test_repeated_tool_call_graders.py
+++ b/examples/evals/realtime_evals/tests/test_repeated_tool_call_graders.py
@@ -1,0 +1,65 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from shared.graders import (
+    check_tool_args_correct,
+    check_tool_call_names_correct,
+    compute_tool_call_grade,
+)
+
+
+def test_tool_name_grader_preserves_duplicate_call_count() -> None:
+    passed, _ = check_tool_call_names_correct(
+        [{"name": "lookup_order"}],
+        ["lookup_order", "lookup_order"],
+    )
+
+    assert passed is False
+
+
+def test_tool_name_grader_remains_order_insensitive() -> None:
+    passed, reason = check_tool_call_names_correct(
+        [
+            {"name": "lookup_order"},
+            {"name": "send_email"},
+            {"name": "lookup_order"},
+        ],
+        ["send_email", "lookup_order", "lookup_order"],
+    )
+
+    assert passed is True
+    assert reason == ""
+
+
+def test_tool_args_grader_checks_later_calls_with_same_name() -> None:
+    passed, reason = check_tool_args_correct(
+        [
+            {"name": "lookup_order", "arguments": {"order_id": "ORD-WRONG"}},
+            {"name": "lookup_order", "arguments": {"order_id": "ORD-1001"}},
+        ],
+        "lookup_order",
+        {"order_id": "ORD-1001"},
+    )
+
+    assert passed is True
+    assert reason == ""
+
+
+def test_compatibility_grade_reports_matching_repeated_call_arguments() -> None:
+    result = compute_tool_call_grade(
+        "lookup_order",
+        '{"order_id":"ORD-1001"}',
+        [
+            {"name": "lookup_order", "arguments": {"order_id": "ORD-WRONG"}},
+            {"name": "lookup_order", "arguments": {"order_id": "ORD-1001"}},
+        ],
+    )
+
+    assert result["tool_call_correctness"] == 0
+    assert result["tool_call_arg_correctness"] == 1
+    assert json.loads(result["pred_tool_call_arg"]) == {"order_id": "ORD-1001"}


### PR DESCRIPTION
## Summary

- Preserve duplicate tool-call counts when grading expected tool names instead of collapsing names through `set(...)`.
- Keep name matching order-insensitive by comparing multisets.
- Check every same-name tool call for the expected argument subset rather than failing on the first mismatch.
- Make the compatibility grade report arguments from the same-name call that actually matched.
- Add focused regression coverage for repeated calls.

## Motivation

The deterministic realtime graders have two incorrect repeated-call behaviors.

First, tool names are compared as sets. That means one `lookup_order` call and two `lookup_order` calls are treated as equivalent even though the number of tool invocations differs.

Second, argument grading returns failure on the first same-name call with mismatched arguments. A later `lookup_order` call with the expected arguments is never considered, even though the grader contract asks whether a named call includes the expected argument subset.

These cases can produce incorrect eval scores when an agent retries or invokes the same tool more than once.

## Validation

Added deterministic regression tests covering:

- missing one expected duplicate call -> fail
- same duplicate-call multiset in a different order -> pass
- first same-name call wrong, later call correct -> argument grade passes
- compatibility result reports the arguments from the matching later call while still marking the extra duplicate call as a tool-name mismatch

No API calls or external services are involved.

## Self-review

- [x] Change is limited to deterministic realtime tool-call grading.
- [x] Existing order-insensitive tool-name behavior is preserved.
- [x] Duplicate-call multiplicity is now enforced.
- [x] No dependencies, notebooks, registry entries, or documentation changes.
- [x] Searched open PRs for existing repeated-tool-call grader fixes and found none.

Maintainers may modify the branch if needed.