### PR TITLE
Fix TypeError in EvalsAPI_Audio_Inputs: access Result.passed as attribute

### DIFF
--- a/examples/evaluation/use-cases/EvalsAPI_Audio_Inputs.ipynb
+++ b/examples/evaluation/use-cases/EvalsAPI_Audio_Inputs.ipynb
@@ -479,7 +479,7 @@
     "                \"category\": [item.datasource_item[\"category\"] for item in output_items],\n",
     "                \"official_answer\": [item.datasource_item[\"official_answer\"] for item in output_items],\n",
     "                \"model_response\": [item.sample.output[0].content for item in output_items],\n",
-    "                \"grading_results\": [\"passed\" if item.results[0][\"passed\"] else \"failed\"\n",
+    "                \"grading_results\": [\"passed\" if item.results[0].passed else \"failed\"\n",
     "                                    for item in output_items]\n",
     "            })\n",
     "        display(df)\n",


### PR DESCRIPTION
## Summary

In the results-summary cell of `examples/evaluation/use-cases/EvalsAPI_Audio_Inputs.ipynb`, `item.results[0]["passed"]` raises `TypeError: 'Result' object is not subscriptable`. This changes the line to `item.results[0].passed`.

One-line change. The notebook JSON was edited in place, so the diff is exactly one line with no metadata churn.

## Motivation

The output-item `results` entries are typed `Result` Pydantic models in the current openai SDK (verified on 3.3.1), so the field must be read as an attribute. The same summary cell in the sibling notebook `EvalsAPI_Image_Inputs.ipynb` already uses attribute access on main; this brings the audio notebook in line with it.

This is existing content, not new or relocated, so no `registry.yaml` or `authors.yaml` changes are needed.
