### PR TITLE
Reject unsupported image data URL extensions

### DIFF
--- a/examples/evals/imagegen_evals/vision_harness/io.py
+++ b/examples/evals/imagegen_evals/vision_harness/io.py
@@ -12,6 +12,9 @@ _MIME_BY_SUFFIX = {
 
 
 def image_to_data_url(path: Path) -> str:
-    mime = _MIME_BY_SUFFIX.get(path.suffix.lower(), "image/png")
+    suffix = path.suffix.lower()
+    if suffix not in _MIME_BY_SUFFIX:
+        raise ValueError(f"Unsupported image extension: {suffix or '<none>'}")
+    mime = _MIME_BY_SUFFIX[suffix]
     b64 = base64.b64encode(path.read_bytes()).decode("utf-8")
     return f"data:{mime};base64,{b64}"


### PR DESCRIPTION
## Summary

- Stop defaulting unknown image file extensions to `image/png` in `image_to_data_url()`.
- Raise a clear `ValueError` for unsupported or extensionless image paths.
- Preserve JPEG, PNG, and WebP handling unchanged.

## Motivation

`image_to_data_url()` currently labels every unrecognized file as PNG. A GIF, BMP, or other unsupported file is therefore base64-encoded with a false `data:image/png` MIME type even though its bytes are not PNG data.

An eval harness should not silently mislabel artifact bytes. Failing explicitly keeps the MIME type and file contents consistent and makes unsupported input immediately visible.

## Validation

The supported suffix mapping is unchanged:

- `.jpg` / `.jpeg` -> `image/jpeg`
- `.png` -> `image/png`
- `.webp` -> `image/webp`
- anything else -> clear `ValueError`

No API calls, image bytes, grading behavior, dependencies, notebooks, registry entries, or documentation are changed.

## Self-review

- [x] Five changed lines in one small helper.
- [x] Supported image formats preserve existing behavior.
- [x] Searched open PRs for an existing MIME/unsupported-extension fix and found none.
- [x] Maintainers may modify the branch if needed.