### PR TITLE
Update Realtime API documentation links

### DIFF
--- a/examples/voice_solutions/one_way_translation_using_realtime_api/README.md
+++ b/examples/voice_solutions/one_way_translation_using_realtime_api/README.md
@@ -1,6 +1,6 @@
 # Translation Demo
 
-This project demonstrates how to use the [OpenAI Realtime API](https://platform.openai.com/docs/guides/realtime) to build a one-way translation application with WebSockets. It is implemented using the [Realtime + Websockets integration](https://platform.openai.com/docs/guides/realtime-websocket). A real-world use case for this demo is multilingual, conversational translation—where a speaker talks into the speaker app and listeners hear translations in their selected native languages via the listener app. Imagine a conference room with multiple participants with headphones, listening live to a speaker in their own languages. Due to the current turn-based nature of audio models, the speaker must pause briefly to allow the model to process and translate speech. However, as models become faster and more efficient, this latency will decrease significantly and the translation will become more seamless.
+This project demonstrates how to use the [OpenAI Realtime API](https://developers.openai.com/api/docs/guides/realtime) to build a one-way translation application with WebSockets. It is implemented using the [Realtime + Websockets integration](https://developers.openai.com/api/docs/guides/realtime-websocket). A real-world use case for this demo is multilingual, conversational translation—where a speaker talks into the speaker app and listeners hear translations in their selected native languages via the listener app. Imagine a conference room with multiple participants with headphones, listening live to a speaker in their own languages. Due to the current turn-based nature of audio models, the speaker must pause briefly to allow the model to process and translate speech. However, as models become faster and more efficient, this latency will decrease significantly and the translation will become more seamless.
 
 ## How to Use
 
@@ -9,7 +9,7 @@ This project demonstrates how to use the [OpenAI Realtime API](https://platform.
 1. **Set up the OpenAI API:**
 
    - If you're new to the OpenAI API, [sign up for an account](https://platform.openai.com/signup).
-   - Follow the [Quickstart](https://platform.openai.com/docs/quickstart) to retrieve your API key.
+   - Follow the [Quickstart](https://developers.openai.com/api/docs/quickstart) to retrieve your API key.
 
 2. **Clone the Repository:**
 


### PR DESCRIPTION
## Summary

- Replace legacy OpenAI Realtime overview, WebSocket, and Quickstart documentation links with their current developers.openai.com locations.
- Leave the application instructions and code unchanged.

## Validation

- Verified all three replacement documentation pages resolve.
- Final diff is limited to documentation URLs in one README.