### PR TITLE
docs: fix image and LICENSE relative paths that escape the repo

### DIFF
--- a/examples/chatgpt/gpt_actions_library/gpt_action_github.md
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_github.md
@@ -198,7 +198,7 @@ In ChatGPT, click on "Authentication" and choose **"Bearer"**. Enter in the info
 
 You are now ready to test out the GPT. You can enter a simple prompt like "Can you review my pull request? owner: <org_name>, repo: <repo_name>, pull request number: <PR_Number>" and expect to see the following:
 
-![landing_page.png](../../../../images/landing_page.png)
+![landing_page.png](../../../images/landing_page.png)
 
 1. A summary of changes in the referenced pull request(PR).
 

--- a/examples/chatgpt/gpt_actions_library/gpt_action_workday.md
+++ b/examples/chatgpt/gpt_actions_library/gpt_action_workday.md
@@ -36,9 +36,9 @@ To connect ChatGPT with Workday, use OAuth:
 
 *The redirection URI is retrieved from the GPT setup once OAuth has been selected as authentication, on the GPT set-up screen.* 
 
-![workday-cgpt-oauth.png](../../../../images/workday-cgpt-oauth.png)
+![workday-cgpt-oauth.png](../../../images/workday-cgpt-oauth.png)
 
-![workday-api-client.png](../../../../images/workday-api-client.png)
+![workday-api-client.png](../../../images/workday-api-client.png)
 
 The [Workday Community page on API client]((https://doc.workday.com/admin-guide/en-us/authentication-and-security/authentication/oauth/dan1370797831010.html)) can be a good resource to go deeper *(this requires a community account)*.
 
@@ -75,9 +75,9 @@ Use the following instructions to cover PTO Submission use-cases, Worker details
 As employee ID is required to take actions on Workday onto the employee, this information will need to be retrieved before doing any queries. We have accomplished this by calling a RAAS report in workday after authentication that provides the user who is logging in. There may be another way to do this via just a REST API call itself. Once the ID has been returned it will be used in all other actions.
 
 Sample RAAS Report: Using the field Current User will return the worker who has authenticated via OAuth.    
-![custom-report-workday-01.png](../../../../images/custom-report-workday-01.png)
+![custom-report-workday-01.png](../../../images/custom-report-workday-01.png)
 
-![custom-report-workday-02.png](../../../../images/custom-report-workday-02.png)
+![custom-report-workday-02.png](../../../images/custom-report-workday-02.png)
 
 ### OpenAPI Schema
 
@@ -394,6 +394,6 @@ Congratulations on setting up a GPT for Workday with capabilities such as PTO su
 
 This integration can streamline HR processes, provide quick access to personal details, and make it easy for employees to request PTO. This guide provides a customizable framework for implementing ChatGPT with Workday, allowing you to easily add more actions and enhance GPT capabilities further.
 
-![workday-gpt.png](../../../../images/workday-gpt.png)
+![workday-gpt.png](../../../images/workday-gpt.png)
 
-![pto-request.png](../../../../images/pto-request.png)
+![pto-request.png](../../../images/pto-request.png)

--- a/examples/voice_solutions/running_realtime_api_speech_on_esp32_arduino_edge_runtime_elatoai.md
+++ b/examples/voice_solutions/running_realtime_api_speech_on_esp32_arduino_edge_runtime_elatoai.md
@@ -234,7 +234,7 @@ lib_deps =
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](../../LICENSE) file for details.
 
 ---
 


### PR DESCRIPTION
Seven image links across `gpt_action_workday.md` / `gpt_action_github.md` used four `../` — from `examples/chatgpt/gpt_actions_library/` that resolves above the repo, so every embedded image 404'd (the sibling links in `gpt_action_github.md` at lines 205-213 correctly use three). All normalized to `../../../images/`.

Also: `running_realtime_api_speech_on_esp32_arduino_edge_runtime_elatoai.md` linked a `LICENSE` file that doesn't exist in its directory → repointed at the repo-root LICENSE.