### PR TITLE
Quote deployment manager project paths

### DIFF
--- a/examples/agents_sdk/deployment_manager/Makefile
+++ b/examples/agents_sdk/deployment_manager/Makefile
@@ -81,7 +81,7 @@ deploy:
 		echo "PROJECT_PATH is required. Example: make deploy PROJECT_PATH=/path/to/agents-sdk-app"; \
 		exit 2; \
 	fi
-	$(PYTHON) scripts/local_deploy.py $(PROJECT_PATH) --manager-port $(PORT) $(if $(APP_PORT),--app-port $(APP_PORT),) $(if $(NAME),--name "$(NAME)",) $(if $(SANDBOX_BACKEND),--sandbox-backend $(SANDBOX_BACKEND),) $(if $(TARGET),--target $(TARGET),) $(if $(NO_START),--no-start,)
+	$(PYTHON) scripts/local_deploy.py "$(PROJECT_PATH)" --manager-port $(PORT) $(if $(APP_PORT),--app-port $(APP_PORT),) $(if $(NAME),--name "$(NAME)",) $(if $(SANDBOX_BACKEND),--sandbox-backend $(SANDBOX_BACKEND),) $(if $(TARGET),--target $(TARGET),) $(if $(NO_START),--no-start,)
 
 clean:
 	rm -rf dist node_modules


### PR DESCRIPTION
## Summary

- Quote `PROJECT_PATH` when the Deployment Manager Makefile forwards it to `scripts/local_deploy.py`.
- Preserve project directories containing spaces as one CLI argument.

## Motivation

The `deploy` target currently expands `$(PROJECT_PATH)` without shell quoting:

```make
scripts/local_deploy.py $(PROJECT_PATH) ...
```

A valid project path such as `/Users/example/Agents SDK Demo` is therefore split into multiple arguments and `argparse` rejects the command before deployment begins.

Quoting the path fixes that case without changing normal paths or any deployment behavior.

## Validation

The change is a one-line shell-argument fix. With quoting, `PROJECT_PATH="/tmp/Agents SDK Demo"` is passed to `local_deploy.py` as a single positional argument; paths without spaces are unchanged.

## Self-review

- [x] One-line, narrowly scoped change.
- [x] No dependencies, notebooks, registry entries, or documentation changed.
- [x] Existing Makefile syntax and deploy options remain unchanged.
- [x] Searched open PRs for an existing project-path quoting fix and found none.

Maintainers may modify the branch if needed.