### PR TITLE
Align judge scores with quantified runs

### DIFF
--- a/examples/gpt-5/prompt-optimization-cookbook/scripts/results_summarizer.py
+++ b/examples/gpt-5/prompt-optimization-cookbook/scripts/results_summarizer.py
@@ -113,6 +113,11 @@ def summarize_groups(
         qrows = _read_quant_csv(qpath)
         jrows = _read_judge_csv(judge_paths[name]) if name in judge_paths and judge_paths[name].exists() else []
         jmap = {Path(j.file).stem: j for j in jrows}
+        jrows = [
+            jmap[Path(q.file).stem]
+            for q in qrows
+            if Path(q.file).stem in jmap
+        ]
 
         n_total = len(qrows)
         n_success = sum(1 for r in qrows if r.compiled)


### PR DESCRIPTION
## Summary

- Restrict LLM-as-judge averages to judgment rows whose file stems are present in the quantitative results being summarized.
- Reuse the existing file-to-judgment map to perform the alignment.

## Motivation

`results_summarizer.py` builds a `jmap` keyed by judged file name, but currently averages every row in `judgement_summary.csv`. If that CSV contains stale or extra judgments from another evaluation run, those scores silently change the current baseline/optimized summary even though the corresponding files are absent from the quantitative results.

A comparison summary should aggregate judge scores for the same set of generated runs represented by its quantitative CSV. The existing `jmap` already provides the intended alignment key but was not being used.

## Validation

After the change:

- judgment rows matching quantitative run file stems contribute normally
- extra/stale judgment rows are ignored
- missing judgment rows remain omitted from judge averages
- quantitative metrics, charts, and output schema are unchanged

No OpenAI API calls or benchmark execution behavior are changed.

## Self-review

- [x] Five added lines in one summarizer file.
- [x] Existing filename-stem mapping is reused rather than introducing a new key scheme.
- [x] No dependencies, notebooks, registry entries, or documentation changed.
- [x] Searched open PRs for an existing judge/quant alignment fix and found none.

Maintainers may modify the branch if needed.