### PR TITLE
Avoid unnecessary reasoning summary requests in prompt optimizer helpers

### DIFF
--- a/examples/gpt-5/prompt-optimization-cookbook/scripts/gen_baseline.py
+++ b/examples/gpt-5/prompt-optimization-cookbook/scripts/gen_baseline.py
@@ -31,7 +31,7 @@ def _call_model_with_retry(
             {"role": "user", "content": [{"type": "input_text", "text": user_prompt}]},
         ],
         "text": {"format": {"type": "text"}, "verbosity": "medium"},
-        "reasoning": {"effort": "medium", "summary": "auto"},
+        "reasoning": {"effort": "medium"},
         "tools": [],
     }
     for attempt in range(max_retries):

--- a/examples/gpt-5/prompt-optimization-cookbook/scripts/gen_optimized.py
+++ b/examples/gpt-5/prompt-optimization-cookbook/scripts/gen_optimized.py
@@ -28,7 +28,7 @@ def _call_model_with_retry(*, model: str, dev_prompt: str, user_prompt: str, max
             {"role": "user", "content": [{"type": "input_text", "text": user_prompt}]},
         ],
         "text": {"format": {"type": "text"}, "verbosity": "medium"},
-        "reasoning": {"effort": "medium", "summary": "auto"},
+        "reasoning": {"effort": "medium"},
         "tools": [],
     }
     for attempt in range(max_retries):

--- a/examples/gpt-5/prompt-optimization-cookbook/scripts/llm_judge.py
+++ b/examples/gpt-5/prompt-optimization-cookbook/scripts/llm_judge.py
@@ -136,7 +136,7 @@ def judge_folder(
                     model=model,
                     input=messages,
                     text={"format": {"type": "text"}, "verbosity": "medium"},
-                    reasoning={"effort": "medium", "summary": "auto"},
+                    reasoning={"effort": "medium"},
                     tools=[],
                 )
                 raw = _to_text(resp)
@@ -279,7 +279,7 @@ def judge_one(
                 model=model,
                 input=messages,
                 text={"format": {"type": "text"}, "verbosity": "medium"},
-                reasoning={"effort": "medium", "summary": "auto"},
+                reasoning={"effort": "medium"},
                 tools=[],
             )
             raw = _to_text(resp)


### PR DESCRIPTION
## Summary

- Stop requesting reasoning summaries in the prompt optimizer Top-K generation helpers and LLM judge.
- Keep reasoning effort at `medium`.
- Leave prompts, output handling, retries, concurrency, and evaluation logic unchanged.

## Motivation

These helpers only consume the final response text, but they also request `summary: "auto"`. Users have reported organization-verification errors when reasoning summaries are requested, even though the example does not use the summary.

Reasoning summaries are optional, so these paths should not require them when they are unused.

Related to #2271.

## Validation

- Baseline generation still uses `reasoning={"effort": "medium"}`.
- Optimized generation still uses `reasoning={"effort": "medium"}`.
- Both LLM judge paths still use `reasoning={"effort": "medium"}`.
- Final diff is limited to three helper files and four request fields.
