### PR TITLE
Validate prompt generation concurrency

### DIFF
--- a/examples/gpt-5/prompt-optimization-cookbook/scripts/gen_baseline.py
+++ b/examples/gpt-5/prompt-optimization-cookbook/scripts/gen_baseline.py
@@ -53,6 +53,9 @@ def generate_baseline_topk(
     dev_prompt: str,
     user_prompt: str,
 ) -> Path:
+    if concurrency < 1:
+        raise ValueError("concurrency must be at least 1")
+
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
 

--- a/examples/gpt-5/prompt-optimization-cookbook/scripts/gen_optimized.py
+++ b/examples/gpt-5/prompt-optimization-cookbook/scripts/gen_optimized.py
@@ -42,6 +42,9 @@ def _call_model_with_retry(*, model: str, dev_prompt: str, user_prompt: str, max
 
 
 def generate_optimized_topk(*, model: str = "gpt-5", n_runs: int = 30, concurrency: int = 10, output_dir: str = "results_topk_optimized", dev_prompt: str, user_prompt: str) -> Path:
+    if concurrency < 1:
+        raise ValueError("concurrency must be at least 1")
+
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary

- Reject non-positive `concurrency` values in both baseline and optimized prompt-generation helpers.
- Keep all valid worker counts and generation behavior unchanged.

## Motivation

Both helpers pass `concurrency` directly to `ThreadPoolExecutor(max_workers=...)`. Values such as `0` or `-1` therefore perform setup work and then fail later with an executor-internal error.

Validating the parameter at the helper boundary gives a clear error before output directories or worker pools are created and keeps baseline/optimized behavior consistent.

## Validation

- `concurrency < 1` -> `ValueError("concurrency must be at least 1")`
- `concurrency >= 1` -> existing behavior unchanged

No API request shape, retry logic, model defaults, `n_runs` behavior, dependencies, notebooks, registry entries, or documentation are changed.

## Self-review

- [x] Three added lines in each of two small helper files.
- [x] Baseline and optimized paths remain symmetric.
- [x] Searched open PRs for an existing generation-concurrency fix and found none.
- [x] Maintainers may modify the branch if needed.