### PR TITLE
docs: fix duplicate 'on' in web search example prompt

### DIFF
--- a/examples/third_party/Web_search_with_google_api_bring_your_own_browser_tool.ipynb
+++ b/examples/third_party/Web_search_with_google_api_bring_your_own_browser_tool.ipynb
@@ -579,7 +579,7 @@
     "import json \n",
     "\n",
     "final_prompt = (\n",
-    "    f\"The user will provide a dictionary of search results in JSON format for search query {search_term} Based on on the search results provided by the user, provide a detailed response to this query: **'{search_query}'**. Make sure to cite all the sources at the end of your answer.\"\n",
+    "    f\"The user will provide a dictionary of search results in JSON format for search query {search_term} Based on the search results provided by the user, provide a detailed response to this query: **'{search_query}'**. Make sure to cite all the sources at the end of your answer.\"\n",
     ")\n",
     "\n",
     "response = client.chat.completions.create(\n",


### PR DESCRIPTION
## Summary
- Fix a duplicated word in the web search example notebook: "Based on on the search results" → "Based on the search results" in the `final_prompt` string.

## Motivation
- The prompt sent to the model contains a duplicated "on", which is a clear typo in the example code. Fixing it keeps the example clean and correct.

## Change
- `examples/third_party/Web_search_with_google_api_bring_your_own_browser_tool.ipynb` — one-word removal in the prompt-building code cell.

## Verification
- [x] Notebook JSON parses correctly after the edit
- [x] `git diff --check` clean
- [x] Diff is 1 line / 1 file
- [x] No duplicate "on on" remains in the file

This change is intentionally tiny and documentation-only (example code string).
