### PR TITLE
Reject invalid realtime bootstrap tool mocks

### DIFF
--- a/examples/evals/realtime_evals/skills/bootstrap-realtime-eval/scripts/bootstrap_realtime_eval.py
+++ b/examples/evals/realtime_evals/skills/bootstrap-realtime-eval/scripts/bootstrap_realtime_eval.py
@@ -176,8 +176,9 @@ def parse_json_array(json_text: str) -> list[dict[str, Any]]:
         raise ValueError("Expected a JSON array.")
     normalized: list[dict[str, Any]] = []
     for item in parsed:
-        if isinstance(item, dict):
-            normalized.append(item)
+        if not isinstance(item, dict):
+            raise ValueError("Expected a JSON array of objects.")
+        normalized.append(item)
     return normalized
 
 


### PR DESCRIPTION
## Summary

- Require every entry in `--tool-mocks-json` to be a JSON object.
- Preserve valid object arrays and the existing empty-input behavior.

## Motivation

The realtime eval bootstrapper currently accepts a JSON array and silently drops any non-object entries while normalizing tool mocks. For example, a value such as `[{"name":"lookup"}, "unexpected"]` produces a generated simulation containing only the first entry, with no indication that part of the caller's configuration was discarded.

For eval scaffolding, silently changing the requested tool-mock set can produce a different test configuration than intended. Invalid entries should fail at the parser boundary instead.

## Validation

- empty input -> existing empty list behavior unchanged
- array containing only JSON objects -> existing behavior unchanged
- non-array JSON -> existing `ValueError` unchanged
- array containing any non-object entry -> clear `ValueError` instead of silent omission

## Self-review

- [x] Five changed lines in one bootstrap helper.
- [x] No harness runtime, model, API, notebook, registry, or generated schema changes for valid input.
- [x] Searched open PRs for an existing tool-mock validation fix and found none.

Maintainers may modify the branch if needed.