### PR TITLE
Reject duplicate walk eval example IDs

### DIFF
--- a/examples/evals/realtime_evals/walk_harness/generate_audio.py
+++ b/examples/evals/realtime_evals/walk_harness/generate_audio.py
@@ -58,6 +58,10 @@ def load_dataset(path: Path) -> pd.DataFrame:
     missing = required_columns.difference(dataset.columns)
     if missing:
         raise ValueError(f"Missing required columns: {sorted(missing)}")
+    normalized_ids = dataset["example_id"].map(lambda value: str(value).strip())
+    duplicate_ids = sorted(set(normalized_ids[normalized_ids.duplicated(keep=False)]))
+    if duplicate_ids:
+        raise ValueError(f"Duplicate example_id values: {duplicate_ids}")
     return dataset
 
 


### PR DESCRIPTION
## Summary

- Reject duplicate normalized `example_id` values when loading the walk-harness source dataset.
- Detect IDs that collide after the same `str(...).strip()` normalization used during audio generation.

## Motivation

The audio generator derives both its temporary PCM path and final WAV path directly from `example_id`. If two rows normalize to the same ID, they map to the same audio file.

With the default non-overwrite behavior, the later row can then silently reuse audio generated from an earlier row's `user_text`. The resulting CSV still contains both rows, so this can corrupt evaluation inputs without an obvious generation failure.

Rejecting duplicate normalized IDs before any TTS calls keeps the one-row/one-audio-file assumption explicit.

## Validation

- unique IDs -> existing behavior unchanged
- exact duplicate IDs -> clear `ValueError`
- whitespace-equivalent IDs such as `case-1` and ` case-1 ` -> clear `ValueError`
- no TTS or output files are created before the duplicate check

## Self-review

- [x] Four added lines in the dataset loader.
- [x] No model, API, audio encoding, notebook, registry, or output-schema changes.
- [x] Searched open PRs for an existing duplicate-ID audio-generation fix and found none.

Maintainers may modify the branch if needed.