### PR TITLE
Require migration artifact paths to be files

### DIFF
--- a/examples/agents_sdk/sandboxed-code-migration/evals.py
+++ b/examples/agents_sdk/sandboxed-code-migration/evals.py
@@ -40,7 +40,7 @@ def read_jsonl(path: Path) -> list[dict[str, Any]]:
 
 
 def require_output(path: Path) -> None:
-    if not path.exists():
+    if not path.is_file():
         raise FileNotFoundError(
             f"Missing {path}. Run the full migration agent before running artifact evals."
         )


### PR DESCRIPTION
## Summary

- Require generated migration artifact paths to be regular files before reading them.
- Preserve the existing empty-file check and all content validation.

## Motivation

`require_output()` currently checks only `Path.exists()`. A directory named like an expected artifact, such as `migration.patch` or `migration_result.json`, therefore passes the initial validation and fails later with an unrelated filesystem error when the evaluator tries to read it.

The artifact validator should reject that condition at its own boundary with the same missing-artifact path used for non-files.

## Validation

This is a one-line check change:

- missing path -> rejected as before
- directory at an artifact path -> now rejected immediately
- regular non-empty file -> existing behavior unchanged
- empty regular file -> existing empty-file `ValueError` unchanged

## Self-review

- [x] One-line correctness fix in one file.
- [x] No artifact schema, API, dependency, notebook, registry, or documentation changes.
- [x] Searched open PRs for an existing file-vs-directory artifact validation fix and found none.

Maintainers may modify the branch if needed.