### PR TITLE
Validate printed invoice subtotals in document review

### DIFF
--- a/examples/agents_api/apps/document_review/agent.py
+++ b/examples/agents_api/apps/document_review/agent.py
@@ -89,15 +89,27 @@ def validate_review(report: dict[str, Any], document: str) -> None:
             for item in line_items
         ]
         shipping = Decimal(str(calculation["shipping"]))
+        stated_subtotal = Decimal(str(calculation["stated_subtotal"]))
         stated = Decimal(str(report["amount"]))
         calculated = Decimal(str(calculation["calculated_total"]))
         difference = Decimal(str(calculation["difference"]))
         if not all(
             value.is_finite()
-            for value in [*amounts, shipping, stated, calculated, difference]
+            for value in [
+                *amounts,
+                shipping,
+                stated_subtotal,
+                stated,
+                calculated,
+                difference,
+            ]
         ):
             raise ValueError("Invoice amounts must be finite")
-        if sum(amounts) + shipping != calculated or stated - calculated != difference:
+        if (
+            sum(amounts) != stated_subtotal
+            or stated_subtotal + shipping != calculated
+            or stated - calculated != difference
+        ):
             raise ValueError("Invoice totals do not match the extracted line items")
     except (KeyError, TypeError, ValueError, InvalidOperation) as error:
         raise ValueError(f"{document}: invalid invoice calculation: {error}") from error

--- a/examples/agents_api/apps/document_review/skills/expense-review-policy/SKILL.md
+++ b/examples/agents_api/apps/document_review/skills/expense-review-policy/SKILL.md
@@ -47,6 +47,7 @@ Write `/workspace/output/<document-stem>.json` with the following fields:
   "recommendation": "Escalate for human review.",
   "calculation": {
     "line_items": [{"quantity": 2, "unit_price": 100}],
+    "stated_subtotal": 200,
     "shipping": 20,
     "calculated_total": 220,
     "difference": 6200
@@ -56,8 +57,10 @@ Write `/workspace/output/<document-stem>.json` with the following fields:
 
 Every `issues` entry must be a plain-English string, not a nested object.
 Use the actual document values, not the illustrative numbers above. Include every
-invoice line item in `calculation`; `amount` is the stated total. For contracts,
-set `document_type` to `contract` and `calculation` to `null`.
+invoice line item in `calculation`; `stated_subtotal` is the printed subtotal,
+`amount` is the stated total, and `calculated_total` must equal
+`stated_subtotal + shipping`. For contracts, set `document_type` to `contract`
+and `calculation` to `null`.
 
 Only the coordinator writes `summary.json`. A specialist writes its assigned report.
 


### PR DESCRIPTION
## Summary

- Validate that extracted invoice line items add up to the printed subtotal.
- Require the subtotal in the expense-review report schema and verify subtotal plus shipping against the calculated total.

## Motivation

The document-review example previously checked only the final calculated total. A report could therefore pass even when its line items disagreed with the invoice's printed subtotal, as long as the final total was internally consistent.

Fixes #3086

## Testing

- `python3 -m py_compile examples/agents_api/apps/document_review/agent.py`
- `git diff --check`

The repository's runtime dependencies are not installed in this environment, so the full document-review application was not run.
