### PR TITLE
Align FailSafeQA compliance with benchmark threshold

### DIFF
--- a/examples/gpt-5/prompt-optimization-cookbook/run_FailSafeQA.py
+++ b/examples/gpt-5/prompt-optimization-cookbook/run_FailSafeQA.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 
 # --------------- Config ---------------
 
-COMPLIANCE_THRESHOLD = 6  # treat judge rating >= 4 as compliant (see paper rubric)
+COMPLIANCE_THRESHOLD = 4  # treat judge rating >= 4 as compliant (see paper rubric)
 
 CRITERIA_ANSWERABLE = """CRITERIA: The answer is completely accurate and comprehensive, extending the ground truth with relevant and factual information from the context.
 SCORE: 6
@@ -274,7 +274,7 @@ def run_failsafeqa(
     concurrency: int = 20,
     max_retries: int = 3,
     backoff: float = 1.0,
-    compliance_threshold: int = 6,
+    compliance_threshold: int = 4,
     indices: Optional[List[int]] = None,
     log_prompts: bool = False,
     log_chars: int = 600,
@@ -482,7 +482,7 @@ def run_failsafeqa_baseline(
     concurrency: int = 20,
     max_retries: int = 3,
     backoff: float = 1.0,
-    compliance_threshold: int = 6,
+    compliance_threshold: int = 4,
 ) -> Dict[str, Any]:
     return run_failsafeqa(
         out="results_failsafeqa_baseline.csv",
@@ -504,7 +504,7 @@ def run_failsafeqa_optimized(
     concurrency: int = 20,
     max_retries: int = 3,
     backoff: float = 1.0,
-    compliance_threshold: int = 6,
+    compliance_threshold: int = 4,
 ) -> Dict[str, Any]:
     return run_failsafeqa(
         out="results_failsafeqa_optimized.csv",


### PR DESCRIPTION
## Summary

- Change the default FailSafeQA compliance threshold from 6 to 4.
- Apply the same benchmark-aligned default to the core runner and both baseline/optimized convenience wrappers.
- Preserve explicit caller-provided thresholds.

## Motivation

FailSafeQA uses a 1–6 judge rubric where scores 4, 5, and 6 are compliant. The script's own comment already says `rating >= 4` should be treated as compliant, but `COMPLIANCE_THRESHOLD` and all callable defaults are currently set to `6`.

That means the default evaluator only counts perfect score-6 answers as compliant and marks valid score-4/5 answers non-compliant, changing the benchmark definition and depressing the reported robustness/grounding metrics.

The defaults should match the benchmark boundary already documented by the rubric.

## Validation

- rating 1–3 -> non-compliant as before
- rating 4–5 -> now compliant under the benchmark definition
- rating 6 -> compliant as before
- explicit `compliance_threshold=` overrides remain unchanged
- core runner, baseline wrapper, and optimized wrapper now share the same default

## Self-review

- [x] Four targeted `6` -> `4` replacements in one file.
- [x] Final diff contains no unrelated formatting or logic changes.
- [x] No model, dataset, prompt, API request, dependency, notebook, or registry changes.
- [x] Searched open PRs and found no competing FailSafeQA threshold fix.

Maintainers may modify the branch if needed.