### PR TITLE
docs(codex): point GitLab readers to maintained guidance

### DIFF
--- a/examples/codex/secure_quality_gitlab.md
+++ b/examples/codex/secure_quality_gitlab.md
@@ -1,5 +1,7 @@
 # Automating Code Quality and Security Fixes with Codex CLI in GitLab
 
+> **Update note — review the current guidance before using these examples.** The `--full-auto` flag used below is deprecated. Do not treat a failed Codex run or invalid output as an empty findings result. For general Codex automation, see [Non-interactive mode](https://learn.chatgpt.com/docs/non-interactive-mode). For dedicated Codex Security scanning and remediation, use the maintained [GitLab CI/CD guide](https://learn.chatgpt.com/docs/security/cli/ci/gitlab). That workflow differs from this article's code-quality analysis and interpretation of existing SAST results; the examples below have not been migrated to it.
+
 ## Introduction
 
 When deploying production code, most teams rely on CI/CD pipelines to validate changes before merging. Reviewers typically look at unit test results, vulnerability scans, and code quality reports. Traditionally, these are produced by rule-based engines that catch known issues but often miss contextual or higher-order problems—while leaving developers with noisy results that are hard to prioritize or act on.


### PR DESCRIPTION
The older GitLab cookbook still uses the deprecated `--full-auto` flag and includes result handling that can convert invalid output to an empty findings array or continue after a nonzero Codex exit. Readers can also confuse its general code-quality/SAST-interpretation workflows with the dedicated Codex Security scanner.

This PR adds a source-visible note at the top of the existing article. It identifies the outdated flag and result-handling risk, links current non-interactive Codex guidance, and directs Codex Security scanning/remediation users to the maintained GitLab CI/CD guide introduced in [openai/developers-website#2564](https://github.com/openai/developers-website/pull/2564).

The original examples remain unchanged. This is a scoped warning and routing correction, not a tested rewrite of the pipeline, a new archive designation, or a claim that the two workflows are interchangeable.

Johannes Bauer's review is requested on the distinction between general Codex interpretation of existing SAST findings and the dedicated Security workflow, and whether the maintained guide is the right destination for these readers.

Validation: repository Docs Editor review; verified current `--full-auto` deprecation and the dedicated GitLab guide; all added links resolve; exact comparison confirms all prior article text and code are preserved; `git diff --check` passed. No executable content changed and no CI pipeline or model call was run. Registry and author changes are not applicable.

Pre-merge `docs-editor` review rerun August 31 on `7e16f3186a386ce2d452a69bf41ad139c96d29e2`: reviewed the notice in the full article context using the repository skill and style guide. No edits or new P0/P1 findings in the notice. Both added links return HTTP 200; the current non-interactive guide confirms the deprecated compatibility flag. Exact comparison confirms the entire original article and all four code fences remain unchanged, both image targets exist in the reviewed Git tree, and `git diff --check` passes. The legacy flag and failure/empty-output risks remain in the old examples and are explicitly documented above and in the note; this is not a validation or modernization of that pipeline. No notebook, registry, author, or executable changes.
