### PR TITLE
[chatgpt] Add Google Drive access policy Admin API example

### DIFF
--- a/examples/chatgpt/google_drive_access/google_drive_access.md
+++ b/examples/chatgpt/google_drive_access/google_drive_access.md
@@ -1,0 +1,284 @@
+# Manage Google Drive access with the ChatGPT Admin API
+
+ChatGPT workspace administrators can choose which Google shared drives the
+Google Drive app may access and configure My Drive access separately. This
+example previews and updates those settings through the ChatGPT Admin API.
+
+The [administration script](google_drive_access_admin.py) uses only the Python
+standard library. It accepts shared-drive IDs or root URLs, imports CSV/text
+files, and supports replacing, adding to, or removing from a selected-drive
+allowlist.
+
+> **Availability:** This example targets the Google Drive access-policy Admin
+> API. Confirm that the endpoint and Google Drive policy enforcement are
+> enabled for your workspace before relying on a policy to restrict access.
+> A successful policy read or save alone does not establish that enforcement
+> is active.
+
+## Understand the policy
+
+All operations use this URL, where `<workspace-id>` is your ChatGPT workspace UUID:
+
+```text
+https://api.chatgpt.com/v1/manage/workspaces/<workspace-id>/google-drive/drive-access/allow-list
+```
+
+| Method | Behavior |
+| --- | --- |
+| `GET` | Read the shared-drive allowlist and My Drive setting. |
+| `PUT` | Replace the shared-drive allowlist; optionally update My Drive. |
+| `DELETE` | Allow all shared drives; preserve the current My Drive setting. |
+
+Every `PUT` requires `drive_ids`. Its three possible states have different meanings:
+
+| `drive_ids` | Shared-drive access |
+| --- | --- |
+| `null` | All shared drives permitted by the user's Google permissions. |
+| `[]` | No shared drives. |
+| `["0AExampleFinanceDrive"]` | Only the listed shared drives, subject to Google permissions. |
+
+`allow_personal_drive` is a separate boolean. Omit it, or send `null`, to preserve
+the setting observed by the server. Its default is `true`. Setting it to `false`
+blocks files outside shared drives, including files shared from another user's
+My Drive. To block both categories, use `drive_ids: []` and
+`allow_personal_drive: false` together.
+
+The API supports whole shared drives, with at most 1,000 IDs per request. IDs
+are case sensitive and contain 5–512 ASCII letters, digits, underscores, or
+hyphens. The script deduplicates IDs before sending them. The API does not
+resolve names or URLs, verify that IDs exist, grant Google permissions, or
+support drive exclusion lists or individual file/folder policies.
+
+## Set up credentials
+
+You need Python 3.10 or later, your workspace UUID, and a ChatGPT workspace
+Admin API key with administrator permissions in the workspace's organization.
+All three methods, including `GET`, require `chatgpt.enterprise.apps.write`.
+
+In the ChatGPT Admin Console, select your workspace, open **Credentials**, and
+choose the **Admin keys** tab. Create a key with **Restricted** permissions and
+set **Apps** to **Write**. An OpenAI API Platform key cannot replace this
+workspace Admin API key.
+
+In Bash, prompt for the key without putting its value in shell history:
+
+```bash
+read -r -s -p "ChatGPT workspace admin key: " CHATGPT_ADMIN_TOKEN
+echo
+export CHATGPT_ADMIN_TOKEN
+
+export WORKSPACE_ID="<workspace-id>"
+```
+
+Replace `<workspace-id>` with your workspace UUID. Run the administration
+commands below from `examples/chatgpt/google_drive_access` in a checkout of this
+repository. No third-party Python packages are required.
+
+### Optional Google Drive credential
+
+The `inspect` command and any command using root URLs also require
+`GOOGLE_DRIVE_TOKEN`. Obtain a Google OAuth access token with the
+`https://www.googleapis.com/auth/drive.readonly` scope, using your organization's
+approved OAuth application with the Google Drive API enabled. The token's user
+must be able to read the shared drives' metadata. See Google's
+[OAuth setup guide](https://developers.google.com/workspace/drive/api/quickstart/python#authorize_credentials_for_a_desktop_application)
+for an example credential setup.
+
+If you adapt that quickstart, request `drive.readonly` instead of its sample
+`drive.metadata.readonly` scope and authorize again after changing scopes.
+Supply the resulting access token, rather than a client secret or refresh token.
+The administration script does not obtain or refresh Google tokens.
+
+```bash
+read -r -s -p "Google Drive access token: " GOOGLE_DRIVE_TOKEN
+echo
+export GOOGLE_DRIVE_TOKEN
+```
+
+The script uses Google's
+[`drives.get` method](https://developers.google.com/workspace/drive/api/reference/rest/v3/drives/get)
+to verify a shared-drive ID and retrieve its name. It does not request domain
+administrator access. Names appear only in inspection and preview output; the
+ChatGPT policy receives IDs. ID-only policy commands do not require a Google
+token and perform syntax validation only.
+
+## Inspect shared drives
+
+Select a shared drive in Google Drive and copy the URL of its root. Replace the
+illustrative ID below with your drive's actual ID:
+
+```bash
+python3 google_drive_access_admin.py inspect \
+  --drive-url https://drive.google.com/drive/folders/0AExampleFinanceDrive
+```
+
+URLs containing an account index, such as `/drive/u/0/folders/ID`, are also
+accepted. A folder URL can look like a drive-root URL, so the script validates
+the extracted ID with `drives.get`. It rejects an ordinary folder instead of
+expanding the request to its containing shared drive. You can also inspect an
+ID directly with `--drive-id`. Inspection calls only Google and does not require
+the ChatGPT Admin API key.
+
+## Read the current policy
+
+```bash
+python3 google_drive_access_admin.py list --workspace-id "$WORKSPACE_ID"
+```
+
+A policy allowing selected shared drives while blocking My Drive looks like:
+
+```json
+{
+  "object": "workspace.google_drive.access_policy",
+  "allow_list": ["0AExampleFinanceDrive", "0AExampleResearchDrive"],
+  "allow_personal_drive": false
+}
+```
+
+The response field is `allow_list`; the request field is `drive_ids`.
+
+## Prepare and replace an allowlist
+
+Create `drives.csv` with a `drive_id` column:
+
+```csv
+drive_id
+0AExampleFinanceDrive
+0AExampleResearchDrive
+```
+
+Replace these sample IDs with actual shared-drive IDs. A CSV with a `drive_url`
+column also works; use exactly one of these two columns. A text file may contain
+one ID or root URL per line. Blank lines, text-file comments starting with `#`,
+and CSV rows without a value in the chosen column are ignored. An empty input
+cannot replace the policy; use the explicit `block-all` command for that intent.
+
+Preview a replacement that also blocks My Drive:
+
+```bash
+python3 google_drive_access_admin.py replace \
+  --workspace-id "$WORKSPACE_ID" \
+  --drives-file drives.csv \
+  --my-drive block \
+  --dry-run
+```
+
+The preview prints the current and proposed policies, resolved drives, HTTP
+method, and request body. It reads the current policy and verifies any supplied
+URLs without writing. Review the result, then run the same command without
+`--dry-run` to send:
+
+```http
+PUT /v1/manage/workspaces/<workspace-id>/google-drive/drive-access/allow-list
+Authorization: Bearer <CHATGPT_ADMIN_TOKEN>
+Content-Type: application/json
+
+{
+  "drive_ids": ["0AExampleFinanceDrive", "0AExampleResearchDrive"],
+  "allow_personal_drive": false
+}
+```
+
+This replaces the full shared-drive allowlist. Omit `--my-drive` to preserve its
+observed setting. You can supply repeated `--drive-id` or `--drive-url` options
+instead of a file, or combine them with a file.
+
+## Add or remove selected drives
+
+For an existing finite allowlist, the script reads it, computes the union or
+difference, and sends one replacement `PUT`:
+
+```bash
+python3 google_drive_access_admin.py add \
+  --workspace-id "$WORKSPACE_ID" \
+  --drive-id 0AExampleOperationsDrive \
+  --dry-run
+
+python3 google_drive_access_admin.py remove \
+  --workspace-id "$WORKSPACE_ID" \
+  --drive-id 0AExampleFinanceDrive \
+  --dry-run
+```
+
+Remove `--dry-run` after review. Removing the final selected drive blocks every
+shared drive and requires `--yes`. Adding a duplicate or removing an absent ID
+leaves the policy unchanged, unless you also change My Drive.
+
+When `allow_list` is `null`, both `add` and `remove` stop: all shared drives are
+already allowed, and the API has no exclusion-list operation. Use `replace` to
+select a finite set. To remove an inaccessible drive, supply its known ID
+directly; URL verification requires Google access to that drive.
+
+## Change My Drive access
+
+To change My Drive while carrying forward the observed shared-drive policy:
+
+```bash
+python3 google_drive_access_admin.py set-my-drive \
+  --workspace-id "$WORKSPACE_ID" \
+  --my-drive block \
+  --dry-run
+```
+
+Review and remove `--dry-run` to apply. Use `--my-drive allow` to allow My Drive.
+The request includes the observed shared-drive IDs because `PUT` requires
+`drive_ids`, even when only My Drive is changing.
+
+## Block or restore shared-drive access
+
+Preview blocking all shared drives and My Drive together:
+
+```bash
+python3 google_drive_access_admin.py block-all \
+  --workspace-id "$WORKSPACE_ID" --my-drive block --dry-run
+```
+
+To apply, replace `--dry-run` with `--yes`. Without `--my-drive`, this command
+blocks shared drives while preserving the observed My Drive setting.
+
+To remove the shared-drive restriction, preview `reset`:
+
+```bash
+python3 google_drive_access_admin.py reset \
+  --workspace-id "$WORKSPACE_ID" --dry-run
+```
+
+Replace `--dry-run` with `--yes` to send `DELETE`. Reset sets `allow_list` to
+`null` and preserves My Drive. It does not reset My Drive to its default.
+Commands whose proposed policy already matches the read policy skip the write.
+
+## Coordinate writes and handle errors
+
+Run one administrator's update at a time. This endpoint has no version
+precondition or guaranteed conflict detection. A concurrent save can overwrite
+changes to these controls or other Google Drive app settings. A dry run is a
+preview, not a reservation; applying the command reads the policy again.
+Keep the app's enabled/disabled state in mind: saving a policy does not enable
+a disabled Google Drive app.
+
+The example retries `GET` requests up to twice after transient network errors or
+HTTP 429, 502, 503, or 504. It sends each `PUT` or `DELETE` only once and provides
+no idempotency-key option. After an ambiguous write failure, run `list`, inspect
+the current state, and reconcile your intended change before retrying.
+
+| Error | What to check |
+| --- | --- |
+| HTTP 401 or 403 | Admin key, `chatgpt.enterprise.apps.write`, administrator permissions, workspace organization, and feature availability. For Google requests, check the Google token and drive access. |
+| HTTP 404 | Workspace ID or shared-drive ID. A folder ID is not a shared-drive ID. |
+| HTTP 400 | Request fields, ID format, and the 1,000-entry limit. |
+| HTTP 409 | Read the current policy and review conflicting changes before retrying. Concurrent saves do not always produce this error. |
+| HTTP 429 | Wait before retrying a write, then inspect the current policy. |
+| HTTP 503 | The Google Drive policy capability may be unavailable or a service may be temporarily unavailable. Confirm workspace support if it persists. |
+
+## Run the offline tests
+
+From the repository root:
+
+```bash
+python3 -B -m unittest discover \
+  -s examples/chatgpt/google_drive_access \
+  -p 'test_*.py' -v
+```
+
+The tests mock Google Drive and the ChatGPT Admin API. They require no
+credentials and make no live requests.

--- a/examples/chatgpt/google_drive_access/google_drive_access_admin.py
+++ b/examples/chatgpt/google_drive_access/google_drive_access_admin.py
@@ -1,0 +1,336 @@
+"""Inspect shared drives and manage Google Drive access in a ChatGPT workspace."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import time
+import uuid
+from http.client import HTTPException
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError
+from urllib.parse import quote, unquote, urlparse
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+CHATGPT_API_BASE_URL = "https://api.chatgpt.com"
+GOOGLE_DRIVE_API_BASE_URL = "https://www.googleapis.com/drive/v3"
+MAX_DRIVES = 1_000
+POLICY_OBJECT = "workspace.google_drive.access_policy"
+DRIVE_ACTIONS = {"inspect", "replace", "add", "remove"}
+
+
+class NoRedirect(HTTPRedirectHandler):
+    """Keep bearer credentials on the API origin selected by this script."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise HTTPError(req.full_url, code, "Unexpected API redirect", headers, fp)
+
+
+def request_json(
+    method: str, url: str, token: str, *, body: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Retry reads only; a failed write can have an uncertain outcome."""
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+    data = None
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(body).encode("utf-8")
+    attempts = 3 if method == "GET" else 1
+    opener = build_opener(NoRedirect())
+    for attempt in range(attempts):
+        try:
+            request = Request(url, data=data, headers=headers, method=method)
+            with opener.open(request, timeout=30) as response:
+                payload = json.load(response)
+            if not isinstance(payload, dict):
+                raise TypeError("Expected a JSON object")
+            return payload
+        except HTTPError as error:
+            error.close()
+            if error.code in {429, 502, 503, 504} and attempt + 1 < attempts:
+                time.sleep(2**attempt)
+                continue
+            detail = f"HTTP {error.code}"
+        except (OSError, HTTPException):
+            if attempt + 1 < attempts:
+                time.sleep(2**attempt)
+                continue
+            detail = "network error or timeout"
+        except (ValueError, TypeError, UnicodeError):
+            detail = "invalid JSON response"
+        advice = "" if method == "GET" else " Read the current policy before retrying."
+        raise SystemExit(f"{method} {url} failed: {detail}.{advice}")
+    raise AssertionError("unreachable")
+
+
+def validate_drive_id(value: str) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[A-Za-z0-9_-]{5,512}", value):
+        raise SystemExit("Shared-drive IDs must contain 5–512 letters, digits, _ or -")
+    return value
+
+
+def parse_drive_reference(value: str) -> tuple[str, bool]:
+    """Extract an ID; a URL still needs drives.get to verify it is a drive root."""
+    value = value.strip()
+    if "://" not in value:
+        return validate_drive_id(value), False
+    try:
+        parsed = urlparse(value)
+    except ValueError as error:
+        raise SystemExit("Use a valid HTTPS shared-drive root URL") from error
+    match = re.fullmatch(r"/drive/(?:u/[0-9]+/)?folders/([^/]+)/?", parsed.path)
+    if parsed.scheme != "https" or parsed.netloc != "drive.google.com" or not match:
+        raise SystemExit(
+            "Use a shared-drive root URL: https://drive.google.com/drive/folders/ID"
+        )
+    return validate_drive_id(unquote(match.group(1))), True
+
+
+def read_drive_references(
+    drive_ids: list[str], drive_urls: list[str], drives_file: str | None
+) -> list[str]:
+    values = [validate_drive_id(value.strip()) for value in drive_ids]
+    for value in drive_urls:
+        if not parse_drive_reference(value)[1]:
+            raise SystemExit("--drive-url requires a shared-drive root URL")
+        values.append(value.strip())
+    if drives_file:
+        source = Path(drives_file)
+        try:
+            with source.open(encoding="utf-8-sig", newline="") as handle:
+                if source.suffix.casefold() == ".csv":
+                    reader = csv.DictReader(handle, strict=True)
+                    columns = [
+                        name
+                        for name in reader.fieldnames or []
+                        if name in {"drive_id", "drive_url"}
+                    ]
+                    if len(columns) != 1:
+                        raise SystemExit(
+                            "CSV must have exactly one drive_id or drive_url column"
+                        )
+                    for row in reader:
+                        if None in row:
+                            raise SystemExit("CSV row has more values than its header")
+                        value = row.get(columns[0])
+                        if value and value.strip():
+                            value = value.strip()
+                            if columns[0] == "drive_id":
+                                validate_drive_id(value)
+                            elif not parse_drive_reference(value)[1]:
+                                raise SystemExit(
+                                    "The drive_url column must contain root URLs"
+                                )
+                            values.append(value)
+                else:
+                    values.extend(
+                        line.strip()
+                        for line in handle
+                        if line.strip() and not line.lstrip().startswith("#")
+                    )
+        except (OSError, UnicodeError, csv.Error) as error:
+            raise SystemExit(f"Cannot read drives file: {source}") from error
+    return list(dict.fromkeys(values))
+
+
+def resolve_drives(
+    references: list[str], *, inspect: bool = False
+) -> list[dict[str, str]]:
+    required: dict[str, bool] = {}
+    for reference in references:
+        drive_id, is_url = parse_drive_reference(reference)
+        required[drive_id] = required.get(drive_id, False) or is_url or inspect
+    if len(required) > MAX_DRIVES:
+        raise SystemExit("A policy can contain at most 1,000 unique shared drives")
+    token = os.environ.get("GOOGLE_DRIVE_TOKEN")
+    if any(required.values()) and not token:
+        raise SystemExit("Set GOOGLE_DRIVE_TOKEN to inspect drives or verify root URLs")
+    drives = []
+    for drive_id, verify in required.items():
+        drive = {"id": drive_id}
+        if verify:
+            metadata = request_json(
+                "GET",
+                f"{GOOGLE_DRIVE_API_BASE_URL}/drives/{quote(drive_id, safe='')}?fields=id,name",
+                token,
+            )
+            if metadata.get("id") != drive_id or not isinstance(
+                metadata.get("name"), str
+            ):
+                raise SystemExit(
+                    "Google Drive returned unexpected shared-drive metadata"
+                )
+            drive["name"] = metadata["name"]
+        drives.append(drive)
+    return drives
+
+
+def validate_policy(policy: dict[str, Any]) -> dict[str, Any]:
+    """Reject incomplete reads before using them to construct a replacement."""
+    if (
+        policy.get("object") != POLICY_OBJECT
+        or "allow_list" not in policy
+        or type(policy.get("allow_personal_drive")) is not bool
+    ):
+        raise SystemExit("The Admin API returned an unexpected Google Drive policy")
+    allowed = policy["allow_list"]
+    if allowed is not None:
+        if not isinstance(allowed, list) or len(allowed) > MAX_DRIVES:
+            raise SystemExit("The Admin API returned an invalid shared-drive allowlist")
+        allowed = sorted({validate_drive_id(value) for value in allowed})
+    return {
+        "object": POLICY_OBJECT,
+        "allow_list": allowed,
+        "allow_personal_drive": policy["allow_personal_drive"],
+    }
+
+
+def plan_update(
+    current: dict[str, Any], action: str, drive_ids: list[str], my_drive: str | None
+) -> tuple[str, dict[str, Any] | None, dict[str, Any]]:
+    """Translate CLI operations into the endpoint's full replacement contract."""
+    allowed = current["allow_list"]
+    if action == "reset":
+        return "DELETE", None, {**current, "allow_list": None}
+    if action == "replace":
+        allowed = sorted(set(drive_ids))
+    elif action in {"add", "remove"}:
+        if allowed is None:
+            raise SystemExit(
+                "All shared drives are currently allowed. Use replace to choose a finite allowlist; exclude lists are unsupported."
+            )
+        selected = set(allowed)
+        allowed = sorted(
+            selected | set(drive_ids) if action == "add" else selected - set(drive_ids)
+        )
+    elif action == "block-all":
+        allowed = []
+    if allowed is not None and len(allowed) > MAX_DRIVES:
+        raise SystemExit("The resulting policy exceeds 1,000 shared drives")
+    body = {"drive_ids": allowed}
+    proposed = {**current, "allow_list": allowed}
+    if my_drive is not None:
+        body["allow_personal_drive"] = my_drive == "allow"
+        proposed["allow_personal_drive"] = my_drive == "allow"
+    return "PUT", body, proposed
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "action",
+        choices=[
+            "inspect",
+            "list",
+            "replace",
+            "add",
+            "remove",
+            "reset",
+            "block-all",
+            "set-my-drive",
+        ],
+    )
+    parser.add_argument("--workspace-id", help="ChatGPT workspace UUID")
+    parser.add_argument(
+        "--drive-id",
+        action="append",
+        default=[],
+        help="Repeat for multiple shared-drive IDs",
+    )
+    parser.add_argument(
+        "--drive-url",
+        action="append",
+        default=[],
+        help="Repeat for multiple shared-drive root URLs",
+    )
+    parser.add_argument(
+        "--drives-file",
+        help="Text file of IDs/root URLs, or CSV with drive_id or drive_url",
+    )
+    parser.add_argument(
+        "--my-drive",
+        choices=["allow", "block"],
+        help="Optionally update My Drive access with the shared-drive policy",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Read and preview without writing"
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm reset or blocking every shared drive",
+    )
+    args = parser.parse_args(argv)
+
+    has_input = bool(args.drive_id or args.drive_url or args.drives_file)
+    if args.action not in DRIVE_ACTIONS and has_input:
+        parser.error(f"{args.action} does not accept drive inputs")
+    if args.action in {"inspect", "list", "reset"} and args.my_drive is not None:
+        parser.error(f"{args.action} does not accept --my-drive")
+    if args.action == "set-my-drive" and args.my_drive is None:
+        parser.error("set-my-drive requires --my-drive allow or block")
+    references = read_drive_references(args.drive_id, args.drive_url, args.drives_file)
+    if args.action in DRIVE_ACTIONS and not references:
+        parser.error(
+            "Provide at least one --drive-id, --drive-url or nonempty --drives-file"
+        )
+    workspace_id = None
+    admin_token = None
+    if args.action != "inspect":
+        try:
+            workspace_id = str(uuid.UUID(args.workspace_id or ""))
+        except ValueError:
+            parser.error("--workspace-id must be a valid workspace UUID")
+        admin_token = os.environ.get("CHATGPT_ADMIN_TOKEN")
+        if not admin_token:
+            parser.error("Set CHATGPT_ADMIN_TOKEN before reading or updating a policy")
+    drives = resolve_drives(references, inspect=args.action == "inspect")
+    if args.action == "inspect":
+        print(json.dumps({"drives": drives}, indent=2))
+        return
+
+    url = f"{CHATGPT_API_BASE_URL}/v1/manage/workspaces/{workspace_id}/google-drive/drive-access/allow-list"
+    current = validate_policy(request_json("GET", url, admin_token))
+    if args.action == "list":
+        print(json.dumps(current, indent=2))
+        return
+    method, body, proposed = plan_update(
+        current, args.action, [drive["id"] for drive in drives], args.my_drive
+    )
+    preview = {
+        "workspace_id": workspace_id,
+        "action": args.action,
+        "drives": drives,
+        "current_policy": current,
+        "proposed_policy": proposed,
+        "method": method,
+        "request_body": body,
+    }
+    if args.dry_run:
+        print(json.dumps({"dry_run": True, **preview}, indent=2))
+        return
+    if proposed == current:
+        print(json.dumps({"changed": False, "policy": current}, indent=2))
+        return
+    if not args.yes and (
+        args.action in {"reset", "block-all"}
+        or (proposed["allow_list"] == [] and current["allow_list"] != [])
+    ):
+        parser.error(
+            "This change allows all shared drives or blocks every shared drive; review --dry-run, then repeat with --yes"
+        )
+    result = validate_policy(request_json(method, url, admin_token, body=body))
+    print(
+        json.dumps(
+            {"workspace_id": workspace_id, "action": args.action, "policy": result},
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/chatgpt/google_drive_access/test_google_drive_access_admin.py
+++ b/examples/chatgpt/google_drive_access/test_google_drive_access_admin.py
@@ -1,0 +1,558 @@
+"""Offline tests for the Google Drive workspace content-control example."""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from http.client import IncompleteRead
+from pathlib import Path
+from unittest import mock
+from urllib.error import HTTPError, URLError
+from urllib.request import Request
+
+import google_drive_access_admin as drive_access
+
+WORKSPACE_ID = "2a171a87-9cc8-453c-b7c4-0e0316903eb3"
+POLICY_URL = (
+    f"https://api.chatgpt.com/v1/manage/workspaces/{WORKSPACE_ID}"
+    "/google-drive/drive-access/allow-list"
+)
+GOOGLE_URL = "https://www.googleapis.com/drive/v3/drives/DriveA?fields=id,name"
+ROOT_URL = "https://drive.google.com/drive/folders/DriveA"
+ADMIN_TOKEN = "test-admin-token"
+GOOGLE_TOKEN = "test-google-token"
+
+
+def policy(allowed, personal=False):
+    return {
+        "object": "workspace.google_drive.access_policy",
+        "allow_list": allowed,
+        "allow_personal_drive": personal,
+    }
+
+
+class CommandTests(unittest.TestCase):
+    def setUp(self):
+        environment = mock.patch.dict(
+            drive_access.os.environ,
+            {"CHATGPT_ADMIN_TOKEN": ADMIN_TOKEN, "GOOGLE_DRIVE_TOKEN": GOOGLE_TOKEN},
+            clear=True,
+        )
+        environment.start()
+        self.addCleanup(environment.stop)
+        request = mock.patch.object(drive_access, "request_json")
+        self.request = request.start()
+        self.addCleanup(request.stop)
+
+    def run_command(self, action, *arguments, responses):
+        self.request.reset_mock()
+        self.request.side_effect = responses
+        stdout = io.StringIO()
+        argv = [action, *arguments]
+        if action != "inspect":
+            argv[1:1] = ["--workspace-id", WORKSPACE_ID]
+        with mock.patch("sys.stdout", stdout), mock.patch("sys.stderr", io.StringIO()):
+            drive_access.main(argv)
+        return json.loads(stdout.getvalue())
+
+    def assert_methods(self, *methods):
+        self.assertEqual(
+            [call.args[0] for call in self.request.call_args_list], list(methods)
+        )
+
+    def test_list_preserves_all_none_and_my_drive_false(self):
+        for allowed in (None, [], ["DriveA"]):
+            with self.subTest(allowed=allowed):
+                result = self.run_command("list", responses=[policy(allowed)])
+                self.assertEqual(result, policy(allowed))
+                self.request.assert_called_once_with("GET", POLICY_URL, ADMIN_TOKEN)
+
+    def test_replace_replaces_whole_list_and_omits_unchanged_my_drive(self):
+        result = self.run_command(
+            "replace",
+            "--drive-id",
+            "DriveB",
+            responses=[policy(["DriveA"]), policy(["DriveB"])],
+        )
+        self.assertEqual(result["policy"], policy(["DriveB"]))
+        self.assert_methods("GET", "PUT")
+        self.assertEqual(
+            self.request.call_args,
+            mock.call("PUT", POLICY_URL, ADMIN_TOKEN, body={"drive_ids": ["DriveB"]}),
+        )
+
+    def test_explicit_my_drive_values_are_json_booleans(self):
+        for choice, expected in (("allow", True), ("block", False)):
+            with self.subTest(choice=choice):
+                self.run_command(
+                    "replace",
+                    "--drive-id",
+                    "DriveB",
+                    "--my-drive",
+                    choice,
+                    responses=[
+                        policy(["DriveA"], not expected),
+                        policy(["DriveB"], expected),
+                    ],
+                )
+                self.assertEqual(
+                    self.request.call_args.kwargs["body"],
+                    {"drive_ids": ["DriveB"], "allow_personal_drive": expected},
+                )
+
+    def test_add_and_remove_send_complete_replacements(self):
+        cases = [
+            ("add", ["DriveA", "drivea"], "DriveB", ["DriveA", "DriveB", "drivea"]),
+            ("remove", ["DriveA", "DriveB"], "DriveA", ["DriveB"]),
+        ]
+        for action, current, requested, expected in cases:
+            with self.subTest(action=action):
+                self.run_command(
+                    action,
+                    "--drive-id",
+                    requested,
+                    responses=[policy(current), policy(expected)],
+                )
+                self.assert_methods("GET", "PUT")
+                self.assertEqual(
+                    self.request.call_args.kwargs["body"], {"drive_ids": expected}
+                )
+
+    def test_incremental_changes_reject_unrestricted_policy(self):
+        for action in ("add", "remove"):
+            with self.subTest(action=action):
+                with self.assertRaisesRegex(
+                    SystemExit, "exclude lists are unsupported"
+                ):
+                    self.run_command(
+                        action, "--drive-id", "DriveA", responses=[policy(None)]
+                    )
+                self.assert_methods("GET")
+
+    def test_removing_last_drive_requires_confirmation(self):
+        with self.assertRaises(SystemExit):
+            self.run_command(
+                "remove", "--drive-id", "DriveA", responses=[policy(["DriveA"])]
+            )
+        self.assert_methods("GET")
+        self.run_command(
+            "remove",
+            "--drive-id",
+            "DriveA",
+            "--yes",
+            responses=[policy(["DriveA"]), policy([])],
+        )
+        self.assertEqual(self.request.call_args.kwargs["body"], {"drive_ids": []})
+
+    def test_reset_allows_shared_drives_and_preserves_my_drive(self):
+        result = self.run_command(
+            "reset", "--yes", responses=[policy(["DriveA"]), policy(None)]
+        )
+        self.assertEqual(result["policy"], policy(None))
+        self.assert_methods("GET", "DELETE")
+        self.assertEqual(
+            self.request.call_args,
+            mock.call("DELETE", POLICY_URL, ADMIN_TOKEN, body=None),
+        )
+
+    def test_reset_and_block_all_require_confirmation(self):
+        for action in ("reset", "block-all"):
+            with self.subTest(action=action):
+                with self.assertRaises(SystemExit):
+                    self.run_command(action, responses=[policy(["DriveA"])])
+                self.assert_methods("GET")
+
+    def test_set_my_drive_preserves_all_shared_drive_states(self):
+        for allowed in (None, [], ["DriveA"]):
+            with self.subTest(allowed=allowed):
+                self.run_command(
+                    "set-my-drive",
+                    "--my-drive",
+                    "allow",
+                    responses=[policy(allowed), policy(allowed, True)],
+                )
+                self.assertEqual(
+                    self.request.call_args.kwargs["body"],
+                    {"drive_ids": allowed, "allow_personal_drive": True},
+                )
+
+    def test_dry_run_previews_changes_without_write_or_confirmation(self):
+        cases = [
+            ("replace", ["--drive-id", "DriveB"], ["DriveB"], False),
+            ("remove", ["--drive-id", "DriveA"], [], False),
+            ("reset", [], None, False),
+            ("block-all", [], [], False),
+            ("set-my-drive", ["--my-drive", "allow"], ["DriveA"], True),
+        ]
+        for action, arguments, allowed, personal in cases:
+            with self.subTest(action=action):
+                result = self.run_command(
+                    action, *arguments, "--dry-run", responses=[policy(["DriveA"])]
+                )
+                self.assertTrue(result["dry_run"])
+                self.assertEqual(result["proposed_policy"], policy(allowed, personal))
+                self.assert_methods("GET")
+
+    def test_noops_do_not_write(self):
+        cases = [
+            ("replace", ["DriveA"], ["--drive-id", "DriveA"]),
+            ("add", ["DriveA"], ["--drive-id", "DriveA"]),
+            ("remove", ["DriveA"], ["--drive-id", "DriveB"]),
+            ("reset", None, []),
+            ("block-all", [], []),
+            ("set-my-drive", ["DriveA"], ["--my-drive", "block"]),
+        ]
+        for action, allowed, arguments in cases:
+            with self.subTest(action=action):
+                result = self.run_command(
+                    action, *arguments, responses=[policy(allowed)]
+                )
+                self.assertEqual(result, {"changed": False, "policy": policy(allowed)})
+                self.assert_methods("GET")
+
+    def test_incomplete_or_invalid_policy_stops_writes(self):
+        invalid = [
+            {},
+            {"allow_list": []},
+            {
+                "object": "workspace.google_drive.access_policy",
+                "allow_personal_drive": False,
+            },
+            {**policy([]), "object": "other"},
+            policy([], "false"),
+            policy([], 0),
+            policy([], None),
+            policy({}),
+            policy(["root"]),
+            policy(["DriveA", 123]),
+            policy(["DriveA"] * 1001),
+        ]
+        for current in invalid:
+            with self.subTest(current=current):
+                with self.assertRaises(SystemExit):
+                    self.run_command(
+                        "replace", "--drive-id", "DriveB", responses=[current]
+                    )
+                self.assert_methods("GET")
+
+    def test_add_checks_result_limit_before_writing(self):
+        current = [f"Drive{i:04d}" for i in range(1000)]
+        with self.assertRaisesRegex(SystemExit, "resulting policy exceeds"):
+            self.run_command(
+                "add", "--drive-id", "DriveExtra", responses=[policy(current)]
+            )
+        self.assert_methods("GET")
+
+    def test_files_preserve_case_and_deduplicate_sources(self):
+        with tempfile.TemporaryDirectory() as directory:
+            for filename, contents in (
+                ("drives.txt", "# approved drives\n\n DriveA \ndrivea\nDriveB\n"),
+                (
+                    "drives.csv",
+                    "\ufeffdrive_id,description\nDriveA,First\ndrivea,Second\nDriveB,Third\n",
+                ),
+            ):
+                with self.subTest(filename=filename):
+                    path = Path(directory) / filename
+                    path.write_text(contents, encoding="utf-8")
+                    self.run_command(
+                        "replace",
+                        "--drive-id",
+                        "DriveA",
+                        "--drives-file",
+                        str(path),
+                        responses=[policy([]), policy(["DriveA", "DriveB", "drivea"])],
+                    )
+                    self.assertEqual(
+                        self.request.call_args.kwargs["body"],
+                        {"drive_ids": ["DriveA", "DriveB", "drivea"]},
+                    )
+
+    def test_empty_files_cannot_accidentally_block_all_drives(self):
+        with tempfile.TemporaryDirectory() as directory:
+            for filename, contents in (
+                ("empty.txt", "# nothing selected\n \n"),
+                ("empty.csv", "drive_id\n\n"),
+            ):
+                with self.subTest(filename=filename):
+                    path = Path(directory) / filename
+                    path.write_text(contents, encoding="utf-8")
+                    with self.assertRaises(SystemExit):
+                        self.run_command(
+                            "replace", "--drives-file", str(path), responses=[]
+                        )
+                    self.request.assert_not_called()
+
+    def test_malformed_csv_is_rejected_before_requests(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "drives.csv"
+            for contents in (
+                "name\nDriveA\n",
+                "drive_id,drive_url\nDriveA,\n",
+                "drive_id,drive_id\nDriveA,DriveB\n",
+                "drive_id\nDriveA,DriveB\n",
+                'drive_id\n"DriveA\n',
+            ):
+                with self.subTest(contents=contents):
+                    path.write_text(contents, encoding="utf-8")
+                    with self.assertRaises(SystemExit):
+                        self.run_command(
+                            "replace", "--drives-file", str(path), responses=[]
+                        )
+                    self.request.assert_not_called()
+
+    def test_invalid_ids_and_urls_fail_before_requests(self):
+        references = [
+            ("--drive-id", "root"),
+            ("--drive-id", "abcd"),
+            ("--drive-id", "x" * 513),
+            ("--drive-id", "Drive A"),
+            ("--drive-id", "DrivéA"),
+            ("--drive-id", ROOT_URL),
+            ("--drive-url", "DriveA"),
+            ("--drive-url", "http://drive.google.com/drive/folders/DriveA"),
+            ("--drive-url", "https://drive.google.com.evil.test/drive/folders/DriveA"),
+            ("--drive-url", "https://user@drive.google.com/drive/folders/DriveA"),
+            ("--drive-url", "https://drive.google.com:443/drive/folders/DriveA"),
+            ("--drive-url", "https://drive.google.com/file/d/DriveA/view"),
+            ("--drive-url", "https://drive.google.com/drive/folders/root"),
+            ("--drive-url", "https://drive.google.com/drive/folders/Drive%2FA"),
+            ("--drive-url", "https://[drive.google.com/drive/folders/DriveA"),
+        ]
+        for option, value in references:
+            with self.subTest(option=option, value=value):
+                with self.assertRaises(SystemExit):
+                    self.run_command("replace", option, value, responses=[])
+                self.request.assert_not_called()
+
+    def test_invalid_command_options_fail_before_requests(self):
+        for action, arguments in (
+            ("replace", []),
+            ("set-my-drive", []),
+            ("reset", ["--my-drive", "block"]),
+            ("list", ["--drive-id", "DriveA"]),
+            ("replace", ["--drive-id", "DriveA", "--workspace-id", "invalid"]),
+            ("list", ["--api-base-url", "https://other.example"]),
+        ):
+            with self.subTest(action=action, arguments=arguments):
+                with self.assertRaises(SystemExit):
+                    self.run_command(action, *arguments, responses=[])
+                self.request.assert_not_called()
+        with mock.patch.dict(drive_access.os.environ, {}, clear=True):
+            with self.assertRaises(SystemExit):
+                self.run_command("list", responses=[])
+            self.request.assert_not_called()
+
+    def test_all_text_references_are_validated_before_google_requests(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "drives.txt"
+            path.write_text(f"{ROOT_URL}\ninvalid name\n", encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                self.run_command("replace", "--drives-file", str(path), responses=[])
+        self.request.assert_not_called()
+
+    def test_root_urls_are_verified_once_and_tokens_stay_on_their_origins(self):
+        self.run_command(
+            "replace",
+            "--drive-id",
+            "DriveA",
+            "--drive-url",
+            ROOT_URL,
+            responses=[
+                {"id": "DriveA", "name": "Company"},
+                policy([]),
+                policy(["DriveA"]),
+            ],
+        )
+        self.assertEqual(
+            self.request.call_args_list,
+            [
+                mock.call("GET", GOOGLE_URL, GOOGLE_TOKEN),
+                mock.call("GET", POLICY_URL, ADMIN_TOKEN),
+                mock.call(
+                    "PUT", POLICY_URL, ADMIN_TOKEN, body={"drive_ids": ["DriveA"]}
+                ),
+            ],
+        )
+
+    def test_url_verification_and_inspection_require_google_token(self):
+        with mock.patch.dict(
+            drive_access.os.environ, {"CHATGPT_ADMIN_TOKEN": ADMIN_TOKEN}, clear=True
+        ):
+            for action, arguments in (
+                ("replace", ["--drive-url", ROOT_URL]),
+                ("inspect", ["--drive-id", "DriveA"]),
+            ):
+                with self.subTest(action=action):
+                    with self.assertRaisesRegex(SystemExit, "GOOGLE_DRIVE_TOKEN"):
+                        self.run_command(action, *arguments, responses=[])
+                    self.request.assert_not_called()
+
+    def test_inspection_accepts_account_root_urls_without_admin_credentials(self):
+        with mock.patch.dict(
+            drive_access.os.environ, {"GOOGLE_DRIVE_TOKEN": GOOGLE_TOKEN}, clear=True
+        ):
+            result = self.run_command(
+                "inspect",
+                "--drive-url",
+                "https://drive.google.com/drive/u/0/folders/DriveA?usp=sharing",
+                responses=[{"id": "DriveA", "name": "Company"}],
+            )
+        self.assertEqual(result, {"drives": [{"id": "DriveA", "name": "Company"}]})
+        self.request.assert_called_once_with("GET", GOOGLE_URL, GOOGLE_TOKEN)
+
+    def test_bad_google_metadata_stops_before_admin_policy_read(self):
+        for metadata in (
+            {"id": "OtherDrive", "name": "Company"},
+            {"id": "DriveA"},
+            {"id": "DriveA", "name": 7},
+        ):
+            with self.subTest(metadata=metadata):
+                with self.assertRaisesRegex(
+                    SystemExit, "unexpected shared-drive metadata"
+                ):
+                    self.run_command(
+                        "replace", "--drive-url", ROOT_URL, responses=[metadata]
+                    )
+                self.request.assert_called_once_with("GET", GOOGLE_URL, GOOGLE_TOKEN)
+
+    def test_id_limits_apply_after_client_deduplication(self):
+        self.assertEqual(
+            drive_access.resolve_drives(["DriveA"] * 1001 + ["drivea"]),
+            [{"id": "DriveA"}, {"id": "drivea"}],
+        )
+        thousand = [f"Drive{i:04d}" for i in range(1000)]
+        self.assertEqual(len(drive_access.resolve_drives(thousand)), 1000)
+        with self.assertRaisesRegex(SystemExit, "at most 1,000"):
+            drive_access.resolve_drives([*thousand, "ExtraDrive"])
+        self.assertEqual(drive_access.validate_drive_id("x" * 512), "x" * 512)
+        self.request.assert_not_called()
+
+
+class TransportTests(unittest.TestCase):
+    def setUp(self):
+        opener = mock.patch.object(drive_access, "build_opener")
+        self.build_opener = opener.start()
+        self.addCleanup(opener.stop)
+        self.open = self.build_opener.return_value.open
+        sleep = mock.patch.object(drive_access.time, "sleep")
+        self.sleep = sleep.start()
+        self.addCleanup(sleep.stop)
+
+    def http_error(self, code):
+        return HTTPError(
+            POLICY_URL, code, "Private response", {}, io.BytesIO(b"private body")
+        )
+
+    def test_reads_retry_transient_http_and_network_errors(self):
+        for error in [self.http_error(code) for code in (429, 502, 503, 504)] + [
+            URLError("offline"),
+            TimeoutError(),
+            ConnectionResetError("reset"),
+            IncompleteRead(b"partial response"),
+        ]:
+            with self.subTest(error=error):
+                self.open.reset_mock()
+                self.sleep.reset_mock()
+                self.open.side_effect = [error, io.BytesIO(b'{"ok": true}')]
+                self.assertEqual(
+                    drive_access.request_json("GET", POLICY_URL, ADMIN_TOKEN),
+                    {"ok": True},
+                )
+                self.assertEqual(self.open.call_count, 2)
+                self.sleep.assert_called_once_with(1)
+
+    def test_read_retries_are_bounded(self):
+        self.open.side_effect = [self.http_error(503) for _ in range(3)]
+        with self.assertRaisesRegex(SystemExit, "HTTP 503"):
+            drive_access.request_json("GET", POLICY_URL, ADMIN_TOKEN)
+        self.assertEqual(self.open.call_count, 3)
+        self.assertEqual(self.sleep.call_args_list, [mock.call(1), mock.call(2)])
+
+    def test_writes_never_retry_and_explain_uncertain_outcomes(self):
+        for method in ("PUT", "DELETE"):
+            for error in [self.http_error(code) for code in (409, 429, 503)] + [
+                URLError("offline"),
+                TimeoutError(),
+                ConnectionResetError("reset"),
+                IncompleteRead(b"partial response"),
+            ]:
+                with self.subTest(method=method, error=error):
+                    self.open.reset_mock()
+                    self.sleep.reset_mock()
+                    self.open.side_effect = error
+                    with self.assertRaisesRegex(
+                        SystemExit, "Read the current policy before retrying"
+                    ) as caught:
+                        drive_access.request_json(
+                            method, POLICY_URL, ADMIN_TOKEN, body={"drive_ids": []}
+                        )
+                    self.open.assert_called_once()
+                    self.sleep.assert_not_called()
+                    self.assertNotIn(ADMIN_TOKEN, str(caught.exception))
+                    self.assertNotIn("private body", str(caught.exception))
+
+    def test_reads_do_not_retry_permanent_http_errors(self):
+        for status in (400, 401, 403, 404):
+            with self.subTest(status=status):
+                self.open.reset_mock()
+                self.sleep.reset_mock()
+                self.open.side_effect = self.http_error(status)
+                with self.assertRaisesRegex(SystemExit, f"HTTP {status}"):
+                    drive_access.request_json("GET", POLICY_URL, ADMIN_TOKEN)
+                self.open.assert_called_once()
+                self.sleep.assert_not_called()
+
+    def test_invalid_json_or_non_object_response_is_not_retried(self):
+        for payload in (b"not JSON", b"[]", b"null", b'"private-token"'):
+            with self.subTest(payload=payload):
+                self.open.reset_mock()
+                self.open.return_value = io.BytesIO(payload)
+                with self.assertRaisesRegex(
+                    SystemExit, "invalid JSON response"
+                ) as caught:
+                    drive_access.request_json("GET", POLICY_URL, ADMIN_TOKEN)
+                self.open.assert_called_once()
+                self.sleep.assert_not_called()
+                self.assertNotIn("private-token", str(caught.exception))
+
+    def test_request_headers_json_false_and_no_redirect_handler(self):
+        self.open.return_value = io.BytesIO(b'{"ok": true}')
+        body = {"drive_ids": [], "allow_personal_drive": False}
+        drive_access.request_json("PUT", POLICY_URL, ADMIN_TOKEN, body=body)
+        request = self.open.call_args.args[0]
+        self.assertEqual(request.full_url, POLICY_URL)
+        self.assertEqual(request.get_method(), "PUT")
+        self.assertEqual(request.get_header("Authorization"), f"Bearer {ADMIN_TOKEN}")
+        self.assertEqual(request.get_header("Content-type"), "application/json")
+        self.assertEqual(json.loads(request.data), body)
+        self.assertFalse(request.has_header("Idempotency-key"))
+        self.assertEqual(self.open.call_args.kwargs, {"timeout": 30})
+        self.assertIsInstance(
+            self.build_opener.call_args.args[0], drive_access.NoRedirect
+        )
+
+    def test_redirects_are_rejected_instead_of_forwarding_tokens(self):
+        request = Request(
+            POLICY_URL, headers={"Authorization": f"Bearer {ADMIN_TOKEN}"}
+        )
+        for status in (301, 302, 303, 307, 308):
+            with self.subTest(status=status):
+                with self.assertRaises(HTTPError) as caught:
+                    drive_access.NoRedirect().redirect_request(
+                        request,
+                        None,
+                        status,
+                        "redirect",
+                        {},
+                        "https://other.example/policy",
+                    )
+                self.assertEqual(caught.exception.code, status)
+                self.assertEqual(caught.exception.url, POLICY_URL)
+        self.open.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/registry.yaml
+++ b/registry.yaml
@@ -4,6 +4,20 @@
 # should build pages for, and indicates metadata such as tags, creation date and
 # authors for each page.
 
+- title: Manage Google Drive access with the ChatGPT Admin API
+  path: examples/chatgpt/google_drive_access/google_drive_access.md
+  slug: manage-google-drive-access-chatgpt-admin-api
+  description: Inspect shared drives and manage a ChatGPT workspace shared-drive allowlist and My Drive access with the Admin API.
+  date: 2026-09-02
+  authors:
+    - hmittal-oai
+  tags:
+    - chatgpt
+    - chatgpt-and-api
+    - enterprise
+    - admin-api
+    - google-drive
+
 - title: Combining security scanners with the Agents SDK
   path: examples/agents_sdk/security_scanners_with_agents_sdk.ipynb
   slug: evidence-grounded-security-review-swarm


### PR DESCRIPTION
## Summary

Add a guide and Python standard-library CLI for managing Google Drive access through the ChatGPT workspace Admin API, following the SharePoint example in #3032. The example covers shared-drive ID and root-URL inputs, CSV/text imports, dry-run previews, full replacements, additions/removals, and independent My Drive access.

Make `null` (all shared drives), `[]` (no shared drives), and a selected allowlist explicit. Require confirmation for resetting restrictions or blocking every shared drive, reject malformed and empty imports, verify root URLs with Google Drive, and retry reads only. Register the guide in `registry.yaml` using the existing author slug.

This is a draft pending availability of the Google Drive policy endpoint and enforcement for supported workspaces. The guide explains that a successful configuration request alone does not establish enforcement and that concurrent administrator saves can overwrite changes.

## Motivation

Workspace administrators need a reusable example for managing shared-drive and My Drive controls at scale. Google Drive uses full replacement and distinct all/none semantics, so its workflow needs a dedicated example rather than adapting the SharePoint commands unchanged.

## Validation

- `python3 -B -m unittest discover -s examples/chatgpt/google_drive_access -p 'test_*.py' -v` — 31 tests passed with mocked Google Drive and ChatGPT Admin API responses.
- `ruff check examples/chatgpt/google_drive_access`
- `ruff format --check examples/chatgpt/google_drive_access`
- CLI `--help` and Python 3.10 syntax validation.
- Registry JSON-schema validation; unique path/slug, matching title, and local links verified.
- `.github/scripts/check_notebooks.py` — no changed notebooks.
- Repository `docs-editor` review — no remaining findings.
- No live Google Drive or ChatGPT Admin API requests were made. Live endpoint validation remains pending.

---

## For new content

- [x] I have added a new entry in [registry.yaml](https://github.com/openai/openai-cookbook/blob/main/registry.yaml) so that the guide renders on the cookbook website. The existing `hmittal-oai` author slug uses GitHub-profile attribution.
- [x] I have conducted a self-review based on the [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md):
  - [x] Relevance: This demonstrates a ChatGPT workspace Admin API workflow for enterprise administrators.
  - [x] Uniqueness: It complements the SharePoint example with Google Drive's replacement semantics and separate My Drive control.
  - [x] Spelling and Grammar: The guide passed editorial review.
  - [x] Clarity: Setup, previews, updates, and troubleshooting are documented in execution order.
  - [x] Correctness: The example passed its mocked offline tests and local validation; live endpoint validation is explicitly pending.
  - [x] Completeness: The guide includes credentials, source references, API semantics, rollout prerequisites, and concurrency/retry limits.
