### PR TITLE
Avoid duplicate guardrail metric history

### DIFF
--- a/examples/partners/agentic_governance_guide/guardrail_tuner/threshold_adjuster.py
+++ b/examples/partners/agentic_governance_guide/guardrail_tuner/threshold_adjuster.py
@@ -188,7 +188,6 @@ class ThresholdAdjuster:
 
         # Update state
         state.threshold_history.append(state.current_threshold)
-        state.metrics_history.append(metrics)
         state.adjustments.append(adjustment)
         state.current_threshold = new_threshold
         state.last_direction = direction


### PR DESCRIPTION
## Summary

- Stop appending the current metric snapshot a second time inside `ThresholdAdjuster.calculate_adjustment()`.
- Keep threshold history, adjustment history, and explicit `update_metrics()` behavior unchanged.

## Motivation

The feedback loop already records every evaluation result through `ThresholdAdjuster.update_metrics()`: once after the initial eval and once after each subsequent eval. `calculate_adjustment()` then appends that same `GuardrailMetrics` object again before changing the threshold.

As a result, `metrics_history` contains duplicate entries for every metric snapshot that triggers an adjustment. That makes the tuning history inaccurate for diagnostics or future consumers even though the current report's first/last metric lookup happens to mask the duplication.

There is already one explicit method responsible for recording metric observations, so adjustment calculation should not record the same observation again.

## Validation

- initial eval metric -> recorded once by `update_metrics()`
- each re-eval metric -> recorded once by `update_metrics()`
- threshold/adjustment history -> unchanged
- convergence and threshold calculation -> unchanged

## Self-review

- [x] One-line deletion in one guardrail-tuner helper.
- [x] No API, dependency, notebook, registry, or configuration changes.
- [x] Searched open PRs for an existing metric-history duplication fix and found none.

Maintainers may modify the branch if needed.