### PR TITLE
Fix stale embeddings documentation link

### DIFF
--- a/articles/text_comparison_examples.md
+++ b/articles/text_comparison_examples.md
@@ -1,6 +1,6 @@
 # Text comparison examples
 
-The [OpenAI API embeddings endpoint](https://beta.openai.com/docs/guides/embeddings) can be used to measure relatedness or similarity between pieces of text.
+The [OpenAI API embeddings endpoint](https://developers.openai.com/api/docs/guides/embeddings) can be used to measure relatedness or similarity between pieces of text.
 
 By leveraging GPT-3's understanding of text, these embeddings [achieved state-of-the-art results](https://arxiv.org/abs/2201.10005) on benchmarks in unsupervised learning and transfer learning settings.
 


### PR DESCRIPTION
## Summary

- Replace the retired `beta.openai.com` embeddings guide URL with the current OpenAI embeddings documentation.
- Leave all other article content unchanged.

## Motivation

`articles/text_comparison_examples.md` links to the old `beta.openai.com/docs/guides/embeddings` page. The current embeddings guide is hosted at `developers.openai.com/api/docs/guides/embeddings`.

## Validation

- Verified the replacement URL resolves to OpenAI's current Vector embeddings guide.
- Final diff is one changed line in one Markdown file.
