### PR TITLE
Validate LLM judge concurrency

### DIFF
--- a/examples/gpt-5/prompt-optimization-cookbook/scripts/llm_judge.py
+++ b/examples/gpt-5/prompt-optimization-cookbook/scripts/llm_judge.py
@@ -104,6 +104,9 @@ def judge_folder(
     Evaluate each .py code file in results_dir with an LLM-as-judge and write per-file JSON judgments.
     Returns the output directory path.
     """
+    if concurrency < 1:
+        raise ValueError("concurrency must be at least 1")
+
     in_dir = Path(results_dir)
     assert in_dir.exists(), f"Results folder not found: {in_dir}"
 


### PR DESCRIPTION
## Summary

- Reject non-positive `concurrency` values at the `judge_folder()` boundary.
- Keep all valid worker counts and judging behavior unchanged.

## Motivation

`judge_folder()` accepts `concurrency` directly and later passes it to `ThreadPoolExecutor(max_workers=concurrency)`. Values such as `0` or `-1` are therefore accepted by the function and CLI, perform some setup work, and then fail with an executor-internal `ValueError`.

This parameter is part of the evaluator's public helper/CLI surface, so invalid worker counts should fail immediately with a clear, local validation error before creating output directories, loading prompts, or constructing the client.

## Validation

The new guard enforces the executor's existing requirement explicitly:

- `concurrency < 1` -> `ValueError("concurrency must be at least 1")`
- `concurrency >= 1` -> existing behavior unchanged

No API requests, judge prompts, retry behavior, or result formats are changed.

## Self-review

- [x] Three added lines in one file.
- [x] Valid concurrency values preserve existing behavior.
- [x] No dependencies, notebooks, registry entries, or documentation changed.
- [x] Searched open PRs for an existing concurrency-validation fix and found none.

Maintainers may modify the branch if needed.