### PR TITLE
Normalize naive temporal datetimes to UTC

### DIFF
--- a/examples/partners/temporal_agents_with_knowledge_graphs/temporal_agents.ipynb
+++ b/examples/partners/temporal_agents_with_knowledge_graphs/temporal_agents.ipynb
@@ -1685,7 +1685,7 @@
     "    @classmethod\n",
     "    def _parse_date_string(cls, value: str | datetime | None) -> datetime | None:\n",
     "        if isinstance(value, datetime) or value is None:\n",
-    "            return value\n",
+    "            return parse_date_str(value)\n",
     "        return parse_date_str(value)"
    ]
   },

--- a/examples/partners/temporal_agents_with_knowledge_graphs/utils.py
+++ b/examples/partners/temporal_agents_with_knowledge_graphs/utils.py
@@ -15,7 +15,7 @@ def parse_date_str(value: str | datetime | None) -> datetime | None:
         return None
 
     if isinstance(value, datetime):
-        return value
+        return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
 
     try:
         # Year Handling


### PR DESCRIPTION
## Summary

- Normalize timezone-naive `datetime` inputs in `parse_date_str()` to UTC.
- Preserve already timezone-aware `datetime` values unchanged.
- Route the notebook validator's direct `datetime` inputs through the same normalization helper.

## Motivation

`parse_date_str()` documents that parsed datetimes without timezone information default to UTC. String inputs follow that rule, but direct `datetime` inputs currently return immediately before the timezone normalization runs.

As a result, equivalent values behave differently depending on input type: a naive date string becomes UTC-aware, while a naive `datetime` remains timezone-naive. Temporal graph data should not depend on whether the caller supplied a string or an already-constructed `datetime`.

## Validation

- naive `datetime` -> same wall-clock value with `UTC` attached
- aware `datetime` -> unchanged
- string parsing behavior -> unchanged
- notebook `TemporalValidityRange` datetime inputs -> routed through `parse_date_str()`

## Self-review

- [x] Direct datetime normalization and the runnable notebook path are synchronized.
- [x] Existing timezone-aware inputs remain unchanged.
- [x] String parsing behavior is unchanged.
- [x] No dependencies, registry entries, or documentation changed.
- [x] Searched open PRs for an existing timezone-normalization fix and found none.

Maintainers may modify the branch if needed.