### PR TITLE
Reject invalid image eval counts

### DIFF
--- a/examples/evals/imagegen_evals/tests/test_runner_params.py
+++ b/examples/evals/imagegen_evals/tests/test_runner_params.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from vision_harness.runners import _positive_int_param
+
+
+def test_positive_int_param_accepts_integer_and_integer_string() -> None:
+    assert _positive_int_param(1, name="n") == 1
+    assert _positive_int_param(4, name="n") == 4
+    assert _positive_int_param("2", name="n") == 2
+
+
+def test_positive_int_param_rejects_fractional_and_boolean_values() -> None:
+    for value in (1.5, "1.5", True, False):
+        try:
+            _positive_int_param(value, name="n")
+        except ValueError as exc:
+            assert "positive integer" in str(exc)
+        else:
+            raise AssertionError(f"Expected {value!r} to be rejected")
+
+
+def test_positive_int_param_rejects_non_positive_values() -> None:
+    for value in (0, -1, "0"):
+        try:
+            _positive_int_param(value, name="n")
+        except ValueError as exc:
+            assert "positive integer" in str(exc)
+        else:
+            raise AssertionError(f"Expected {value!r} to be rejected")

--- a/examples/evals/imagegen_evals/vision_harness/runners.py
+++ b/examples/evals/imagegen_evals/vision_harness/runners.py
@@ -30,6 +30,23 @@ def _extract_b64_items(images_response) -> list[str]:
     return b64_items
 
 
+def _positive_int_param(value: object, *, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive integer")
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text or not text.isdigit():
+            raise ValueError(f"{name} must be a positive integer")
+        parsed = int(text)
+    else:
+        raise ValueError(f"{name} must be a positive integer")
+    if parsed < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return parsed
+
+
 class ImageGenerationRunner:
     """Text-to-image runner."""
 
@@ -42,7 +59,7 @@ class ImageGenerationRunner:
 
         params = dict(run_cfg.params)
         model = params.pop("model")
-        n = int(params.pop("n", 1))
+        n = _positive_int_param(params.pop("n", 1), name="n")
 
         run_dir = store.run_dir(case.id, run_cfg.label)
         basename = store.new_basename(f"gen_{case.id}_{run_cfg.label}")
@@ -76,7 +93,7 @@ class ImageEditRunner:
 
         params = dict(run_cfg.params)
         model = params.pop("model")
-        n = int(params.pop("n", 1))
+        n = _positive_int_param(params.pop("n", 1), name="n")
 
         run_dir = store.run_dir(case.id, run_cfg.label)
         basename = store.new_basename(f"edit_{case.id}_{run_cfg.label}")


### PR DESCRIPTION
## Summary

- Validate the image-generation/editing `n` parameter as a positive integer instead of coercing arbitrary values with `int(...)`.
- Preserve integer-string compatibility.
- Reject fractional values, booleans, zero, and negative counts before an API request is made.
- Add focused regression tests.

## Motivation

The image eval runners currently use:

```python
n = int(params.pop("n", 1))
```

That silently changes malformed experiment configuration. For example, `1.5` becomes `1`, and `True` becomes `1`. An eval harness should reject invalid run parameters rather than execute a different experiment from the one configured.

This patch keeps normal integer values and integer strings working while failing closed on values that are not positive integers.

## Validation

Added deterministic regression coverage for:

- positive integers -> accepted
- integer strings -> accepted
- fractional numeric/string values -> rejected
- booleans -> rejected
- zero and negative values -> rejected

No OpenAI API calls are required for the tests.

## Self-review

- [x] Change is limited to image eval `n` parsing.
- [x] Both generation and editing runners use the same validation helper.
- [x] Existing default `n=1` behavior is unchanged.
- [x] No dependencies, notebooks, registry entries, or docs changed.
- [x] Searched open PRs for an existing image eval count-validation fix and found none.

Maintainers may modify the branch if needed.