### PR TITLE
docs(codex): link archived recipes to current guidance

### DIFF
--- a/examples/codex/Autofix-github-actions.ipynb
+++ b/examples/codex/Autofix-github-actions.ipynb
@@ -7,6 +7,8 @@
    "source": [
     "# Autofix CI failures on GitHub with Codex CLI\n",
     "\n",
+    "> **Archived example — use the current CI guidance.** The workflow below exposes an API key to the whole job and combines repository-controlled execution with repository write permissions. Do not copy that credential and permission layout. Use the [current autofix workflow](https://learn.chatgpt.com/docs/non-interactive-mode#example-autofix-ci-failures-in-github-actions), which separates patch generation from pull request publication, and the [Codex GitHub Action security checklist](https://learn.chatgpt.com/docs/github-action#security-checklist).\n",
+    "\n",
     "## Purpose of this cookbook\n",
     "\n",
     "This cookbook shows you how to embed the OpenAI Codex CLI into your CI/CD pipeline so that when your builds or tests fail, codex automatically generates & proposes fixes. The following is an example in a node project with CI running in GitHub Actions. \n",

--- a/examples/codex/build_code_review_with_codex_sdk.md
+++ b/examples/codex/build_code_review_with_codex_sdk.md
@@ -1,5 +1,7 @@
 # Build Code Review with the Codex SDK
 
+> **Archived example — review the current CI guidance before using these workflows.** The GitHub example below exposes API and repository tokens to the whole job and combines review with pull request write permissions. Do not copy that credential and permission layout; a read-only sandbox alone does not protect secrets. Use the [current Codex GitHub Action workflow and security checklist](https://learn.chatgpt.com/docs/github-action), which separate review from posting feedback. For other CI systems, follow the [automation authentication guidance](https://learn.chatgpt.com/docs/non-interactive-mode#authenticate-in-automation).
+
 With [Code Review](https://chatgpt.com/codex/settings/code-review) in Codex Cloud, you can connect your team's cloud hosted GitHub repository to Codex and receive automated code reviews on every PR. But what if your code is hosted on-prem, or you don't have GitHub as an SCM?
 
 Luckily, we can replicate Codex's cloud hosted review process in our own CI/CD runners. In this guide, we'll build our own Code Review action using the Codex CLI headless mode with GitHub Actions, GitLab CI/CD, Azure DevOps Pipelines, and Jenkins.

--- a/examples/codex/codex_mcp_agents_sdk/building_consistent_workflows_codex_cli_agents_sdk.ipynb
+++ b/examples/codex/codex_mcp_agents_sdk/building_consistent_workflows_codex_cli_agents_sdk.ipynb
@@ -6,6 +6,9 @@
    "metadata": {},
    "source": [
     "# Building Consistent Workflows with Codex CLI & Agents SDK\n",
+    "\n",
+    "> **Archived example — the Codex MCP server is deprecated.** This notebook uses `codex mcp-server`, which the [current documentation](https://learn.chatgpt.com/docs/mcp-server) retains for existing integrations. For new automation and CI jobs, start with the [Codex SDK](https://learn.chatgpt.com/docs/codex-sdk). For a deeper integration that manages authentication, conversation history, approvals, and streamed events, use the [Codex app server](https://learn.chatgpt.com/docs/app-server). These are different interfaces; the code below is not a migration example.\n",
+    "\n",
     "### Ensuring Repeatable, Traceable, and Scalable Agentic Development\n",
     "\n",
     "## Introduction\n",


### PR DESCRIPTION
These archived Codex recipes remain reachable by direct URL and through Markdown retrieval. Their source content does not explain which instructions are outdated or where readers should go next. The GitHub examples use job-wide credentials and combine analysis with repository-write privileges; the orchestration example uses the deprecated `codex mcp-server` interface.

This PR adds one notice immediately after the title of each affected recipe:

- Autofix CI failures links the maintained autofix workflow and GitHub Action security checklist.
- Code Review identifies the GitHub credential/permission issue, links the separate review/publication pattern, and points other CI users to current authentication guidance.
- The MCP workflow names the deprecation and distinguishes the SDK automation path from app-server integrations.

The existing archive flags stay in place. Source-visible notices also preserve the explanation when the site's generic archive banner is omitted from Markdown retrieval. This is an interim documentation correction; it does not rewrite or validate the archived executable recipes.

Validation: repository Docs Editor review; both changed notebooks passed `.github/scripts/check_notebooks.py` with Python 3.12 and nbformat 5.10.4; independent comparisons confirmed all code cells, outputs, execution counts, cell order, and metadata are unchanged. The Markdown file preserves all prior content. `git diff --check` and all seven destination/three anchor checks passed. No notebook code was executed.

Registry and author updates are not applicable: no content was added, moved, or reattributed. The GitLab cookbook is handled separately so its update can be reviewed with the author of the maintained GitLab guide.
