### PR TITLE
Avoid image eval artifact filename collisions

### DIFF
--- a/examples/evals/imagegen_evals/tests/test_output_store.py
+++ b/examples/evals/imagegen_evals/tests/test_output_store.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from vision_harness import storage
+from vision_harness.storage import OutputStore
+
+
+def test_new_basename_is_unique_within_same_millisecond(tmp_path: Path) -> None:
+    original_time = storage.time.time
+    try:
+        storage.time.time = lambda: 1234.567
+        store = OutputStore(tmp_path)
+        first = store.new_basename("case-model")
+        second = store.new_basename("case-model")
+    finally:
+        storage.time.time = original_time
+
+    assert first != second
+    assert first.startswith("case-model_1234567_")
+    assert second.startswith("case-model_1234567_")

--- a/examples/evals/imagegen_evals/vision_harness/storage.py
+++ b/examples/evals/imagegen_evals/vision_harness/storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -22,7 +23,8 @@ class OutputStore:
 
     def new_basename(self, prefix: str) -> str:
         created_ms = int(time.time() * 1000)
-        return f"{prefix}_{created_ms}"
+        unique_suffix = uuid.uuid4().hex[:8]
+        return f"{prefix}_{created_ms}_{unique_suffix}"
 
     def save_png(self, run_dir: Path, basename: str, idx: int, png_bytes: bytes) -> Path:
         out = run_dir / f"{basename}_{idx}.png"


### PR DESCRIPTION
## Summary

- Add a short random suffix to image eval artifact basenames.
- Preserve the existing millisecond timestamp for readability.
- Add a regression test proving two outputs created in the same millisecond receive different basenames.

## Motivation

`OutputStore.new_basename()` currently uses only `int(time.time() * 1000)`. If the same test/model prefix is used twice within one millisecond, both runs generate the same basename and later writes can overwrite earlier artifacts.

This is particularly risky for scripted or parallel eval workflows, where artifact loss changes what is available for later inspection and judging.

Keeping the timestamp and adding a short UUID suffix makes filenames collision-resistant without changing the flat output-directory layout used by the Cookbook.

## Validation

Added a deterministic regression test that fixes the clock to one millisecond, requests two basenames for the same prefix, and verifies they remain distinct while preserving the timestamp portion.

No OpenAI API calls are involved.

## Self-review

- [x] Change is limited to output basename generation.
- [x] Existing flat output-directory behavior is unchanged.
- [x] Timestamp readability is preserved.
- [x] No dependencies, notebooks, registry entries, or docs changed.
- [x] Searched open PRs for an existing image artifact collision fix and found none.

Maintainers may modify the branch if needed.