### PR TITLE
Add Erika Kettleson as third voice evaluation author

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -3738,6 +3738,7 @@
   authors:
     - kait-oai
     - karsten-oai
+    - erikakettleson-openai
   tags:
     - audio
     - speech


### PR DESCRIPTION
## Summary

Add Erika Kettleson as the third author of the GPT-Live evaluation guide, after Kait Healy and Karsten Schroer. Reuse her existing author profile and avatar.

## Validation

- Parsed `registry.yaml` and `authors.yaml`; verified the exact author order and all three avatar entries.
- Ran `uv run --no-project --with nbformat python .github/scripts/check_notebooks.py`: no changed notebooks.
- `git diff --check` passed.

## Metadata checklist

- [x] Updated the existing registry entry.
- [x] Confirmed the existing author profile in `authors.yaml`; no duplicate entry needed.
- [x] Self-reviewed the one-line metadata change.

Follow-up to #3074.
