### PR TITLE
Fix fenced JSON parsing in model selection guide

### DIFF
--- a/examples/partners/model_selection_guide/agent_utils.py
+++ b/examples/partners/model_selection_guide/agent_utils.py
@@ -168,7 +168,7 @@ def _parse_json(text: str) -> Dict[str, Any]:
         return json.loads(text)
     except json.JSONDecodeError:
         # try to rescue JSON from a ```json ...``` block
-        m = re.search(r"```(?:json)?\\s*(.*?)```", text, re.S)
+        m = re.search(r"```(?:json)?\s*(.*?)```", text, re.S)
         if m:
             try:
                 return json.loads(m.group(1))


### PR DESCRIPTION
## Summary

- Correct the whitespace escape in the model-selection guide's fenced-JSON fallback regex.
- Keep direct JSON parsing and raw fallback behavior unchanged.

## Motivation

`_parse_json()` is intended to rescue JSON returned inside a Markdown code fence, but the raw-string regex currently contains `\\s*`. That matches a literal backslash sequence instead of normal whitespace, so a standard response such as a `json` fence followed by a newline does not reach the documented rescue path.

Using `\s*` restores the intended fenced-JSON parsing behavior.

## Validation

- direct JSON -> unchanged
- normal fenced JSON with whitespace/newline -> captured and parsed
- malformed fenced JSON -> still falls through to `{"raw": text}`

## Self-review

- [x] One-line regex correctness fix in one file.
- [x] No API, dependency, notebook, registry, or documentation changes.
- [x] Searched open PRs for an existing fenced-JSON parsing fix and found none.

Maintainers may modify the branch if needed.