### PR TITLE
docs: update transparent image assets for GPT Image 2.5

### DIFF
--- a/examples/multimodal/transparent-image-assets-for-campaigns-and-presentations.ipynb
+++ b/examples/multimodal/transparent-image-assets-for-campaigns-and-presentations.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Generate Transparent Image Assets for Campaigns and Presentations\n",
     "\n",
-    "A great image should work on any background. Transparent image assets (in preview) make it easy to reuse the same visuals across campaigns, websites, presentations, and product catalogs without white boxes or manual background removal.\n",
+    "A great image should work on any background. Transparent image assets make it easy to reuse the same visuals across campaigns, websites, presentations, and product catalogs without white boxes or manual background removal.\n",
     "\n",
     "This cookbook covers four customer use cases:\n",
     "\n",
@@ -26,9 +26,11 @@
     "\n",
     "Install the Python packages with `pip install openai pillow`, and set `OPENAI_API_KEY` in your environment. You will also need access to a transparency-capable image model and Codex to build the website.\n",
     "\n",
-    "This example uses `gpt-image-2` and requests PNG output with `background=\"transparent\"`.\n",
+    "This example uses `gpt-image-2.5-flare` and requests PNG output with `background=\"transparent\"`. To compare a model optimized for demanding quality requirements, set `IMAGE_MODEL` to `\"gpt-image-2.5-sunburst\"`. Both models support transparent backgrounds. Keep the prompts, sizes, and `quality=\"high\"` unchanged for the first comparison, then inspect transparency, fine edges, and text before tuning quality or latency.\n",
     "\n",
-    "For more background, see the [GPT Image Generation Models Prompting Guide](https://developers.openai.com/cookbook/examples/multimodal/image-gen-models-prompting-guide), the [OpenAI models page](https://developers.openai.com/api/docs/models), and the [image generation guide](https://developers.openai.com/api/docs/guides/image-generation)."
+    "The images and screenshots below are retained from the original GPT Image 2 version of this cookbook. They illustrate the workflows, not measured GPT Image 2.5 results. Save a copy of those assets before rerunning the generation cells, which write to the same filenames.\n",
+    "\n",
+    "For more background, see the [image prompting guide](https://developers.openai.com/api/docs/guides/image-prompting), the [OpenAI models page](https://developers.openai.com/api/docs/models), and the [image generation guide](https://developers.openai.com/api/docs/guides/image-generation)."
    ]
   },
   {
@@ -48,7 +50,7 @@
     "if not os.getenv(\"OPENAI_API_KEY\"):\n",
     "    raise RuntimeError(\"Set OPENAI_API_KEY before running this notebook.\")\n",
     "\n",
-    "IMAGE_MODEL = \"gpt-image-2\"\n",
+    "IMAGE_MODEL = \"gpt-image-2.5-flare\"\n",
     "\n",
     "client = OpenAI()\n",
     "asset_dir = Path(\"images/transparent-image-assets\")\n",


### PR DESCRIPTION
## Summary
Update the transparent image assets cookbook to use `gpt-image-2.5-flare` and explain how to compare `gpt-image-2.5-sunburst` while keeping prompts, dimensions, and quality fixed. Replace the old Cookbook prompting link with the canonical [image prompting docs](https://developers.openai.com/api/docs/guides/image-prompting).

Remove the old transparency preview label and identify the retained images and screenshots as GPT Image 2 examples. The existing four workflows and assets remain intact.

## Motivation
Keep this reusable workflow current following Images 2.5, without presenting historical artwork as newly generated model results.

## Validation
- Verified model IDs and transparency settings against the current official image prompting guide.
- Notebook structure validation passed.
- All Python code cells parse successfully.
- `git diff --check` passed.
- Live API generation was not run; existing assets were not regenerated.

## Self-review
- [x] Existing registry entry and author metadata remain accurate; no new content registration needed.
- [x] Reviewed wording, links, and the focused notebook diff.

[🧵 Codex Thread](https://chatgpt.com/s/cx_6aa4598e383881919560f7ccee98cd0c)<sub>[orig](https://codex-thread-link.openai.chatgpt.site/thread/01a091c8-a04f-71e3-8776-c71f4f8fbdfb)</sub>
[→ Review this PR in ChatGPT](https://chatgpt.com/?surface=work&prompt=Walk%20me%20through%20https%3A%2F%2Fgithub.com%2Fopenai%2Fopenai-cookbook%2Fpull%2F3085)
