### PR TITLE
Detect spaced file I/O in top-k eval constraints

### DIFF
--- a/examples/gpt-5/prompt-optimization-cookbook/scripts/topk_eval.py
+++ b/examples/gpt-5/prompt-optimization-cookbook/scripts/topk_eval.py
@@ -25,7 +25,7 @@ DISALLOWED_IMPORTS = {
     "socket": "network",
 }
 DISALLOWED_PATTERNS = [
-    ("file_io", re.compile(r"(?<![\w\.])open\s*\(")),
+    ("file_io", re.compile(r"(?<![\w\.])open[ \t]*\(")),
 ]
 
 

--- a/examples/gpt-5/prompt-optimization-cookbook/scripts/topk_eval.py
+++ b/examples/gpt-5/prompt-optimization-cookbook/scripts/topk_eval.py
@@ -25,7 +25,7 @@ DISALLOWED_IMPORTS = {
     "socket": "network",
 }
 DISALLOWED_PATTERNS = [
-    ("file_io", re.compile(r"(?<![\w\.])open\(")),
+    ("file_io", re.compile(r"(?<![\w\.])open\s*\(")),
 ]
 
 


### PR DESCRIPTION
## Summary

- Allow whitespace between the built-in `open` name and its opening parenthesis in the Top-K evaluator's static file-I/O check.
- Preserve all existing import and constraint checks.

## Motivation

The Top-K task explicitly forbids file I/O, and the evaluator scans submissions for direct calls to the built-in `open(...)`. The current pattern only matches `open(` exactly, so valid Python such as:

```python
open ("output.txt", "w")
```

bypasses the constraint scan and is executed/scored as if it were compliant.

Allowing optional whitespace before `(` closes that formatting-dependent bypass without changing compliant submissions or attribute calls such as `obj.open(...)`.

## Validation

The regex change makes the existing static check match both `open(` and `open (` while preserving the negative lookbehind that excludes attribute access.

No OpenAI API calls, benchmark parameters, or scoring logic are changed.

## Self-review

- [x] One-line regex change only.
- [x] Existing compliant submissions are unaffected.
- [x] No dependencies, notebooks, registry entries, or documentation changed.
- [x] Searched open PRs for an existing whitespace-bypass fix and found none.

Maintainers may modify the branch if needed.