### PR TITLE
Reject duplicate image eval score keys

### DIFF
--- a/examples/evals/imagegen_evals/vision_harness/evaluate.py
+++ b/examples/evals/imagegen_evals/vision_harness/evaluate.py
@@ -44,6 +44,8 @@ def evaluate(
             for grader in graders:
                 scored = grader.grade(response, case)
                 for score in _as_score_list(scored):
+                    if score.key in score_map:
+                        raise ValueError(f"Duplicate score key: {score.key}")
                     score_map[score.key] = score.value
                     reason_map[score.key] = score.reason
 


### PR DESCRIPTION
## Summary

This change raises a clear error when image-eval grader outputs reuse the same score key instead of silently overwriting an earlier score and reason.

## Why

Scores are stored in dictionaries keyed by `score.key`. Reusing a key currently makes the later result replace the earlier one, so evaluation output can lose data without warning.

## Scope

- Two added lines in `vision_harness/evaluate.py`.
- Unique score keys behave exactly as before.
- No API, dependency, notebook, registry, or documentation changes.
- No existing open PR for this fix was found.

Maintainers may modify the branch if needed.