### PR TITLE
docs: fix 'reponses' typo in SharePoint tutorial

### DIFF
--- a/examples/chatgpt/sharepoint_azure_function/Using_Azure_Functions_and_Microsoft_Graph_to_Query_SharePoint.md
+++ b/examples/chatgpt/sharepoint_azure_function/Using_Azure_Functions_and_Microsoft_Graph_to_Query_SharePoint.md
@@ -766,7 +766,7 @@ module.exports = async function (context, req) {
                         const { name, id } = hit.resource;
                         // We use the below to grab the URL of the file to include in the response
                         const webUrl = hit.resource.webUrl.replace(/\s/g, "%20");
-                        // The Microsoft Graph API ranks the reponses, so we use this to order it
+                        // The Microsoft Graph API ranks the responses, so we use this to order it
                         const rank = hit.rank;
                         // The below is where the file lives
                         const driveId = hit.resource.parentReference.driveId;


### PR DESCRIPTION
## Summary

- Fix a one-word spelling typo in the SharePoint tutorial: `reponses` → `responses`, in the code comment explaining how the Microsoft Graph API ranks search results (`examples/chatgpt/sharepoint_azure_function/Using_Azure_Functions_and_Microsoft_Graph_to_Query_SharePoint.md`, line 769).

## Motivation

The tutorial is a frequently referenced walkthrough for querying SharePoint with Microsoft Graph and Azure Functions, and the typo sits in the prose explaining the ranking logic. Spelling and grammar review is part of the cookbook's own contribution rubric, and this is the last remaining `reponses` misspelling in the repo. Documentation-only change — no code or notebook behavior is affected.

## Verification

- Confirmed exactly one line changed (`git diff --stat`: 1 file, +1/-1)
- `git diff --check` passes (no whitespace errors)
- Searched the working tree for `reponses`: 0 remaining occurrences
- Checked open PRs touching this file (#2787 fixes a different typo, `and and`, at line 161 in the same file — this one is not covered there)