### PR TITLE
Align image eval OCR text with flyer prompt

### DIFF
--- a/examples/evals/imagegen_evals/generation_harness/run_imagegen_evals.py
+++ b/examples/evals/imagegen_evals/generation_harness/run_imagegen_evals.py
@@ -256,9 +256,9 @@ MARKETING_SCHEMA = {
 REQUIRED_TEXT = {
     "WINTER LATTE WEEK",
     "Try our Cinnamon Oat Latte",
-    "20% OFF • Mon–Thu",
+    "20% OFF - Mon-Thu",
     "Order Ahead",
-    "123 Market St • 7am–6pm",
+    "123 Market St - 7am-6pm",
 }
 
 


### PR DESCRIPTION
## Summary

- Align the coffee-flyer OCR oracle with the exact text required by `COFFEE_PROMPT`.
- Replace the two punctuation variants in `REQUIRED_TEXT` with the prompt's literal hyphenated strings.

## Motivation

The prompt explicitly requires these exact lines:

- `20% OFF - Mon-Thu`
- `123 Market St - 7am-6pm`

But the OCR check currently expects bullet separators and en-dashes instead. Because `add_ocr_text_check()` compares extracted lines by exact set equality, a flyer that follows the generation prompt perfectly can still be marked as missing the expected OCR text and containing extra text.

The oracle should use the same literal strings as the task it is grading.

## Validation

This changes only two entries in `REQUIRED_TEXT`:

- prompt-compliant text now matches the OCR oracle exactly
- OCR set-comparison logic is unchanged
- model, judge, image generation, and reporting behavior are unchanged

## Self-review

- [x] Two-line correctness fix in one file.
- [x] No API, dependency, notebook, registry, or documentation changes.
- [x] Searched open PRs for an existing OCR required-text fix and found none.

Maintainers may modify the branch if needed.