### PR TITLE
Keep commerce tracing configuration run-local

### DIFF
--- a/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/src/agentic_commerce/agent.py
+++ b/examples/partners/AWS/controlled_agentic_commerce_with_agentcore_payments/src/agentic_commerce/agent.py
@@ -12,8 +12,6 @@ from agents import (
     RunConfig,
     Runner,
 )
-from agents.tracing import set_trace_provider
-from agents.tracing.provider import DefaultTraceProvider
 from openai.types.shared import Reasoning
 from pydantic import BaseModel, ConfigDict
 
@@ -152,9 +150,6 @@ async def run_supplier_research(
     """Run the agent and validate its proposal against tool-observed evidence."""
 
     recorder = PurchaseResultRecorder()
-    trace_provider = DefaultTraceProvider()
-    trace_provider.set_disabled(True)
-    set_trace_provider(trace_provider)
     agent = build_supplier_research_agent(
         application,
         model=model,


### PR DESCRIPTION
## Summary

- Stop replacing the process-wide Agents SDK trace provider in the synthetic commerce runner.
- Keep tracing disabled for this run through the existing `RunConfig(tracing_disabled=True)` setting.
- Remove the now-unnecessary trace-provider imports and setup.

## Motivation

`run_supplier_research()` currently creates a disabled `DefaultTraceProvider` and installs it with `set_trace_provider(...)` before starting the agent. That changes global Agents SDK tracing state for the entire Python process, so unrelated agent runs executed afterward can unexpectedly lose tracing.

The commerce run already passes `RunConfig(tracing_disabled=True)`, which scopes the intended behavior to this run. The global provider mutation is therefore unnecessary and has a wider side effect than the example requires.

## Validation

The existing scripted-model workflow test exercises `run_supplier_research()` through the real Agents SDK tool loop. This change leaves its run-local `tracing_disabled=True` configuration unchanged and only removes the redundant global mutation.

## Self-review

- [x] Five-line deletion only.
- [x] Commerce policy, payment, tool, and typed-output behavior are unchanged.
- [x] Tracing remains disabled for the synthetic commerce run itself.
- [x] No dependencies, notebooks, registry entries, or documentation changed.
- [x] Searched open PRs for an existing trace-provider side-effect fix and found none.

Maintainers may modify the branch if needed.