### PR TITLE
Update Elasticsearch Chat Completions documentation link

### DIFF
--- a/examples/vector_databases/elasticsearch/README.md
+++ b/examples/vector_databases/elasticsearch/README.md
@@ -27,5 +27,5 @@ In this notebook you'll learn how to:
 This notebooks builds on the semantic search notebook by:
 
 - Selecting the top hit from a semantic search
-- Sending that result to the OpenAI [Chat Completions](https://platform.openai.com/docs/guides/gpt/chat-completions-api) API endpoint for retrieval augmented generation (RAG)
+- Sending that result to the OpenAI [Chat Completions](https://developers.openai.com/api/docs/guides/text) API endpoint for retrieval augmented generation (RAG)
 


### PR DESCRIPTION
## Summary

- Replace the outdated Chat Completions documentation URL in the Elasticsearch README with the current OpenAI text-generation guide.
- Leave all other content unchanged.

## Validation

- Verified the replacement URL resolves to the current OpenAI Text generation documentation.
- Final diff is one changed line in one README.