### PR TITLE
Exclude git metadata from deployment images

### DIFF
--- a/examples/agents_sdk/deployment_manager/app/dockerfile_writer.py
+++ b/examples/agents_sdk/deployment_manager/app/dockerfile_writer.py
@@ -10,6 +10,7 @@ node_modules
 __pycache__
 .ruff_cache
 .DS_Store
+.git
 .env
 data
 uploads


### PR DESCRIPTION
## Summary

- Add `.git` to the Deployment Manager's generated `.dockerignore`.
- Keep all existing generated ignore entries and Dockerfile behavior unchanged.

## Motivation

The generated Dockerfile uses `COPY . .`, while the generated `.dockerignore` currently excludes virtual environments, `.env`, data, uploads, and other local state but not the project's `.git` directory.

For a Git-backed project, that sends repository history and metadata into the Docker build context and can copy it into the image. Besides unnecessary build context and image size, this can expose commit history, branch metadata, and configured repository remotes inside the built container.

The generated ignore file should exclude `.git` by default. Existing user-supplied `.dockerignore` files are not overwritten by this helper.

## Validation

This is a single added ignore entry:

- generated `.dockerignore` now excludes `.git`
- application source files remain included
- existing ignore entries are unchanged
- existing project `.dockerignore` files remain untouched

## Self-review

- [x] One-line correctness/hardening change in one file.
- [x] Dockerfile commands and deployment behavior are otherwise unchanged.
- [x] No dependencies, notebooks, registry entries, or documentation changed.
- [x] Searched open PRs for an existing Deployment Manager `.git` ignore fix and found none.

Maintainers may modify the branch if needed.