### PR TITLE
Confine portfolio file tools to outputs directory

### DIFF
--- a/examples/agents_sdk/multi-agent-portfolio-collaboration/utils.py
+++ b/examples/agents_sdk/multi-agent-portfolio-collaboration/utils.py
@@ -75,23 +75,24 @@ class FileSpanExporter(TracingExporter):
 
 
 def output_file(name: str | Path, *, make_parents: bool = True) -> Path:
-    """Return an absolute Path under the shared outputs/ directory.
+    """Return an absolute Path confined to the shared outputs/ directory.
 
     If *name* already starts with the string "outputs/", that prefix is removed
     to avoid accidentally nesting a second outputs folder (e.g.
-    `outputs/outputs/foo.png`).  Absolute paths are returned unchanged.
+    `outputs/outputs/foo.png`). Absolute paths are accepted only when they
+    resolve inside the shared outputs directory.
     """
 
     path = Path(name)
-
-    if path.is_absolute():
-        return path
+    base = outputs_dir().resolve()
 
     # Strip leading "outputs/" if present
-    if path.parts and path.parts[0] == "outputs":
+    if not path.is_absolute() and path.parts and path.parts[0] == "outputs":
         path = Path(*path.parts[1:])
 
-    final = outputs_dir() / path
+    final = path.resolve() if path.is_absolute() else (base / path).resolve()
+    if not final.is_relative_to(base):
+        raise ValueError("output path must stay within the shared outputs directory")
 
     if make_parents:
         final.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- Resolve `output_file()` targets against the shared `outputs/` directory before returning them.
- Reject relative traversal and absolute paths that resolve outside that directory.
- Preserve normal relative paths and the existing `outputs/` prefix de-nesting behavior.

## Motivation

The multi-agent portfolio example exposes model-facing file tools such as `write_markdown`, `read_file`, and `run_code_interpreter`. Their contract says file paths are relative to `outputs/`, but the shared helper currently returns absolute paths unchanged and allows relative paths such as `../outside.txt` to escape the artifact directory.

That means a tool call can read or write outside the intended shared output area. Resolving the target first and then enforcing `Path.is_relative_to()` establishes the boundary that the tool descriptions already promise. It also prevents path traversal through symlinks that resolve outside the output root.

## Validation

The new path handling preserves expected cases and rejects escapes:

- `report.md` -> `outputs/report.md`
- `outputs/report.md` -> the same shared output path, without double nesting
- an absolute path that resolves inside `outputs/` -> allowed
- `../outside.md` -> rejected with `ValueError`
- an absolute path outside `outputs/` -> rejected with `ValueError`

Parent-directory creation remains unchanged for accepted paths.

## Self-review

- [x] Change is limited to the shared portfolio output-path helper.
- [x] Existing normal output filenames keep their behavior.
- [x] No model, API, dependency, notebook, registry, or prompt changes.
- [x] Searched open PRs for an existing output-path containment fix and found none.

Maintainers may modify the branch if needed.