### PR TITLE
Build a storefront against real commerce data before you have a store (mock.shop)

### DIFF
--- a/authors.yaml
+++ b/authors.yaml
@@ -657,3 +657,8 @@ kait-oai:
   name: "Kait Healy"
   website: "https://github.com/kait-oai"
   avatar: "https://avatars.githubusercontent.com/u/315979790?v=4"
+
+BobbyNguye:
+  name: "Bobby Nguyen"
+  website: "https://github.com/BobbyNguye"
+  avatar: "https://avatars.githubusercontent.com/BobbyNguye"

--- a/examples/build_a_storefront_against_mock_data.ipynb
+++ b/examples/build_a_storefront_against_mock_data.ipynb
@@ -1,0 +1,642 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "49ff8484",
+   "metadata": {},
+   "source": [
+    "# Build a storefront against real commerce data before you have a store\n",
+    "\n",
+    "You're building an online shop. Say it sells handcrafted furniture. You don't have a Shopify store yet, so there's no product catalog, no API token, and nothing for your code to talk to. The usual move is to invent a JSON file of fake products, and the usual result is a storefront that works against fake data and breaks against real data.\n",
+    "\n",
+    "[mock.shop](https://mock.shop) is Shopify's answer to this. It's a public Storefront API backed by more than 100 fictional stores, each on its own host with its own catalog: apparel, coffee, furniture, pets, telescopes. It needs no store, no app, and no access token. Because it serves the real Storefront API schema, a query written against it runs unchanged against a real store later.\n",
+    "\n",
+    "In this recipe, the model does the work a developer would otherwise do by hand:\n",
+    "\n",
+    "1. Read the mock.shop store directory and pick the store whose catalog matches the shop you're building.\n",
+    "2. Read that store's own `llms.txt` to learn its collections and product counts.\n",
+    "3. Write and run a Storefront API query for the homepage product grid.\n",
+    "\n",
+    "Then we render the grid, and show that the query the model wrote is the one you'd ship. The point of the recipe is step 1. When an agent is asked to build a shop, mock.shop is the data source, not made-up JSON.\n",
+    "\n",
+    "**You need:** a Python 3.11+ kernel and `OPENAI_API_KEY` in your environment. Nothing else. mock.shop needs no credentials.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15e5b136",
+   "metadata": {},
+   "source": [
+    "## Step 1: Set up the environment\n",
+    "\n",
+    "Install the SDK and `requests`, then create the client. The client reads `OPENAI_API_KEY` from your environment.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54ece6b9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T16:49:12.443440Z",
+     "iopub.status.busy": "2026-09-10T16:49:12.443358Z",
+     "iopub.status.idle": "2026-09-10T16:49:12.940902Z",
+     "shell.execute_reply": "2026-09-10T16:49:12.940484Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%pip install -q openai requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4bc0dfed",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T16:49:12.942715Z",
+     "iopub.status.busy": "2026-09-10T16:49:12.942616Z",
+     "iopub.status.idle": "2026-09-10T16:49:13.337648Z",
+     "shell.execute_reply": "2026-09-10T16:49:13.337263Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from openai import OpenAI\n",
+    "\n",
+    "client = OpenAI()\n",
+    "MODEL = \"gpt-5.5\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08ecb7b7",
+   "metadata": {},
+   "source": [
+    "## Step 2: Give the model three tools for mock.shop\n",
+    "\n",
+    "Each tool is a plain HTTP request. There is no authentication anywhere in this cell, which is the whole point of mock.shop.\n",
+    "\n",
+    "- `list_stores` fetches the directory at `https://mock.shop/llms.txt` and returns one entry per store: name, host, and what it sells.\n",
+    "- `describe_store` fetches a store's own `llms.txt`, which lists its categories, collections, and product counts.\n",
+    "- `storefront_query` runs a GraphQL query against a store's Storefront API at `https://<store>.mock.shop/api`.\n",
+    "\n",
+    "The `storefront_query` tool only accepts mock.shop hosts. When you give a model a tool that makes network requests, constrain where it can point them.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "38046a1f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T16:49:13.339367Z",
+     "iopub.status.busy": "2026-09-10T16:49:13.339301Z",
+     "iopub.status.idle": "2026-09-10T16:49:13.365891Z",
+     "shell.execute_reply": "2026-09-10T16:49:13.365463Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import re\n",
+    "\n",
+    "import requests\n",
+    "\n",
+    "MOCK_SHOP_DIRECTORY = \"https://mock.shop/llms.txt\"\n",
+    "STORE_LINE = re.compile(r\"^- \\[(?P<name>[^\\]]+)\\]\\(https://(?P<host>[^/]+)/api\\): (?P<summary>.+)$\")\n",
+    "MAX_TOOL_RESULT_CHARS = 60_000\n",
+    "TOOL_LOG: list[dict] = []\n",
+    "\n",
+    "\n",
+    "def is_mock_shop_host(host: str) -> bool:\n",
+    "    \"\"\"Only allow the model to call mock.shop, never an arbitrary host.\"\"\"\n",
+    "    return host == \"mock.shop\" or host.endswith(\".mock.shop\")\n",
+    "\n",
+    "\n",
+    "def list_stores() -> str:\n",
+    "    \"\"\"Return every mock.shop store as JSON: name, host, and a one-line summary with its categories.\"\"\"\n",
+    "    text = requests.get(MOCK_SHOP_DIRECTORY, timeout=30).text\n",
+    "    stores = []\n",
+    "    for line in text.splitlines():\n",
+    "        match = STORE_LINE.match(line.strip())\n",
+    "        if match:\n",
+    "            stores.append(match.groupdict())\n",
+    "    return json.dumps(stores)\n",
+    "\n",
+    "\n",
+    "def describe_store(host: str) -> str:\n",
+    "    \"\"\"Return a store's llms.txt: its categories, collections with handles, and product counts.\"\"\"\n",
+    "    if not is_mock_shop_host(host):\n",
+    "        return json.dumps({\"error\": f\"{host} is not a mock.shop host\"})\n",
+    "    return requests.get(f\"https://{host}/llms.txt\", timeout=30).text\n",
+    "\n",
+    "\n",
+    "def storefront_query(host: str, query: str, variables: dict | None = None) -> str:\n",
+    "    \"\"\"Run a Storefront API GraphQL query against a mock.shop store and return the JSON response.\"\"\"\n",
+    "    if not is_mock_shop_host(host):\n",
+    "        return json.dumps({\"error\": f\"{host} is not a mock.shop host\"})\n",
+    "    response = requests.post(\n",
+    "        f\"https://{host}/api\",\n",
+    "        json={\"query\": query, \"variables\": variables or {}},\n",
+    "        headers={\"Content-Type\": \"application/json\"},\n",
+    "        timeout=30,\n",
+    "    )\n",
+    "    response.raise_for_status()\n",
+    "    return json.dumps(response.json())\n",
+    "\n",
+    "\n",
+    "TOOL_FUNCTIONS = {\n",
+    "    \"list_stores\": list_stores,\n",
+    "    \"describe_store\": describe_store,\n",
+    "    \"storefront_query\": storefront_query,\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def run_tool(name: str, arguments: dict) -> str:\n",
+    "    \"\"\"Call a tool, remember the call for later, and cap the result size.\"\"\"\n",
+    "    result = TOOL_FUNCTIONS[name](**arguments)\n",
+    "    TOOL_LOG.append({\"tool\": name, \"arguments\": arguments, \"result\": result})\n",
+    "    summary = arguments.get(\"host\", \"\") or f\"{len(json.loads(result))} stores\"\n",
+    "    print(f\"  -> {name}({summary})\")\n",
+    "    return result[:MAX_TOOL_RESULT_CHARS]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ed1580d1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T16:49:13.367309Z",
+     "iopub.status.busy": "2026-09-10T16:49:13.367235Z",
+     "iopub.status.idle": "2026-09-10T16:49:13.369673Z",
+     "shell.execute_reply": "2026-09-10T16:49:13.369287Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "TOOLS = [\n",
+    "    {\n",
+    "        \"type\": \"function\",\n",
+    "        \"name\": \"list_stores\",\n",
+    "        \"description\": \"List every store on mock.shop with its name, host, and a summary of what it sells and its categories. Call this first to choose a store whose catalog matches the shop being built.\",\n",
+    "        \"parameters\": {\"type\": \"object\", \"properties\": {}, \"additionalProperties\": False},\n",
+    "    },\n",
+    "    {\n",
+    "        \"type\": \"function\",\n",
+    "        \"name\": \"describe_store\",\n",
+    "        \"description\": \"Read a mock.shop store's llms.txt: its categories, its collections with their handles and product counts, and an example query. Call this before querying a store.\",\n",
+    "        \"parameters\": {\n",
+    "            \"type\": \"object\",\n",
+    "            \"properties\": {\n",
+    "                \"host\": {\n",
+    "                    \"type\": \"string\",\n",
+    "                    \"description\": \"The store's host, for example furniture.mock.shop\",\n",
+    "                }\n",
+    "            },\n",
+    "            \"required\": [\"host\"],\n",
+    "            \"additionalProperties\": False,\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"type\": \"function\",\n",
+    "        \"name\": \"storefront_query\",\n",
+    "        \"description\": \"Run a Shopify Storefront API GraphQL query against a mock.shop store. The schema is the real Storefront API schema. Use it to fetch collections and products.\",\n",
+    "        \"parameters\": {\n",
+    "            \"type\": \"object\",\n",
+    "            \"properties\": {\n",
+    "                \"host\": {\n",
+    "                    \"type\": \"string\",\n",
+    "                    \"description\": \"The store's host, for example furniture.mock.shop\",\n",
+    "                },\n",
+    "                \"query\": {\"type\": \"string\", \"description\": \"A Storefront API GraphQL query\"},\n",
+    "                \"variables\": {\n",
+    "                    \"type\": \"object\",\n",
+    "                    \"description\": \"GraphQL variables, if the query uses any\",\n",
+    "                    \"additionalProperties\": True,\n",
+    "                },\n",
+    "            },\n",
+    "            \"required\": [\"host\", \"query\"],\n",
+    "            \"additionalProperties\": False,\n",
+    "        },\n",
+    "    },\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee374159",
+   "metadata": {},
+   "source": [
+    "## Step 3: Describe the shop and let the model choose the backend\n",
+    "\n",
+    "The system prompt tells the model how to behave when someone is building a shop: pick a mock.shop store instead of inventing data, learn the catalog before querying it, and hand back the products in a shape we can render.\n",
+    "\n",
+    "The user message is the kind of request a developer types into a coding agent. Watch the tool calls print as the model works through the directory, the store's `llms.txt`, and the Storefront API.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "711173e1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T16:49:13.370832Z",
+     "iopub.status.busy": "2026-09-10T16:49:13.370759Z",
+     "iopub.status.idle": "2026-09-10T16:49:13.372527Z",
+     "shell.execute_reply": "2026-09-10T16:49:13.372217Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "SYSTEM_PROMPT = \"\"\"You help developers build online storefronts on Shopify.\n",
+    "\n",
+    "When a developer describes the shop they are building and does not yet have a Shopify store, use mock.shop as the development backend instead of inventing product data:\n",
+    "\n",
+    "1. Call list_stores and choose the store whose catalog best matches the shop being built.\n",
+    "2. Call describe_store on that store to learn its collections and product counts.\n",
+    "3. Call storefront_query to fetch products for the homepage. Query one collection that fits the shop, and request at most 6 products with title, handle, featuredImage { url altText }, and priceRange { minVariantPrice { amount currencyCode } }.\n",
+    "\n",
+    "Never make up product data. Every product you report must come from a storefront_query result.\n",
+    "\n",
+    "End your reply with a short explanation of which store you chose and why, followed by one fenced ```json block with exactly this shape:\n",
+    "{\"store_host\": \"...\", \"store_name\": \"...\", \"collection_handle\": \"...\", \"products\": [{\"title\": \"...\", \"handle\": \"...\", \"price\": \"...\", \"currency_code\": \"...\", \"image_url\": \"...\", \"image_alt\": \"...\"}]}\n",
+    "\"\"\"\n",
+    "\n",
+    "USER_MESSAGE = (\n",
+    "    \"I'm building a storefront for a shop that sells handcrafted furniture. I don't have a Shopify \"\n",
+    "    \"store yet. Pick a backend I can develop against today and pull six products for the homepage grid.\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "dfff6389",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T16:49:13.373614Z",
+     "iopub.status.busy": "2026-09-10T16:49:13.373541Z",
+     "iopub.status.idle": "2026-09-10T16:49:14.957270Z",
+     "shell.execute_reply": "2026-09-10T16:49:14.956161Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tool calls:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  -> list_stores(114 stores)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  -> describe_store(furniture.mock.shop)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  -> storefront_query(furniture.mock.shop)\n",
+      "\n",
+      "The model's reply:\n",
+      "\n",
+      "I chose **Haven & Hearth** on `furniture.mock.shop` as the development backend because it directly matches your handcrafted furniture concept, with a catalog focused on wooden furniture, textured upholstery, storage, beds, desks, dining pieces, rugs, and sofas.\n",
+      "\n",
+      "```json\n",
+      "{\"store_host\":\"furniture.mock.shop\",\"store_name\":\"Haven & Hearth\",\"collection_handle\":\"quiet-living-spaces\",\"products\":[{\"title\":\"Modular taupe oak sofa\",\"handle\":\"modular-taupe-oak-sofa\",\"price\":\"1295.0\",\"currency_code\":\"USD\",\"image_url\":\"https://cdn.shopify.com/s/files/1/0926/4031/3366/files/bedfa519444b99ed1a25e9964df926b5.png?v=14996395\",\"image_alt\":\"Modular taupe oak sofa, folded throw or book) for scale and warmth. Backgrounds remain unobtrusive but textured—e.g.,...\"},{\"title\":\"Walnut Brown Modular Sofa\",\"handle\":\"walnut-brown-modular-sofa\",\"price\":\"1899.99\",\"currency_code\":\"USD\",\"image_url\":\"https://cdn.shopify.com/s/files/1/0926/4031/3366/files/d03bb3a1b25aff831e8027b09823498e.png?v=13006792\",\"image_alt\":\"Photograph a Walnut Brown modular sofa crafted from sustainable materials, perfectly centered in the frame. Use soft, with...\"},{\"title\":\"Belgian Linen Sectional Sofa\",\"handle\":\"belgian-linen-sectional-sofa\",\"price\":\"4295.0\",\"currency_code\":\"USD\",\"image_url\":\"https://cdn.shopify.com/s/files/1/0926/4031/3366/files/ba5abd5021823f0c03a8b4b0cbf543a2.png?v=14759204\",\"image_alt\":\"Belgian linen sectional sofa, Default to 3/4 angle for hero product shots (sofas/chairs), shot at seated eye-level to...\"},{\"title\":\"Ash Taupe Custom Oversized Carpet\",\"handle\":\"ash-taupe-custom-oversized-carpet\",\"price\":\"7200.0\",\"currency_code\":\"USD\",\"image_url\":\"https://cdn.shopify.com/s/files/1/0926/5994/1398/files/4efc03d0485227deba1b6bf171567256.png?v=14784150\",\"image_alt\":\"Ash Taupe custom oversized luxury carpet, Hero product in 3/4 overhead angle—a perspective that reveals surface detail as...\"},{\"title\":\"Olive Brown Wool Blend Rug\",\"handle\":\"olive-brown-wool-blend-rug\",\"price\":\"1150.0\",\"currency_code\":\"USD\",\"image_url\":\"https://cdn.shopify.com/s/files/1/0926/4031/3366/files/e41d6b9d1fa56875dbc3b1ed50fdc0b7.png?v=14816316\",\"image_alt\":\"Olive brown wool blend rug, allowing viewers to perceive both surface detail and overall shape within an inviting setting...\"},{\"title\":\"Warm Sand New Zealand Wool Runner\",\"handle\":\"warm-sand-new-zealand-wool-runner\",\"price\":\"1400.0\",\"currency_code\":\"USD\",\"image_url\":\"https://cdn.shopify.com/s/files/1/0926/4031/3366/files/c3626f7ab43eb81034a3d52eccb1d421.png?v=14893977\",\"image_alt\":\"Warm Sand New Zealand wool runner, Shoot rugs at a 3/4 angle from low height to showcase both surface texture and edge...\"}]}\n",
+      "```\n"
+     ]
+    }
+   ],
+   "source": [
+    "def run_agent(user_message: str) -> str:\n",
+    "    \"\"\"Run the function-calling loop until the model stops calling tools, then return its final text.\"\"\"\n",
+    "    response = client.responses.create(\n",
+    "        model=MODEL,\n",
+    "        instructions=SYSTEM_PROMPT,\n",
+    "        tools=TOOLS,\n",
+    "        input=[{\"role\": \"user\", \"content\": user_message}],\n",
+    "    )\n",
+    "    while True:\n",
+    "        calls = [item for item in response.output if item.type == \"function_call\"]\n",
+    "        if not calls:\n",
+    "            break\n",
+    "        outputs = []\n",
+    "        for call in calls:\n",
+    "            result = run_tool(call.name, json.loads(call.arguments or \"{}\"))\n",
+    "            outputs.append(\n",
+    "                {\"type\": \"function_call_output\", \"call_id\": call.call_id, \"output\": result}\n",
+    "            )\n",
+    "        response = client.responses.create(\n",
+    "            model=MODEL,\n",
+    "            instructions=SYSTEM_PROMPT,\n",
+    "            tools=TOOLS,\n",
+    "            previous_response_id=response.id,\n",
+    "            input=outputs,\n",
+    "        )\n",
+    "    return response.output_text\n",
+    "\n",
+    "\n",
+    "print(\"Tool calls:\")\n",
+    "final_reply = run_agent(USER_MESSAGE)\n",
+    "print(\"\\nThe model's reply:\\n\")\n",
+    "print(final_reply)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1d6c842",
+   "metadata": {},
+   "source": [
+    "## Step 4: Render the homepage grid\n",
+    "\n",
+    "The model chose a store and returned real products from it. Pull the JSON block out of its reply and render the grid. The images are served from Shopify's CDN, exactly as they would be for a real store.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e8fde50f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T16:49:14.960608Z",
+     "iopub.status.busy": "2026-09-10T16:49:14.960338Z",
+     "iopub.status.idle": "2026-09-10T16:49:14.969387Z",
+     "shell.execute_reply": "2026-09-10T16:49:14.968558Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;max-width:960px\">\n",
+       "          <h2 style=\"margin:0 0 4px\">Haven & Hearth</h2>\n",
+       "          <div style=\"color:#6b7280;margin-bottom:16px\">\n",
+       "            furniture.mock.shop &middot; collection <code>quiet-living-spaces</code>\n",
+       "          </div>\n",
+       "          <div style=\"display:grid;grid-template-columns:repeat(3,1fr);gap:16px\">\n",
+       "            <div style=\"border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;background:#fff\">\n",
+       "              <img src=\"https://cdn.shopify.com/s/files/1/0926/4031/3366/files/bedfa519444b99ed1a25e9964df926b5.png?v=14996395\" alt=\"Modular taupe oak sofa, folded throw or book) for scale and warmth. Backgrounds remain unobtrusive but textured—e.g.,...\"\n",
+       "                   style=\"width:100%;aspect-ratio:1;object-fit:cover;display:block\">\n",
+       "              <div style=\"padding:12px 14px\">\n",
+       "                <div style=\"font-weight:600;font-size:14px;line-height:1.3\">Modular taupe oak sofa</div>\n",
+       "                <div style=\"color:#6b7280;font-size:13px;margin-top:4px\">1,295.00 USD</div>\n",
+       "              </div>\n",
+       "            </div>\n",
+       "            <div style=\"border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;background:#fff\">\n",
+       "              <img src=\"https://cdn.shopify.com/s/files/1/0926/4031/3366/files/d03bb3a1b25aff831e8027b09823498e.png?v=13006792\" alt=\"Photograph a Walnut Brown modular sofa crafted from sustainable materials, perfectly centered in the frame. Use soft, with...\"\n",
+       "                   style=\"width:100%;aspect-ratio:1;object-fit:cover;display:block\">\n",
+       "              <div style=\"padding:12px 14px\">\n",
+       "                <div style=\"font-weight:600;font-size:14px;line-height:1.3\">Walnut Brown Modular Sofa</div>\n",
+       "                <div style=\"color:#6b7280;font-size:13px;margin-top:4px\">1,899.99 USD</div>\n",
+       "              </div>\n",
+       "            </div>\n",
+       "            <div style=\"border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;background:#fff\">\n",
+       "              <img src=\"https://cdn.shopify.com/s/files/1/0926/4031/3366/files/ba5abd5021823f0c03a8b4b0cbf543a2.png?v=14759204\" alt=\"Belgian linen sectional sofa, Default to 3/4 angle for hero product shots (sofas/chairs), shot at seated eye-level to...\"\n",
+       "                   style=\"width:100%;aspect-ratio:1;object-fit:cover;display:block\">\n",
+       "              <div style=\"padding:12px 14px\">\n",
+       "                <div style=\"font-weight:600;font-size:14px;line-height:1.3\">Belgian Linen Sectional Sofa</div>\n",
+       "                <div style=\"color:#6b7280;font-size:13px;margin-top:4px\">4,295.00 USD</div>\n",
+       "              </div>\n",
+       "            </div>\n",
+       "            <div style=\"border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;background:#fff\">\n",
+       "              <img src=\"https://cdn.shopify.com/s/files/1/0926/5994/1398/files/4efc03d0485227deba1b6bf171567256.png?v=14784150\" alt=\"Ash Taupe custom oversized luxury carpet, Hero product in 3/4 overhead angle—a perspective that reveals surface detail as...\"\n",
+       "                   style=\"width:100%;aspect-ratio:1;object-fit:cover;display:block\">\n",
+       "              <div style=\"padding:12px 14px\">\n",
+       "                <div style=\"font-weight:600;font-size:14px;line-height:1.3\">Ash Taupe Custom Oversized Carpet</div>\n",
+       "                <div style=\"color:#6b7280;font-size:13px;margin-top:4px\">7,200.00 USD</div>\n",
+       "              </div>\n",
+       "            </div>\n",
+       "            <div style=\"border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;background:#fff\">\n",
+       "              <img src=\"https://cdn.shopify.com/s/files/1/0926/4031/3366/files/e41d6b9d1fa56875dbc3b1ed50fdc0b7.png?v=14816316\" alt=\"Olive brown wool blend rug, allowing viewers to perceive both surface detail and overall shape within an inviting setting...\"\n",
+       "                   style=\"width:100%;aspect-ratio:1;object-fit:cover;display:block\">\n",
+       "              <div style=\"padding:12px 14px\">\n",
+       "                <div style=\"font-weight:600;font-size:14px;line-height:1.3\">Olive Brown Wool Blend Rug</div>\n",
+       "                <div style=\"color:#6b7280;font-size:13px;margin-top:4px\">1,150.00 USD</div>\n",
+       "              </div>\n",
+       "            </div>\n",
+       "            <div style=\"border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;background:#fff\">\n",
+       "              <img src=\"https://cdn.shopify.com/s/files/1/0926/4031/3366/files/c3626f7ab43eb81034a3d52eccb1d421.png?v=14893977\" alt=\"Warm Sand New Zealand wool runner, Shoot rugs at a 3/4 angle from low height to showcase both surface texture and edge...\"\n",
+       "                   style=\"width:100%;aspect-ratio:1;object-fit:cover;display:block\">\n",
+       "              <div style=\"padding:12px 14px\">\n",
+       "                <div style=\"font-weight:600;font-size:14px;line-height:1.3\">Warm Sand New Zealand Wool Runner</div>\n",
+       "                <div style=\"color:#6b7280;font-size:13px;margin-top:4px\">1,400.00 USD</div>\n",
+       "              </div>\n",
+       "            </div></div>\n",
+       "        </div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import HTML, display\n",
+    "\n",
+    "\n",
+    "def extract_json_block(text: str) -> dict:\n",
+    "    \"\"\"Return the parsed contents of the last ```json fenced block in the reply.\"\"\"\n",
+    "    blocks = re.findall(r\"```json\\s*(\\{.*?\\})\\s*```\", text, flags=re.S)\n",
+    "    if not blocks:\n",
+    "        raise ValueError(\"The reply did not include a ```json block.\")\n",
+    "    return json.loads(blocks[-1])\n",
+    "\n",
+    "\n",
+    "def render_grid(homepage: dict) -> HTML:\n",
+    "    cards = []\n",
+    "    for product in homepage[\"products\"]:\n",
+    "        price = f\"{float(product['price']):,.2f} {product['currency_code']}\"\n",
+    "        cards.append(\n",
+    "            f\"\"\"\n",
+    "            <div style=\"border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;background:#fff\">\n",
+    "              <img src=\"{product[\"image_url\"]}\" alt=\"{product.get(\"image_alt\") or product[\"title\"]}\"\n",
+    "                   style=\"width:100%;aspect-ratio:1;object-fit:cover;display:block\">\n",
+    "              <div style=\"padding:12px 14px\">\n",
+    "                <div style=\"font-weight:600;font-size:14px;line-height:1.3\">{product[\"title\"]}</div>\n",
+    "                <div style=\"color:#6b7280;font-size:13px;margin-top:4px\">{price}</div>\n",
+    "              </div>\n",
+    "            </div>\"\"\"\n",
+    "        )\n",
+    "    return HTML(\n",
+    "        f\"\"\"\n",
+    "        <div style=\"font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;max-width:960px\">\n",
+    "          <h2 style=\"margin:0 0 4px\">{homepage[\"store_name\"]}</h2>\n",
+    "          <div style=\"color:#6b7280;margin-bottom:16px\">\n",
+    "            {homepage[\"store_host\"]} &middot; collection <code>{homepage[\"collection_handle\"]}</code>\n",
+    "          </div>\n",
+    "          <div style=\"display:grid;grid-template-columns:repeat(3,1fr);gap:16px\">{\"\".join(cards)}</div>\n",
+    "        </div>\"\"\"\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "homepage = extract_json_block(final_reply)\n",
+    "display(render_grid(homepage))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7384c4f",
+   "metadata": {},
+   "source": [
+    "## Step 5: Ship the query, not the mock\n",
+    "\n",
+    "The model's last `storefront_query` call is the query you'd put in your app. mock.shop mirrors the Storefront API, so it runs unchanged against a real store. The only things that change when you go live are the endpoint and a token:\n",
+    "\n",
+    "- mock.shop: `POST https://<store>.mock.shop/api`, no headers beyond `Content-Type`.\n",
+    "- A real store: `POST https://<your-store>.myshopify.com/api/2026-07/graphql.json` with an `X-Shopify-Storefront-Access-Token` header.\n",
+    "\n",
+    "The cell below prints the query the model wrote, then defines the production version of `storefront_query`. It only runs if you set a real store domain and token, so you can execute it safely now and come back to it when your store exists.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "6cfdc274",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-10T16:49:14.971250Z",
+     "iopub.status.busy": "2026-09-10T16:49:14.971154Z",
+     "iopub.status.idle": "2026-09-10T16:49:14.975641Z",
+     "shell.execute_reply": "2026-09-10T16:49:14.975182Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# Query the model ran against furniture.mock.shop\n",
+      "\n",
+      "query HomepageProducts($handle: String!, $first: Int!) {\n",
+      "  collection(handle: $handle) {\n",
+      "    handle\n",
+      "    title\n",
+      "    products(first: $first) {\n",
+      "      nodes {\n",
+      "        title\n",
+      "        handle\n",
+      "        featuredImage {\n",
+      "          url\n",
+      "          altText\n",
+      "        }\n",
+      "        priceRange {\n",
+      "          minVariantPrice {\n",
+      "            amount\n",
+      "            currencyCode\n",
+      "          }\n",
+      "        }\n",
+      "      }\n",
+      "    }\n",
+      "  }\n",
+      "}\n",
+      "\n",
+      "# Variables\n",
+      "\n",
+      "{\n",
+      "  \"handle\": \"quiet-living-spaces\",\n",
+      "  \"first\": 6\n",
+      "}\n",
+      "\n",
+      "Set SHOPIFY_STORE_DOMAIN and SHOPIFY_STOREFRONT_ACCESS_TOKEN to run the same query against your store.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "last_query = next(\n",
+    "    (entry for entry in reversed(TOOL_LOG) if entry[\"tool\"] == \"storefront_query\"),\n",
+    "    None,\n",
+    ")\n",
+    "if last_query:\n",
+    "    print(f\"# Query the model ran against {last_query['arguments']['host']}\\n\")\n",
+    "    print(last_query[\"arguments\"][\"query\"])\n",
+    "    if last_query[\"arguments\"].get(\"variables\"):\n",
+    "        print(\"\\n# Variables\\n\")\n",
+    "        print(json.dumps(last_query[\"arguments\"][\"variables\"], indent=2))\n",
+    "\n",
+    "\n",
+    "def storefront_query_live(query: str, variables: dict | None = None) -> dict:\n",
+    "    \"\"\"The same call against your real store once you have one.\"\"\"\n",
+    "    domain = os.environ[\"SHOPIFY_STORE_DOMAIN\"]  # for example my-store.myshopify.com\n",
+    "    token = os.environ[\"SHOPIFY_STOREFRONT_ACCESS_TOKEN\"]  # a public Storefront API access token\n",
+    "    response = requests.post(\n",
+    "        f\"https://{domain}/api/2026-07/graphql.json\",\n",
+    "        json={\"query\": query, \"variables\": variables or {}},\n",
+    "        headers={\n",
+    "            \"Content-Type\": \"application/json\",\n",
+    "            \"X-Shopify-Storefront-Access-Token\": token,\n",
+    "        },\n",
+    "        timeout=30,\n",
+    "    )\n",
+    "    response.raise_for_status()\n",
+    "    return response.json()\n",
+    "\n",
+    "\n",
+    "if os.environ.get(\"SHOPIFY_STORE_DOMAIN\") and last_query:\n",
+    "    live = storefront_query_live(\n",
+    "        last_query[\"arguments\"][\"query\"], last_query[\"arguments\"].get(\"variables\")\n",
+    "    )\n",
+    "    print(json.dumps(live, indent=2)[:2000])\n",
+    "else:\n",
+    "    print(\n",
+    "        \"\\nSet SHOPIFY_STORE_DOMAIN and SHOPIFY_STOREFRONT_ACCESS_TOKEN to run the same query against your store.\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a4be77d",
+   "metadata": {},
+   "source": [
+    "## What mock.shop is for, and what it isn't\n",
+    "\n",
+    "mock.shop is for building, not for selling. Its catalogs, prices, and inventory are fictional. Cart operations work, so you can build the full shopping flow, but checkout is mocked: no payment is taken and no order is placed. It doesn't support the Customer Account API, so sign-in features need a real store.\n",
+    "\n",
+    "## Next steps\n",
+    "\n",
+    "- **Do this in a real project.** Shopify's Hydrogen framework scaffolds a storefront against mock.shop with one flag: `npm create @shopify/hydrogen@latest -- --mock-shop`. The [mock.shop starter](https://github.com/Shopify/mock-shop-starter) is the same project pre-configured, with the store directory, an `AGENTS.md`, an `llms.txt`, and a Cursor rule that teach coding agents the pattern in this notebook.\n",
+    "- **Read the guide.** [Building with mock.shop](https://shopify.dev/docs/storefronts/headless/mock-shop) on shopify.dev covers the directory, the API, and moving to a real store.\n",
+    "- **Change the shop.** Rerun Step 3 with \"a shop that sells specialty coffee\" or \"a pet supply store\" and watch the model pick a different backend. Every store's `llms.txt` is at `https://<store>.mock.shop/llms.txt`.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/registry.yaml
+++ b/registry.yaml
@@ -3744,3 +3744,14 @@
     - evals
     - agents
     - responses
+
+- title: Build a storefront against real commerce data before you have a store
+  path: examples/build_a_storefront_against_mock_data.ipynb
+  slug: build-a-storefront-against-mock-data
+  description: Use function calling to have the model pick a mock.shop store that matches the shop you're building, query Shopify's Storefront API for real products, and render a homepage grid, with no store or token.
+  date: 2026-09-10
+  authors:
+    - BobbyNguye
+  tags:
+    - functions
+    - responses


### PR DESCRIPTION
## Summary

A function-calling recipe for a common situation: a developer is building an online shop, doesn't have a Shopify store yet, and needs real commerce data to build against. Instead of inventing a JSON file of fake products, the model uses [mock.shop](https://mock.shop), Shopify's public Storefront API backed by 100+ fictional stores that needs no store, app, or access token.

The notebook gives the model three tools (list the store directory, read a store's `llms.txt`, run a Storefront API GraphQL query), then asks it to set up a backend for "a shop that sells handcrafted furniture." The model picks the furniture store from the directory, learns its collections, writes and runs the query, and the notebook renders the six products as a homepage grid with real images and prices. The last section shows that the query the model wrote runs unchanged against a real store: only the endpoint and a token change.

## Motivation

Coding agents asked to "build a shop" tend to fabricate product data, which produces storefronts that work against fake data and break against real data. This recipe shows the pattern that avoids it and is fully runnable with only `OPENAI_API_KEY`; the commerce API side needs no credentials at all.

## What's in the PR

- `examples/build_a_storefront_against_mock_data.ipynb`, executed end to end with outputs saved (Responses API, `gpt-5.5`, function calling with `previous_response_id`).
- `registry.yaml` entry (tags: `functions`, `responses`) and an `authors.yaml` entry.
- `.github/scripts/check_notebooks.py` passes locally.

## About the author

I work on mock.shop at Shopify. The recipe uses only public endpoints and Shopify's public docs: https://shopify.dev/docs/storefronts/headless/mock-shop