### PR TITLE
Report Promptfoo runtime failures as provider errors

### DIFF
--- a/examples/partners/agentic_governance_guide/promptfoo/promptfoo_target.py
+++ b/examples/partners/agentic_governance_guide/promptfoo/promptfoo_target.py
@@ -198,6 +198,6 @@ def call_api(prompt: str, options: dict, context: dict) -> dict:
                 "output": f"[BLOCKED] Guardrail triggered: {exc.guardrail_result.guardrail.name}"
             }
         except Exception as e:
-            return {"output": f"[ERROR] {str(e)}"}
+            return {"output": "", "error": str(e)}
 
     return asyncio.run(_run())


### PR DESCRIPTION
## Summary

- Return unexpected runtime/API failures through Promptfoo's provider `error` field instead of presenting them as assistant output.
- Keep successful responses and explicit guardrail-tripwire blocks unchanged.

## Motivation

The Promptfoo target currently catches any unexpected exception and returns `[ERROR] ...` in the normal `output` field. That makes infrastructure or provider failures look like model behavior to the red-team evaluator, so they can be scored as if the assistant actually produced that text.

Promptfoo's Python provider result contract has a dedicated `error` field for provider failures. Using it keeps evaluation failures distinct from governed assistant responses.

## Validation

- successful run -> existing `output` behavior unchanged
- input/output guardrail tripwire -> existing `[BLOCKED]` output unchanged
- unexpected runtime/API exception -> empty `output` plus populated `error`

## Self-review

- [x] One-line correctness fix in one file.
- [x] No model, policy, dependency, notebook, registry, or configuration changes.
- [x] Searched open PRs for an existing Promptfoo provider-error fix and found none.

Maintainers may modify the branch if needed.