### PR TITLE
Reject non-positive parallel processor limits

### DIFF
--- a/examples/api_request_parallel_processor.py
+++ b/examples/api_request_parallel_processor.py
@@ -35,6 +35,7 @@ Inputs:
     - e.g., {"model": "text-embedding-3-small", "input": "embed me", "metadata": {"row_id": 1}}
     - as with all jsonl files, take care that newlines in the content are properly escaped (json.dumps does this automatically)
     - an example file is provided at examples/data/example_requests_to_parallel_process.jsonl
+    - the code to generate the example file is appended to the bottom of this script
 - save_filepath : str, optional
     - path to the file where the results will be saved
     - file will be a jsonl file, where each line is an array with the original request plus the API response

--- a/examples/api_request_parallel_processor.py
+++ b/examples/api_request_parallel_processor.py
@@ -35,7 +35,6 @@ Inputs:
     - e.g., {"model": "text-embedding-3-small", "input": "embed me", "metadata": {"row_id": 1}}
     - as with all jsonl files, take care that newlines in the content are properly escaped (json.dumps does this automatically)
     - an example file is provided at examples/data/example_requests_to_parallel_process.jsonl
-    - the code to generate the example file is appended to the bottom of this script
 - save_filepath : str, optional
     - path to the file where the results will be saved
     - file will be a jsonl file, where each line is an array with the original request plus the API response
@@ -119,6 +118,13 @@ async def process_api_requests_from_file(
     logging_level: int,
 ):
     """Processes API requests in parallel, throttling to stay under rate limits."""
+    if max_requests_per_minute <= 0:
+        raise ValueError("max_requests_per_minute must be positive")
+    if max_tokens_per_minute <= 0:
+        raise ValueError("max_tokens_per_minute must be positive")
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be at least 1")
+
     # constants
     seconds_to_pause_after_rate_limit_error = 15
     seconds_to_sleep_each_loop = (


### PR DESCRIPTION
## Summary

- Reject non-positive request and token rate limits before the parallel processor enters its scheduling loop.
- Require at least one request attempt so failed requests cannot be requeued indefinitely with a negative attempt counter.
- Keep all valid positive limits and retry behavior unchanged.

## Motivation

`process_api_requests_from_file()` assumes its scheduling limits are positive, but currently accepts zero and negative values.

That can make the processor fail to terminate:

- `max_requests_per_minute <= 0` means request capacity never reaches the `>= 1` scheduling condition.
- `max_tokens_per_minute <= 0` means token capacity cannot satisfy a positive request cost.
- `max_attempts == 0` is decremented to `-1` before the first call; if that call fails, `if self.attempts_left:` treats the negative value as truthy and requeues the request indefinitely.

Failing at the processor boundary prevents these hang/infinite-retry states without changing normal throttling behavior.

Closes #3012.

## Validation

- positive request/token limits and `max_attempts >= 1` -> existing behavior unchanged
- zero or negative request limit -> immediate `ValueError`
- zero or negative token limit -> immediate `ValueError`
- `max_attempts < 1` -> immediate `ValueError`
- validation occurs before opening the request file or entering the scheduling loop

## Self-review

- [x] Final diff is seven added lines in one file.
- [x] Restored an accidentally omitted documentation line before opening the PR; final compare contains no unrelated changes.
- [x] No API request schema, throttling formula, retry behavior for valid inputs, dependency, notebook, or registry changes.
- [x] Searched open PRs and found no competing fix.

Maintainers may modify the branch if needed.