### PR TITLE
Archive Compliance Logs Platform quickstart

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -3491,6 +3491,7 @@
   path: examples/chatgpt/compliance_api/logs_platform.ipynb
   slug: logs-platform
   date: 2025-12-11
+  archived: true
   authors:
     - kevinv-openai
   tags:


### PR DESCRIPTION
## Summary

Add `archived: true` to the existing `registry.yaml` entry for [OpenAI Compliance Logs Platform quickstart](https://developers.openai.com/cookbook/examples/chatgpt/compliance_api/logs_platform) by Kevin Verdieck.

The notebook at `examples/chatgpt/compliance_api/logs_platform.ipynb`, author attribution, and all other Cookbook entries remain unchanged. The diff is one insertion in one file.

## Motivation

Archive this quickstart through the repository's established registry-only convention, preserving the original source for reference. This follows the same mechanism used in #2954 and #2956.

## Validation

- Both the baseline and updated registry pass `.github/registry_schema.json` validation (311 entries).
- Semantic comparison confirms exactly one newly archived entry and no other metadata changes.
- The notebook is byte-identical to main; `git diff --check` passes.
- `python .github/scripts/check_notebooks.py` passes: no changed notebooks to validate. No Compliance API requests were executed.

## Self-review

- [x] Updated the existing registry entry for the exact quickstart.
- [x] Checked `authors.yaml`; `kevinv-openai` remains Kevin Verdieck, with no author changes needed.
- [x] Reviewed the exact diff and checked open archive-related PRs for overlap.

Based on `main` at `79791c4e0dcc794d0110787805a5833c87092132`.

[🧵 Codex Thread](https://chatgpt.com/s/cx_6a8ca1675cf48191a2b5fa90e678554a)<sub>[orig](https://codex-thread-link.openai.chatgpt.site/thread/01a0354f-463d-7003-9cfa-c73180120997)</sub>
[→ Review this PR in ChatGPT](https://chatgpt.com/?surface=work&prompt=Walk%20me%20through%20https%3A%2F%2Fgithub.com%2Fopenai%2Fopenai-cookbook%2Fpull%2F3023)
