### PR TITLE
Keep canonical entity names stable

### DIFF
--- a/examples/partners/temporal_agents_with_knowledge_graphs/cb_functions.py
+++ b/examples/partners/temporal_agents_with_knowledge_graphs/cb_functions.py
@@ -80,12 +80,9 @@ def _load_entity_maps(conn: sqlite3.Connection) -> tuple[dict[bytes, bytes], dic
         name = row[1]
         resolved_id = row[2]
 
-        if resolved_id:
-            # If entity has a resolved_id, map to that
-            entity_to_canonical[entity_id] = resolved_id
-        else:
-            # If no resolved_id, entity is its own canonical version
-            entity_to_canonical[entity_id] = entity_id
+        canonical_id = resolved_id or entity_id
+        entity_to_canonical[entity_id] = canonical_id
+        if canonical_id == entity_id:
             canonical_names[entity_id] = name
 
     return entity_to_canonical, canonical_names

--- a/examples/partners/temporal_agents_with_knowledge_graphs/cb_functions.py
+++ b/examples/partners/temporal_agents_with_knowledge_graphs/cb_functions.py
@@ -83,8 +83,6 @@ def _load_entity_maps(conn: sqlite3.Connection) -> tuple[dict[bytes, bytes], dic
         if resolved_id:
             # If entity has a resolved_id, map to that
             entity_to_canonical[entity_id] = resolved_id
-            # Store name of the canonical entity
-            canonical_names[resolved_id] = name
         else:
             # If no resolved_id, entity is its own canonical version
             entity_to_canonical[entity_id] = entity_id


### PR DESCRIPTION
## Summary

- Keep canonical entity names stable when loading temporal knowledge-graph entity mappings.
- Treat both unresolved canonical rows (`resolved_id` empty) and self-resolved canonical rows (`resolved_id == id`) as canonical-name sources.
- Keep true aliases mapped to their canonical IDs without allowing alias names to overwrite the canonical name.

## Motivation

`_load_entity_maps()` maps entity rows to canonical IDs. Canonical rows can be represented either with no `resolved_id` or, after entity resolution, with `resolved_id` equal to their own ID. True aliases point to a different canonical ID.

If self-resolved canonical rows are treated like aliases, their canonical name is lost and graph construction can fall back to per-triplet alias names. That can make node labels unstable and, when names are used as nodes, split one canonical entity across multiple alias names.

## Validation

- unresolved canonical rows populate `canonical_names`
- self-resolved canonical rows also populate `canonical_names`
- true aliases map to the canonical ID but do not overwrite its name
- graph construction and temporal metadata behavior are otherwise unchanged

Maintainers may modify the branch if needed.