### PR TITLE
docs: archive the GPT Image models prompting guide

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -3668,6 +3668,7 @@
 - title: GPT Image Generation Models Prompting Guide
   path: examples/multimodal/image-gen-models-prompting-guide.ipynb
   slug: image-gen-models-prompting-guide
+  archived: true
   description: Cookbook to prompt gpt-image models for reliable image generation results.
   date: 2026-04-21
   authors:


### PR DESCRIPTION
## Summary
Archive the GPT Image Generation Models Prompting Guide, which still recommends GPT Image 2 as the default. The canonical [image prompting docs](https://developers.openai.com/api/docs/guides/image-prompting) cover GPT Image 2.5 and retain historical guidance for GPT Image 2, 1.5, and 1.

Companion redirect PR: https://github.com/openai/developers-website/pull/2959. The notebook remains available in GitHub.

## Validation
- Parsed registry.yaml and verified the target entry is archived.
- Notebook validation passed (no notebooks changed).
- git diff --check passed.

## Self-review
- [x] Registry metadata updated; existing authors retained.
- [x] Reviewed scope and destination. No new content or code changes.

[🧵 Codex Thread](https://chatgpt.com/s/cx_6aa457b584a481919094a3adf31f6209)<sub>[orig](https://codex-thread-link.openai.chatgpt.site/thread/01a091c8-a04f-71e3-8776-c71f4f8fbdfb)</sub>
[→ Review this PR in ChatGPT](https://chatgpt.com/?surface=work&prompt=Walk%20me%20through%20https%3A%2F%2Fgithub.com%2Fopenai%2Fopenai-cookbook%2Fpull%2F3084)
