### PR TITLE
Archive six Cookbook guides and examples

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -648,6 +648,7 @@
     - open-models
     - gpt-oss
     - gpt-oss-server
+  archived: true
 
 - title: How to run gpt-oss locally with Ollama
   path: articles/gpt-oss/run-locally-ollama.md
@@ -1020,6 +1021,7 @@
     - shyamal-anadkat
   tags:
     - completions
+  archived: true
 
 - title: Creating slides with the Assistants API and DALL·E 3
   path: examples/Creating_slides_with_Assistants_API_and_DALL-E3.ipynb
@@ -1107,6 +1109,7 @@
   tags:
     - embeddings
     - completions
+  archived: true
 
 - title: Embedding texts that are longer than the model's maximum context length
   path: examples/Embedding_long_inputs.ipynb
@@ -2287,6 +2290,7 @@
   authors:
     - ted-at-openai
   tags: []
+  archived: true
 
 - title: Function calling with an OpenAPI specification
   path: examples/Function_calling_with_an_OpenAPI_spec.ipynb
@@ -2807,6 +2811,7 @@
   tags:
     - completions
     - functions
+  archived: true
 
 - title: GPT Actions library (Middleware) - Google Cloud Function
   path: examples/chatgpt/gpt_actions_library/gpt_middleware_google_cloud_function.md
@@ -3031,6 +3036,7 @@
     - vision
     - fine-tuning
     - completions
+  archived: true
 
 - title: Steering Text-to-Speech for more dynamic audio generation
   path: examples/voice_solutions/steering_tts.ipynb


### PR DESCRIPTION
## Summary

Add `archived: true` to six existing entries in `registry.yaml`:

- How to run gpt-oss with vLLM
- Embedding Wikipedia articles for search
- Vision Fine-tuning on GPT-4o for Visual Question Answering
- Introduction to Structured Outputs
- Using logprobs
- What makes documentation good

## Motivation

Continue the requested Cookbook catalog curation after #3025 merged. Remove these six entries from active discovery while preserving their content and existing URLs. This is an archival decision, not a claim that every example is broken.

## Validation and self-review

- [x] Registry and authors checked: exactly six existing archive flags added; no new entries or author changes.
- [x] All 311 registry entries pass the repository JSON schema, including date-format validation.
- [x] Parsed before/after comparison confirms only these six archive flags change. Paths, slugs, redirects, dates, tags, and attribution remain intact.
- [x] Repository notebook validation passed: no changed notebooks to validate. No code was executed or modified.
- [x] `git diff --check` passed. Final diff is one file, six additions.

## Rollout

Archival takes effect on the developers site after it refreshes upstream Cookbook content. No source content is deleted, and this PR does not update the separate Cookbook views dashboard.

[🧵 Codex Thread](https://chatgpt.com/s/cx_6a8cde9f929881919fd722391be93837)<sub>[orig](https://codex-thread-link.openai.chatgpt.site/thread/01a01c5a-c21a-7332-84e4-48a84e714e1e)</sub>
[→ Review this PR in ChatGPT](https://chatgpt.com/?surface=work&prompt=Walk%20me%20through%20https%3A%2F%2Fgithub.com%2Fopenai%2Fopenai-cookbook%2Fpull%2F3026)
