### PR TITLE
Archive seven Cookbook guides and examples

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -441,6 +441,7 @@
 - title: Building Consistent Workflows with Codex CLI & Agents SDK
   path: examples/codex/codex_mcp_agents_sdk/building_consistent_workflows_codex_cli_agents_sdk.ipynb
   slug: building-consistent-workflows-codex-cli-agents-sdk
+  archived: true
   date: 2025-10-01
   authors:
     - jhall-openai
@@ -486,6 +487,7 @@
 - title: Realtime Prompting Guide
   path: examples/Realtime_prompting_guide.ipynb
   slug: realtime-prompting-guide
+  archived: true
   date: 2026-02-25
   authors:
     - minh-hoque
@@ -498,6 +500,7 @@
 - title: "Fine-tune gpt-oss for better Korean language performance"
   path: articles/gpt-oss/fine-tune-korean.ipynb
   slug: fine-tune-korean
+  archived: true
   date: 2025-08-26
   authors:
     - heejingithub
@@ -3442,6 +3445,7 @@
 - title: Use Codex CLI to automatically fix CI failures
   path: examples/codex/Autofix-github-actions.ipynb
   slug: autofix-github-actions
+  archived: true
   date: 2025-09-30
   authors:
     - himadri518
@@ -3453,6 +3457,7 @@
 - title: Building resilient prompts using an evaluation flywheel
   path: examples/evaluation/Building_resilient_prompts_using_an_evaluation_flywheel.md
   slug: building-resilient-prompts-using-an-evaluation-flywheel
+  archived: true
   date: 2025-10-06
   authors:
     - neelk-oai
@@ -3598,6 +3603,7 @@
 - title: Skills in OpenAI API
   path: examples/skills_in_api.ipynb
   slug: skills-in-api
+  archived: true
   description: Cookbook for building skills with the OpenAI API.
   date: 2026-02-10
   authors:
@@ -3610,6 +3616,7 @@
 - title: Prompt Caching 201
   path: examples/Prompt_Caching_201.ipynb
   slug: prompt-caching-201
+  archived: true
   description: Cookbook for improving prompt caching hit rate, latency, and cost.
   date: 2026-02-18
   authors:


### PR DESCRIPTION
## Summary

Mark these seven existing Cookbook entries as archived in `registry.yaml`:

- Fine-tune gpt-oss for better Korean language performance
- Building Consistent Workflows with Codex CLI & Agents SDK
- Use Codex CLI to automatically fix CI failures
- Building resilient prompts using an evaluation flywheel
- Skills in OpenAI API
- Prompt Caching 201
- Realtime Prompting Guide

Preserve all notebooks, articles, assets, slugs, and author metadata. This PR does not change Docs links or redirects.

## Verification and self-review

- [x] Validated all 311 registry entries against `.github/registry_schema.json`, including date formats.
- [x] Confirmed exactly the seven requested entries changed, each only by adding `archived: true`.
- [x] Confirmed all seven content paths still exist and only `registry.yaml` changed.
- [x] Ran the repository notebook checker (no changed notebooks to validate).
- [x] Ran `git diff --check` and reviewed the complete seven-line diff.

The new-content checklist is not applicable to this metadata-only change. No notebook execution or production deployment is claimed.

[🧵 Codex Thread](https://chatgpt.com/s/cx_6a8f5271ddc48191bcce775447bafb03)<sub>[orig](https://codex-thread-link.openai.chatgpt.site/thread/01a03ac1-9f24-73f0-8027-088aca987260)</sub>
[→ Review this PR in ChatGPT](https://chatgpt.com/?surface=work&prompt=Walk%20me%20through%20https%3A%2F%2Fgithub.com%2Fopenai%2Fopenai-cookbook%2Fpull%2F3029)
