### PR TITLE
Validate realtime plot summary shape

### DIFF
--- a/examples/evals/realtime_evals/plot_eval_results.py
+++ b/examples/evals/realtime_evals/plot_eval_results.py
@@ -45,6 +45,8 @@ def main() -> None:
 
     results = pd.read_csv(results_csv_path)
     summary = json.loads(summary_json_path.read_text(encoding="utf-8"))
+    if not isinstance(summary, dict):
+        raise ValueError(f"{summary_json_path} must contain a JSON object.")
     harness_label = args.harness_label or infer_harness_label(run_dir)
     run_label = args.run_label or run_dir.name
 


### PR DESCRIPTION
## Summary

- Require `summary.json` loaded by the realtime plotting CLI to contain a JSON object.
- Keep valid summary objects and plotting behavior unchanged.

## Motivation

`plot_eval_results.py` currently accepts any syntactically valid JSON value and passes it directly to `build_realtime_eval_plots()`. A list, string, number, or other non-object JSON value therefore gets past the file-loading boundary and fails later inside plotting code that expects mapping-style summary data.

The run summary contract is an object. Validating that shape immediately produces a clear error at the source instead of an unrelated downstream attribute/type failure.

## Validation

- object-valued `summary.json` -> existing plotting path unchanged
- malformed JSON -> existing `JSONDecodeError` behavior unchanged
- valid non-object JSON -> clear `ValueError` naming the summary file

## Self-review

- [x] Two added lines in one CLI file.
- [x] No chart behavior changes for valid runs.
- [x] No dependencies, notebooks, registry entries, or documentation changed.
- [x] Searched open PRs for an existing realtime plot summary-shape fix and found none.

Maintainers may modify the branch if needed.