### PR TITLE
docs: fix CONTRIBUTING title and the PR template's dead rubric anchor

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Why are these changes necessary? How do they improve the cookbook?
 When contributing new content, read through our [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md), and mark the following action items as completed:
 
 - [ ] I have added a new entry in [registry.yaml](https://github.com/openai/openai-cookbook/blob/main/registry.yaml) (and, optionally, in [authors.yaml](https://github.com/openai/openai-cookbook/blob/main/authors.yaml)) so that my content renders on the cookbook website.
-- [ ] I have conducted a self-review of my content based on the [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md#rubric):
+- [ ] I have conducted a self-review of my content based on the [contribution guidelines](https://github.com/openai/openai-cookbook/blob/main/CONTRIBUTING.md):
   - [ ] Relevance: This content is related to building with OpenAI technologies and is useful to others.
   - [ ] Uniqueness: I have searched for related examples in the OpenAI Cookbook, and verified that my content offers new insights or unique information compared to existing documentation.
   - [ ] Spelling and Grammar: I have checked for spelling or grammatical mistakes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing the the cookbook
+# Contributing to the cookbook
 
 The OpenAI Cookbook is a collection of useful patterns and examples of working with the OpenAI platform, provided as a community resource.
 


### PR DESCRIPTION
Two fixes:

- `CONTRIBUTING.md` title: "Contributing **the the** cookbook" → "Contributing **to** the cookbook"
- `.github/pull_request_template.md`: linked `CONTRIBUTING.md#rubric` — that file has no headings at all, so the anchor matched nothing; the link now points at the file