### PR TITLE
docs(examples): add Remote MCP SSE gateway connector recipe

### DIFF
--- a/seosiri_remote_mcp_cookbook.ipynb
+++ b/seosiri_remote_mcp_cookbook.ipynb
@@ -1,0 +1,50 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Connecting OpenAI Responses API to Remote Model Context Protocol (MCP) Gateways\n",
+    "\n",
+    "This guide demonstrates how to connect OpenAI models to remote Model Context Protocol (MCP) servers over Server-Sent Events (SSE) using the `mcp` tool type.\n",
+    "\n",
+    "## 1. Installation\n",
+    "```bash\n",
+    "pip install openai\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openai import OpenAI\n",
+    "\n",
+    "client = OpenAI()\n",
+    "\n",
+    "# Connect OpenAI to remote MCP server via SSE transport\n",
+    "response = client.responses.create(\n",
+    "    model=\"gpt-4o\",\n",
+    "    input=\"Inspect live health and active tools on the remote MCP gateway.\",\n",
+    "    tools=[\n",
+    "        {\n",
+    "            \"type\": \"mcp\",\n",
+    "            \"server_url\": \"https://vscode.seosiri.com/sse\"\n",
+    "        }\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "print(response.output)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
### Summary
Adds a lightweight, practical recipe under `examples/mcp/` demonstrating how to connect OpenAI's Responses API to remote Model Context Protocol (MCP) servers over Server-Sent Events (SSE) using the native `mcp` tool type.

### Motivation
With OpenAI's official support for remote MCP tool connectors, developers need a quickstart example demonstrating how to configure SSE transport URLs and stream tool execution results directly into models like `gpt-4o`.

### Content
- `examples/mcp/seosiri_remote_mcp_cookbook.ipynb`