### PR TITLE
Avoid image eval run directory collisions

### DIFF
--- a/examples/evals/imagegen_evals/shared/reporting.py
+++ b/examples/evals/imagegen_evals/shared/reporting.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import uuid
 from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
@@ -16,7 +17,8 @@ def ensure_dir(path: Path) -> None:
 def default_run_id(run_name: str) -> str:
     if run_name:
         return run_name
-    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    return f"{timestamp}_{uuid.uuid4().hex[:8]}"
 
 
 def summarize_results(results: list[dict[str, Any]]) -> dict[str, Any]:

--- a/examples/evals/imagegen_evals/tests/test_reporting_run_id.py
+++ b/examples/evals/imagegen_evals/tests/test_reporting_run_id.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from shared.reporting import default_run_id
+
+
+def test_default_run_id_is_unique_for_rapid_runs() -> None:
+    first = default_run_id("")
+    second = default_run_id("")
+
+    assert first != second
+
+
+def test_default_run_id_preserves_explicit_name() -> None:
+    assert default_run_id("comparison-run") == "comparison-run"


### PR DESCRIPTION
## Summary

- Make auto-generated image eval run IDs collision-resistant.
- Preserve the existing UTC timestamp prefix for readability.
- Keep explicit user-supplied run names unchanged.
- Add focused regression tests.

## Motivation

`default_run_id()` currently formats the current UTC time only to whole seconds. Two image eval invocations started within the same second therefore receive the same default run ID and write to the same results directory, allowing `results.json`, `results.csv`, and `summary.json` from one run to overwrite another.

Appending a short UUID suffix keeps the current human-readable timestamp while giving independently started runs distinct directories.

## Validation

Added deterministic regression coverage that verifies:

- two rapidly generated default run IDs are different
- an explicit run name is returned unchanged

No OpenAI API calls are involved.

## Self-review

- [x] Change is limited to default image eval run ID generation.
- [x] Explicit run-name behavior is unchanged.
- [x] Existing timestamp prefix remains intact.
- [x] No dependencies, notebooks, registry entries, or docs changed.
- [x] Searched open PRs for an existing image eval run-ID collision fix and found none.

Maintainers may modify the branch if needed.