### PR TITLE
Filter aliases from canonical entity lookup

### DIFF
--- a/examples/partners/temporal_agents_with_knowledge_graphs/db_interface.py
+++ b/examples/partners/temporal_agents_with_knowledge_graphs/db_interface.py
@@ -290,9 +290,15 @@ def insert_entity(conn: sqlite3.Connection, entity: dict[str, Any]) -> None:
     c = conn.cursor()
     c.execute(
         """
-              INSERT OR IGNORE INTO entities (id, name, type, description)
-              VALUES (?, ?, ?, ?)""",
-        (entity["id"], entity["name"], entity.get("type"), entity.get("description")),
+              INSERT OR IGNORE INTO entities (id, name, type, description, resolved_id)
+              VALUES (?, ?, ?, ?, ?)""",
+        (
+            entity["id"],
+            entity["name"],
+            entity.get("type"),
+            entity.get("description"),
+            entity.get("resolved_id"),
+        ),
     )
 
 
@@ -302,7 +308,10 @@ def get_all_canonical_entities(conn: sqlite3.Connection) -> list[Entity]:
     Returns a list of dicts with id, name, type, and description.
     """
     c = conn.cursor()
-    c.execute("SELECT id, name, type, description FROM entities WHERE resolved_id IS NULL")
+    c.execute(
+        "SELECT id, name, type, description FROM entities "
+        "WHERE resolved_id IS NULL OR resolved_id = id"
+    )
     rows = c.fetchall()
     return [
         Entity(

--- a/examples/partners/temporal_agents_with_knowledge_graphs/db_interface.py
+++ b/examples/partners/temporal_agents_with_knowledge_graphs/db_interface.py
@@ -302,7 +302,7 @@ def get_all_canonical_entities(conn: sqlite3.Connection) -> list[Entity]:
     Returns a list of dicts with id, name, type, and description.
     """
     c = conn.cursor()
-    c.execute("SELECT id, name, type, description FROM entities")
+    c.execute("SELECT id, name, type, description FROM entities WHERE resolved_id IS NULL")
     rows = c.fetchall()
     return [
         Entity(


### PR DESCRIPTION
## Summary

- Persist `resolved_id` when entity rows are inserted.
- Make `get_all_canonical_entities()` return canonical rows represented either by a null `resolved_id` or by a self-resolution (`resolved_id == id`).
- Exclude true alias rows whose `resolved_id` points to a different entity.

## Motivation

The entity-resolution workflow can store canonical rows as self-resolved and aliases as references to those canonical IDs. Previously `insert_entity()` discarded `resolved_id`, which made aliases indistinguishable from unresolved canonicals after persistence. Filtering only on `resolved_id IS NULL` also excluded self-resolved canonical rows.

Persisting the resolution ID and recognizing both canonical representations keeps the lookup consistent with the actual ingestion/resolution model.

## Validation

- alias resolution IDs survive persistence
- unresolved canonical rows remain returned
- self-resolved canonical rows remain returned
- true aliases are excluded
- returned `Entity` shape is unchanged

Maintainers may modify the branch if needed.