### PR TITLE
Keep MCP RAG summaries grounded

### DIFF
--- a/examples/partners/mcp_powered_voice_agents/mcp_powered_agents_cookbook.ipynb
+++ b/examples/partners/mcp_powered_voice_agents/mcp_powered_agents_cookbook.ipynb
@@ -208,7 +208,6 @@
         "    \"\"\"\n",
         "    response = client.responses.create(\n",
         "        model=\"gpt-4.1-mini\",\n",
-        "        tools=[{\"type\": \"web_search_preview\"}],\n",
         "        input=\"Summarize the following text concisely: \\n\\n\" + rag_output,\n",
         "    )\n",
         "    return response.output_text\n",

--- a/examples/partners/mcp_powered_voice_agents/search_server.py
+++ b/examples/partners/mcp_powered_voice_agents/search_server.py
@@ -27,7 +27,6 @@ def _summarize_rag_response(rag_output: str) -> str:
     """
     response = client.responses.create(
         model="gpt-4.1-mini",
-        tools=[{"type": "web_search_preview"}],
         input="Summarize the following text concisely: \n\n" + rag_output,
     )
     return response.output_text


### PR DESCRIPTION
## Summary

- Remove `web_search_preview` from the helper that only summarizes already-retrieved RAG text.
- Mirror the same grounding change in the notebook's embedded server listing.
- Leave the separate `run_web_search` MCP tool unchanged.

## Motivation

`_summarize_rag_response()` receives text that has already been retrieved from the user knowledge base, but it also enables the web-search tool on the summarization request. That gives the model permission to fetch unrelated external information while producing what is presented as a summary of grounded internal retrieval.

The MCP server already exposes a dedicated `run_web_search()` tool for cases where web search is actually intended. The RAG summarizer should remain limited to the retrieved text it was given.

## Validation

The same one-line behavioral change is applied in the standalone server and the notebook copy: the summarization request still uses the same model and input text, but no longer exposes an external search tool. The separate web-search path is untouched.

## Self-review

- [x] Grounding behavior is synchronized between the script and notebook example.
- [x] RAG retrieval behavior is unchanged.
- [x] The dedicated web-search MCP tool remains available.
- [x] No dependencies, registry entries, or documentation changed.
- [x] Searched open PRs for an existing grounded-summary fix and found none.

Maintainers may modify the branch if needed.