### PR TITLE
Reject non-positive guardrail tuning steps

### DIFF
--- a/examples/partners/agentic_governance_guide/tune_guardrails.py
+++ b/examples/partners/agentic_governance_guide/tune_guardrails.py
@@ -5,10 +5,10 @@ This script runs the guardrail feedback loop to automatically tune
 confidence_threshold values based on evaluation metrics.
 
 Example:
-    python tune_guardrails.py \\
-        --config eval_data/eval_config.json \\
-        --dataset eval_data/guardrail_test_data.jsonl \\
-        --precision-target 0.90 \\
+    python tune_guardrails.py \
+        --config eval_data/eval_config.json \
+        --dataset eval_data/guardrail_test_data.jsonl \
+        --precision-target 0.90 \
         --recall-target 0.90
 """
 
@@ -31,11 +31,11 @@ Examples:
   python tune_guardrails.py --config config.json --dataset test_data.jsonl
 
   # Custom targets prioritizing precision
-  python tune_guardrails.py --config config.json --dataset test_data.jsonl \\
+  python tune_guardrails.py --config config.json --dataset test_data.jsonl \
       --precision-target 0.95 --recall-target 0.85 --priority precision
 
   # More iterations with smaller steps
-  python tune_guardrails.py --config config.json --dataset test_data.jsonl \\
+  python tune_guardrails.py --config config.json --dataset test_data.jsonl \
       --max-iterations 20 --step-size 0.02
         """,
     )
@@ -104,6 +104,10 @@ Examples:
 
     if not args.dataset.exists():
         print(f"Error: Dataset file not found: {args.dataset}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.step_size <= 0:
+        print("Error: --step-size must be greater than 0.", file=sys.stderr)
         sys.exit(1)
 
     # Setup logging

--- a/examples/partners/agentic_governance_guide/tune_guardrails.py
+++ b/examples/partners/agentic_governance_guide/tune_guardrails.py
@@ -5,10 +5,10 @@ This script runs the guardrail feedback loop to automatically tune
 confidence_threshold values based on evaluation metrics.
 
 Example:
-    python tune_guardrails.py \
-        --config eval_data/eval_config.json \
-        --dataset eval_data/guardrail_test_data.jsonl \
-        --precision-target 0.90 \
+    python tune_guardrails.py \\
+        --config eval_data/eval_config.json \\
+        --dataset eval_data/guardrail_test_data.jsonl \\
+        --precision-target 0.90 \\
         --recall-target 0.90
 """
 
@@ -31,11 +31,11 @@ Examples:
   python tune_guardrails.py --config config.json --dataset test_data.jsonl
 
   # Custom targets prioritizing precision
-  python tune_guardrails.py --config config.json --dataset test_data.jsonl \
+  python tune_guardrails.py --config config.json --dataset test_data.jsonl \\
       --precision-target 0.95 --recall-target 0.85 --priority precision
 
   # More iterations with smaller steps
-  python tune_guardrails.py --config config.json --dataset test_data.jsonl \
+  python tune_guardrails.py --config config.json --dataset test_data.jsonl \\
       --max-iterations 20 --step-size 0.02
         """,
     )


### PR DESCRIPTION
## Summary

- Reject `--step-size` values less than or equal to zero before starting the guardrail feedback loop.
- Keep all valid positive step sizes and tuning behavior unchanged.

## Motivation

The threshold adjuster assumes `step_size` is positive but the CLI currently accepts any float.

A negative value reverses the intended tuning direction: an `INCREASE` action subtracts from the threshold and a `DECREASE` action adds to it, while the log message still says the opposite. A zero value can also stop tuning immediately without making a meaningful adjustment.

Failing at the CLI boundary prevents a configuration value from silently inverting the feedback loop.

## Validation

- positive `--step-size` -> existing behavior unchanged
- `--step-size 0` -> exits with a clear error
- negative `--step-size` -> exits with a clear error before the tuner is created

## Self-review

- [x] Four added validation lines in one CLI file.
- [x] Restored and verified the existing doubled command-continuation escaping; final diff contains no unrelated example-text changes.
- [x] No API, dependency, notebook, registry, or configuration-schema changes.
- [x] Searched open PRs for an existing negative-step fix and found none.

Maintainers may modify the branch if needed.