### PR TITLE
Archive LM Studio gpt-oss setup guide

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -516,6 +516,7 @@
   path: articles/gpt-oss/run-locally-lmstudio.md
   slug: run-locally-lmstudio
   date: 2025-08-07
+  archived: true
   authors:
     - yagil
   tags:


### PR DESCRIPTION
## Summary

Set `archived: true` for **How to run gpt-oss locally with LM Studio** in `registry.yaml`. Preserve the article, path, slug, date, authors, and tags.

## Motivation

The guide primarily collects setup and SDK instructions already covered by LM Studio. Its Python and TypeScript file-writing examples are near-identical to the corresponding LM Studio examples, with little unique implementation guidance.

Equivalent documentation:

- [gpt-oss model setup and downloads](https://lmstudio.ai/models/gpt-oss)
- [Model loading](https://lmstudio.ai/docs/cli/local-models/load), [Chat Completions](https://lmstudio.ai/docs/developer/openai-compat/chat-completions), and [MCP setup](https://lmstudio.ai/docs/app/mcp)
- File-writing agent examples in [Python](https://lmstudio.ai/docs/python/agent/act#example-chat-loop-with-create-file-tool) and [TypeScript](https://lmstudio.ai/docs/typescript/agent/act#example-chat-loop-with-create-file-tool)

This archives redundant Cookbook guidance; it does not deprecate gpt-oss or LM Studio support.

## Validation and self-review

- `git diff --check` passed.
- Parsed the registry and validated it against `.github/registry_schema.json`.
- Confirmed the only data change is the target entry's archive flag.
- Notebook validator passed with no changed notebooks. No model execution needed for this metadata-only change.
- [x] Registry updated; no author changes required.
- [x] Self-reviewed scope, spelling, and reference links. No new content or deleted article files.

[🧵 Codex Thread](https://chatgpt.com/s/cx_6a8cce96e7a881918cd53d9edb106ff1)<sub>[orig](https://codex-thread-link.openai.chatgpt.site/thread/01a01c5a-c21a-7332-84e4-48a84e714e1e)</sub>
[→ Review this PR in ChatGPT](https://chatgpt.com/?surface=work&prompt=Walk%20me%20through%20https%3A%2F%2Fgithub.com%2Fopenai%2Fopenai-cookbook%2Fpull%2F3024)
